### PR TITLE
fix: 缓存 HTTPS 端口 + 消除冗余请求 + NvHttp 工厂方法

### DIFF
--- a/entry/src/main/ets/model/ComputerInfo.ets
+++ b/entry/src/main/ets/model/ComputerInfo.ets
@@ -45,22 +45,31 @@ export interface AddressHolder {
   preferredAddress?: string;
 }
 
-export interface ComputerInfo extends AddressHolder {
+/**
+ * NvHttp 连接所需的最小主机信息
+ * ComputerInfo 和 ObservableComputer 均满足此接口
+ */
+export interface NvHttpHost extends AddressHolder {
+  serverCert: string;
+  /** 自定义 HTTP 端口（默认 47989） */
+  httpPort?: number;
+  /** 缓存的 HTTPS 端口（轮询/连接时从 serverinfo 获取） */
+  httpsPort?: number;
+}
+
+export interface ComputerInfo extends NvHttpHost {
   uuid: string;
   name: string;
   macAddress: string;
   state: ComputerState;
   pairState: PairState;
   runningGameId: number;
-  serverCert: string;
   pairName: string;  // 配对时服务器返回的名称
   gpuType: string;
   maxSupportedResolution: Resolution;
   isNvidiaSoftware: boolean;
   // 主机头像 - 第一个应用的 boxArt URL
   boxArtUrl?: string;
-  // 自定义 HTTP 端口（默认 47989）
-  httpPort?: number;
 }
 
 /**
@@ -157,7 +166,8 @@ export class ComputerInfoBuilder {
       maxSupportedResolution: { width: 1920, height: 1080 },
       isNvidiaSoftware: false,
       boxArtUrl: '',
-      httpPort: undefined
+      httpPort: undefined,
+      httpsPort: undefined
     };
   }
 
@@ -256,6 +266,11 @@ export class ComputerInfoBuilder {
     return this;
   }
 
+  setHttpsPort(port: number | undefined): ComputerInfoBuilder {
+    this.info.httpsPort = port;
+    return this;
+  }
+
   build(): ComputerInfo {
     const result: ComputerInfo = {
       uuid: this.info.uuid,
@@ -279,7 +294,8 @@ export class ComputerInfoBuilder {
       },
       isNvidiaSoftware: this.info.isNvidiaSoftware,
       boxArtUrl: this.info.boxArtUrl,
-      httpPort: this.info.httpPort
+      httpPort: this.info.httpPort,
+      httpsPort: this.info.httpsPort
     };
     return result;
   }

--- a/entry/src/main/ets/pages/AppListPageV2.ets
+++ b/entry/src/main/ets/pages/AppListPageV2.ets
@@ -57,16 +57,24 @@ struct AppListPageV2 {
   @State useVirtualDisplay: boolean = false; // 是否使用虚拟显示器
   @State supportsDisplayApi: boolean = false; // 服务器是否支持 displays API
   @StorageLink('smallIconMode') smallIconMode: boolean = false; // UI偏好：小图标/列表模式
+  // 加载失败 - 错误态
+  @State loadError: string = '';
+  @State retryCountdown: number = 0;
   
   private computerId: string = '';
   private computerManager: ComputerManager = ComputerManager.getInstance();
   private nvHttp: NvHttp | null = null;
   private searchDebounceTimer: number = -1; // 搜索防抖定时器
   private iconPollIntervalId: number = -1; // 图标轮询定时器ID
+  private retryTimerId: number = -1; // 自动重试定时器
+  private loadAttempt: number = 0; // 当前加载尝试次数
 
   // 空列表重试常量（匹配 Android EMPTY_LIST_THRESHOLD）
   private static readonly EMPTY_LIST_THRESHOLD = 3;
   private static readonly EMPTY_LIST_RETRY_DELAY_MS = 2000;
+  // 自动重试常量
+  private static readonly MAX_AUTO_RETRY = 2;
+  private static readonly RETRY_COUNTDOWN_SEC = 3;
 
   /**
    * 带重试的应用列表获取（服务端可能因瞬时原因返回空列表）
@@ -149,6 +157,8 @@ struct AppListPageV2 {
       clearTimeout(this.searchDebounceTimer);
       this.searchDebounceTimer = -1;
     }
+    // 清理自动重试定时器
+    this.cancelRetryTimer();
   }
 
   onBackPress(): boolean {
@@ -217,6 +227,8 @@ struct AppListPageV2 {
 
   private async loadApps(): Promise<void> {
     this.isLoading = true;
+    this.loadError = '';
+    this.cancelRetryTimer();
     
     try {
       const computer = this.computerManager.getComputer(this.computerId);
@@ -246,11 +258,64 @@ struct AppListPageV2 {
       this.calculateOptimalRowCount();
       this.loadDisplays();
       this.waitForFirstAppIcon();
+      // 成功 → 重置计数
+      this.loadAttempt = 0;
     } catch (err) {
-      ToastQueue.show({ message: `加载失败: ${(err as Error).message}` });
+      const errMsg = (err as Error).message || '未知错误';
+      this.loadError = this.diagnoseError(errMsg);
+      this.loadAttempt++;
+      // 自动重试（最多 MAX_AUTO_RETRY 次）
+      if (this.loadAttempt <= AppListPageV2.MAX_AUTO_RETRY) {
+        this.startRetryCountdown();
+      }
     } finally {
       this.isLoading = false;
     }
+  }
+
+  /**
+   * 诊断错误类型，返回用户友好的描述
+   */
+  private diagnoseError(errMsg: string): string {
+    const lower = errMsg.toLowerCase();
+    if (lower.includes('timeout') || lower.includes('timed out')) {
+      return '连接超时，主机可能已离线或网络不可达';
+    }
+    if (lower.includes('refused') || lower.includes('unreachable')) {
+      return '连接被拒绝，主机可能未运行串流服务';
+    }
+    if (lower.includes('401') || lower.includes('not authorized') || lower.includes('certificate')) {
+      return '配对已失效，请返回重新配对';
+    }
+    if (lower.includes('dns') || lower.includes('getaddrinfo')) {
+      return '无法解析主机地址，请检查网络连接';
+    }
+    return `加载失败: ${errMsg}`;
+  }
+
+  /**
+   * 启动自动重试倒计时
+   */
+  private startRetryCountdown(): void {
+    this.retryCountdown = AppListPageV2.RETRY_COUNTDOWN_SEC;
+    this.retryTimerId = setInterval(() => {
+      this.retryCountdown--;
+      if (this.retryCountdown <= 0) {
+        this.cancelRetryTimer();
+        this.loadApps();
+      }
+    }, 1000);
+  }
+
+  /**
+   * 取消自动重试定时器
+   */
+  private cancelRetryTimer(): void {
+    if (this.retryTimerId !== -1) {
+      clearInterval(this.retryTimerId);
+      this.retryTimerId = -1;
+    }
+    this.retryCountdown = 0;
   }
   
   /**
@@ -397,6 +462,8 @@ struct AppListPageV2 {
         Stack() {
           if (this.isLoading) {
             this.LoadingState()
+          } else if (this.loadError.length > 0 && this.viewModel.isEmpty) {
+            this.ErrorState()
           } else if (this.viewModel.isEmpty) {
             this.EmptyState()
           } else {
@@ -749,6 +816,75 @@ struct AppListPageV2 {
           .margin({ top: AppSpacing.Medium })
           .onClick(() => this.refreshApps())
       }
+    }
+    .width('100%')
+    .height('100%')
+    .justifyContent(FlexAlign.Center)
+  }
+
+  @Builder
+  ErrorState() {
+    Column() {
+      // 错误图标
+      Column() {
+        Image($r('app.media.ic_error'))
+          .width(36)
+          .height(36)
+          .fillColor(AppColors.TextSecondary)
+      }
+      .width(72)
+      .height(72)
+      .justifyContent(FlexAlign.Center)
+      .borderRadius(36)
+      .backgroundColor(AppColors.CardBackground)
+      .borderWidth(1)
+      .borderColor(AppColors.CardBorder)
+
+      // 错误描述
+      Text(this.loadError)
+        .fontSize(AppSizes.FontBody)
+        .fontColor(AppColors.TextSecondary)
+        .textAlign(TextAlign.Center)
+        .maxLines(3)
+        .margin({ top: AppSpacing.Large })
+        .padding({ left: AppSpacing.XLarge, right: AppSpacing.XLarge })
+
+      // 自动重试倒计时
+      if (this.retryCountdown > 0) {
+        Text(`${this.retryCountdown}s 后自动重试...`)
+          .fontSize(AppSizes.FontCaption)
+          .fontColor(AppColors.TextTertiary)
+          .margin({ top: AppSpacing.Small })
+      }
+
+      // 操作按钮
+      Row({ space: AppSpacing.Medium }) {
+        Button('重试')
+          .type(ButtonType.Normal)
+          .fontSize(AppSizes.FontCaption)
+          .fontColor(AppColors.Primary)
+          .backgroundColor(AppColors.Surface)
+          .borderWidth(1)
+          .borderColor(AppColors.Primary)
+          .borderRadius(AppSizes.RadiusSmall)
+          .height(36)
+          .onClick(() => {
+            this.loadAttempt = 0;
+            this.loadApps();
+          })
+
+        Button('返回')
+          .type(ButtonType.Normal)
+          .fontSize(AppSizes.FontCaption)
+          .fontColor(AppColors.TextSecondary)
+          .backgroundColor(AppColors.Surface)
+          .borderWidth(1)
+          .borderColor(AppColors.CardBorder)
+          .borderRadius(AppSizes.RadiusSmall)
+          .height(36)
+          .onClick(() => router.back())
+      }
+      .margin({ top: AppSpacing.Large })
     }
     .width('100%')
     .height('100%')

--- a/entry/src/main/ets/pages/AppListPageV2.ets
+++ b/entry/src/main/ets/pages/AppListPageV2.ets
@@ -17,7 +17,7 @@ import { AppListItem } from '../components/AppListItem';
 import { AppListViewModel, ObservableApp } from '../viewmodel/AppViewModel';
 import { AppColors, AppSizes, AppSpacing, AppAnimation, AppShadows } from '../common/Theme';
 import { common } from '@kit.AbilityKit';
-import { PairState, selectBestAddress } from '../model/ComputerInfo';
+import { PairState } from '../model/ComputerInfo';
 import { OptionPickerDialog, OptionPickerDialogConfig, OptionItem } from '../components/dialogs/OptionPickerDialog';
 import { ConfirmDialog, ConfirmDialogConfig } from '../components/dialogs/ConfirmDialog';
 import { ToastQueue } from '../utils/ToastQueue';
@@ -235,7 +235,7 @@ struct AppListPageV2 {
       this.computerName = computer.name;
       
       const context = getContext(this) as common.UIAbilityContext;
-      this.nvHttp = new NvHttp(selectBestAddress(computer), computer.serverCert, context, computer.httpPort);
+      this.nvHttp = NvHttp.fromComputer(computer, context);
 
       const apps = await this.getAppListWithRetry('加载');
 

--- a/entry/src/main/ets/pages/StreamPage.ets
+++ b/entry/src/main/ets/pages/StreamPage.ets
@@ -45,7 +45,6 @@ import { CustomKeyManager, CustomKeyManagerHost, SessionLike } from '../service/
 import { CustomKeyStore } from '../service/customkey/CustomKeyStore';
 import { PanZoomHandler, PanZoomState, PointXY } from '../service/input/PanZoomHandler';
 import { AiKeyService, AiKeyRecommendation } from '../service/AiKeyService';
-import { selectBestAddress } from '../model/ComputerInfo';
 import { ComputerManager } from '../service/ComputerManager';
 import { ToastQueue } from '../utils/ToastQueue';
 
@@ -252,7 +251,7 @@ struct StreamPage {
       try {
         const computer = ComputerManager.getInstance().getComputer(this.computerId);
         if (computer) {
-          const nvHttp = new NvHttp(selectBestAddress(computer), computer.serverCert, this.context, computer.httpPort);
+          const nvHttp = NvHttp.fromComputer(computer, this.context);
           this.aiKeyService = new AiKeyService(nvHttp);
 
           // 异步探测 AI 可用性，延迟显示避免与手柄连接等 toast 冲突

--- a/entry/src/main/ets/service/ComputerManager.ets
+++ b/entry/src/main/ets/service/ComputerManager.ets
@@ -177,7 +177,7 @@ export class ComputerManager {
    */
   private async verifyOrPollComputer(computer: ComputerInfo, address: string): Promise<void> {
     try {
-      const nvHttp = new NvHttp(address, computer.serverCert, this.context || undefined, computer.httpPort);
+      const nvHttp = NvHttp.fromAddress(address, computer, this.context || undefined);
       const serverInfo = await nvHttp.getServerInfo();
 
       // 处理 UUID 归一：discovered-* 临时条目获得真实 UUID
@@ -365,6 +365,9 @@ export class ComputerManager {
         if (httpPort) {
           existing.httpPort = httpPort;
         }
+        if (serverInfo.httpsPort > 0) {
+          existing.httpsPort = serverInfo.httpsPort;
+        }
         // 关键：保留 serverCert 和 pairState（如已配对）
         // 只有服务器明确返回 paired=true 时才更新配对状态
         if (serverInfo.paired) {
@@ -398,6 +401,7 @@ export class ComputerManager {
         .setPairState(serverInfo.paired ? PairState.PAIRED : PairState.NOT_PAIRED)
         .setRunningGameId(serverInfo.currentGame || 0)
         .setHttpPort(httpPort) // 保存自定义端口
+        .setHttpsPort(serverInfo.httpsPort > 0 ? serverInfo.httpsPort : undefined)
         .build();
 
       this.computers.set(computer.uuid, computer);
@@ -635,7 +639,7 @@ export class ComputerManager {
    */
   private async tryPollAddress(address: string, computer: ComputerInfo): Promise<PollResult> {
     try {
-      const nvHttp = new NvHttp(address, computer.serverCert, this.context || undefined, computer.httpPort);
+      const nvHttp = NvHttp.fromAddress(address, computer, this.context || undefined);
       const serverInfo = await nvHttp.getServerInfo();
       return { address, serverInfo };
     } catch (err) {
@@ -734,6 +738,11 @@ export class ComputerManager {
     target.address = result.address;
     target.runningGameId = info.currentGame;
     
+    // 缓存 HTTPS 端口（对齐 Android ComputerDetails.update()）
+    if (info.httpsPort > 0) {
+      target.httpsPort = info.httpsPort;
+    }
+    
     // 更新 MAC 地址
     if (info.macAddress && info.macAddress !== '00:00:00:00:00:00') {
       target.macAddress = info.macAddress;
@@ -830,7 +839,7 @@ export class ComputerManager {
   private async loadFirstAppBoxArt(computer: ComputerInfo, address: string): Promise<void> {
     try {
       // 使用保存的自定义端口（如果有）
-      const nvHttp = new NvHttp(address, computer.serverCert, this.context || undefined, computer.httpPort);
+      const nvHttp = NvHttp.fromAddress(address, computer, this.context || undefined);
       const apps = await nvHttp.getAppList();
       if (apps.length > 0) {
         // 下载并缓存第一个应用的 boxArt，使用本地文件路径
@@ -950,7 +959,7 @@ export class ComputerManager {
       throw new Error('电脑不存在');
     }
 
-    const nvHttp = new NvHttp(selectBestAddress(computer), computer.serverCert, this.context || undefined, computer.httpPort);
+    const nvHttp = NvHttp.fromComputer(computer, this.context || undefined);
     await nvHttp.unpair();
     
     computer.pairState = PairState.NOT_PAIRED;

--- a/entry/src/main/ets/service/ComputerPersistence.ets
+++ b/entry/src/main/ets/service/ComputerPersistence.ets
@@ -42,6 +42,7 @@ interface SavedComputerData {
   runningGameId: number;
   boxArtUrl?: string;
   httpPort?: number;
+  httpsPort?: number;
 }
 
 /** 持久化存储键名 */
@@ -91,7 +92,8 @@ export class ComputerPersistence {
       },
       isNvidiaSoftware: computer.isNvidiaSoftware,
       boxArtUrl: computer.boxArtUrl,
-      httpPort: computer.httpPort
+      httpPort: computer.httpPort,
+      httpsPort: computer.httpsPort
     };
   }
 
@@ -129,7 +131,8 @@ export class ComputerPersistence {
           pairState: pairStateStr,
           runningGameId: computer.runningGameId,
           boxArtUrl: computer.boxArtUrl || '',
-          httpPort: computer.httpPort
+          httpPort: computer.httpPort,
+          httpsPort: computer.httpsPort
         };
         computerList.push(savedData);
       });
@@ -198,6 +201,7 @@ export class ComputerPersistence {
           .setRunningGameId(saved.runningGameId || 0)
           .setBoxArtUrl(saved.boxArtUrl || '')
           .setHttpPort(httpPort)
+          .setHttpsPort(saved.httpsPort)
           .build();
 
         computers.set(computer.uuid, computer);

--- a/entry/src/main/ets/service/streaming/NvHttp.ets
+++ b/entry/src/main/ets/service/streaming/NvHttp.ets
@@ -19,12 +19,14 @@ import { StringUtil } from '../../utils/StringUtil';
 import { CryptoUtil } from '../../utils/CryptoUtil';
 import { DEFAULT_HTTP_PORT, DEFAULT_HTTPS_PORT } from '../../common/NetworkConstants';
 import { parseAddressAndPort, formatAddressForUrl } from '../../utils/NetHelper';
+import { selectBestAddress, NvHttpHost } from '../../model/ComputerInfo';
 
 /**
  * NvHTTP - 与 NVIDIA GameStream / Sunshine 服务器通信
  *
  * 这是 Android 版本 NvHTTP.java 的 HarmonyOS 移植
  */
+
 export interface ServerInfo {
   hostname: string;
   uniqueId: string;
@@ -111,13 +113,30 @@ export class NvHttp {
     NvHttp.cachedUniqueId = null;
   }
 
-  constructor(address: string, serverCert: string | null, context?: common.UIAbilityContext, httpPort?: number) {
+  /**
+   * 从电脑信息创建 NvHttp（自动选择最佳地址）
+   * 替代重复的 new NvHttp(selectBestAddress(c), c.serverCert, ctx, c.httpPort, c.httpsPort)
+   */
+  static fromComputer(computer: NvHttpHost, context?: common.UIAbilityContext): NvHttp {
+    return new NvHttp(selectBestAddress(computer), computer.serverCert || null, context, computer.httpPort, computer.httpsPort);
+  }
+
+  /**
+   * 从指定地址 + 电脑信息创建 NvHttp（用于轮询/测试指定地址）
+   */
+  static fromAddress(address: string, computer: NvHttpHost, context?: common.UIAbilityContext): NvHttp {
+    return new NvHttp(address, computer.serverCert || null, context, computer.httpPort, computer.httpsPort);
+  }
+
+  constructor(address: string, serverCert: string | null, context?: common.UIAbilityContext, httpPort?: number, httpsPort?: number) {
     // 解析地址中可能包含的端口号
     const parsed = parseAddressAndPort(address);
     this.address = parsed.host;
     this.serverCert = serverCert;
     // 优先使用显式传入的端口，其次使用地址中解析的端口，最后使用默认端口
     this.httpPort = httpPort || parsed.port || NvHttp.DEFAULT_HTTP_PORT;
+    // 使用缓存的 HTTPS 端口（轮询阶段从 serverinfo 获取）
+    this.httpsPort = httpsPort || 0;
     if (context) {
       this.context = context;
       this.certFilePath = context.filesDir + '/client_cert.pem';
@@ -239,31 +258,35 @@ export class NvHttp {
    * 3. 根据 httpPort 计算的端口（httpPort - 5）作为最终兜底
    */
   private async getHttpsBaseUrl(): Promise<string> {
-    if (this.httpsPort <= 0) {
-      // 和 Android 一样：httpsPort 未知时，自动通过 HTTP 调用 serverinfo 获取
-      try {
-        const url = this.buildUrl(this.getHttpBaseUrl(), 'serverinfo');
-        const response = await this.doRequest(url);
-        const port = XmlUtil.getIntValue(response, 'HttpsPort', 0);
-        if (port > 0) {
-          this.httpsPort = port;
-          console.info(`NvHttp: 自动解析 HTTPS 端口: ${port}`);
-        }
-      } catch (err) {
-        console.warn(`NvHttp: 自动解析 HTTPS 端口失败: ${err}`);
-      }
+    // 已缓存 → 直接使用
+    if (this.httpsPort > 0) {
+      return `https://${formatAddressForUrl(this.address)}:${this.httpsPort}`;
     }
 
-    let port: number;
-    if (this.httpsPort > 0) {
-      // 使用已知的 HTTPS 端口
-      port = this.httpsPort;
-    } else {
-      // 自动解析也失败了，使用默认 HTTPS 端口（对齐 Android getHttpsPort 回退逻辑）
-      port = NvHttp.DEFAULT_HTTPS_PORT;
-      console.info(`NvHttp: 使用默认 HTTPS 端口 ${port}`);
+    // 自定义端口（frp / 端口转发）→ Sunshine 规则直接推算，跳过 HTTP 探测避免 3s 超时
+    if (this.httpPort !== NvHttp.DEFAULT_HTTP_PORT) {
+      const port = this.httpPort - 5;
+      console.info(`NvHttp: 自定义端口场景，推算 HTTPS 端口 ${port} (httpPort=${this.httpPort} - 5)`);
+      return `https://${formatAddressForUrl(this.address)}:${port}`;
     }
-    return `https://${formatAddressForUrl(this.address)}:${port}`;
+
+    // 默认端口 + 未缓存 → 通过 HTTP serverinfo 获取（和 Android 一致）
+    try {
+      const url = this.buildUrl(this.getHttpBaseUrl(), 'serverinfo');
+      const response = await this.doRequest(url);
+      const port = XmlUtil.getIntValue(response, 'HttpsPort', 0);
+      if (port > 0) {
+        this.httpsPort = port;
+        console.info(`NvHttp: 自动解析 HTTPS 端口: ${port}`);
+        return `https://${formatAddressForUrl(this.address)}:${port}`;
+      }
+    } catch (err) {
+      console.warn(`NvHttp: 自动解析 HTTPS 端口失败: ${err}`);
+    }
+
+    // 最终兜底：默认 HTTPS 端口
+    console.info(`NvHttp: 使用默认 HTTPS 端口 ${NvHttp.DEFAULT_HTTPS_PORT}`);
+    return `https://${formatAddressForUrl(this.address)}:${NvHttp.DEFAULT_HTTPS_PORT}`;
   }
 
   /**
@@ -325,8 +348,8 @@ export class NvHttp {
           // 对齐 Android：SSLHandshakeException+CertificateException 或 HTTP 401 才降级
           // 注意：HarmonyOS 错误为英文消息（即使中文设备），无中文误判风险
           // 排除明确的非证书错误（超时/拒绝/DNS）以避免错误降级
-          const isTransientError = errMsg.includes('timeout') ||
-            errMsg.includes('timed out') ||
+          const isTimeoutError = errMsg.includes('timeout') || errMsg.includes('timed out');
+          const isTransientError = isTimeoutError ||
             errMsg.includes('refused') ||
             errMsg.includes('unreachable') ||
             errMsg.includes('dns') ||
@@ -338,10 +361,31 @@ export class NvHttp {
             errMsg.includes('ssl') ||
             errMsg.includes('tls') ||
             /\bcode[=: ]+2305/.test(errMsg));  // HarmonyOS TLS 证书错误码系列
+
           if (isCertError) {
             console.warn(`NvHttp: HTTPS serverinfo 证书错误: ${err}, 降级到 HTTP`);
             const url = this.buildUrl(this.getHttpBaseUrl(), 'serverinfo');
             response = await this.doRequest(url);
+          } else if (isTimeoutError && this.httpPort !== NvHttp.DEFAULT_HTTP_PORT) {
+            // frp/端口转发场景：serverInfo 报告的 HTTPS 端口是服务端本地端口，
+            // 可能与外部转发端口不同。用 Sunshine 端口规则（httpPort - 5）重试一次
+            const guessedPort = this.httpPort - 5;
+            if (guessedPort > 0 && guessedPort !== this.httpsPort) {
+              console.info(`NvHttp: HTTPS 超时，尝试推算端口 ${guessedPort} (httpPort=${this.httpPort} - 5)`);
+              try {
+                const retryBaseUrl = `https://${formatAddressForUrl(this.address)}:${guessedPort}`;
+                const retryUrl = this.buildUrl(retryBaseUrl, 'serverinfo');
+                response = await this.doRequest(retryUrl, NvHttp.READ_TIMEOUT, true);
+                // 推算端口成功，缓存
+                this.httpsPort = guessedPort;
+                console.info(`NvHttp: 推算 HTTPS 端口 ${guessedPort} 连接成功`);
+              } catch {
+                console.warn(`NvHttp: 推算端口 ${guessedPort} 也失败，放弃 HTTPS`);
+                throw new Error(`HTTPS serverinfo 失败: ${err}`);
+              }
+            } else {
+              throw new Error(`HTTPS serverinfo 失败: ${err}`);
+            }
           } else {
             console.warn(`NvHttp: HTTPS serverinfo 失败 (非证书错误，不降级): ${err}`);
             throw new Error(`HTTPS serverinfo 失败: ${err}`);

--- a/entry/src/main/ets/service/streaming/StreamingSession.ets
+++ b/entry/src/main/ets/service/streaming/StreamingSession.ets
@@ -11,7 +11,7 @@
 import { StreamConfig, HdrMode, getSurroundAudioInfo } from '../../model/StreamConfig';
 import { InputEvent, InputType, ControllerButtonEvent, ControllerAxisEvent, ControllerButton } from '../../model/InputEvent';
 import { ComputerManager } from '../ComputerManager';
-import { ComputerInfo, selectBestAddress } from '../../model/ComputerInfo';
+import { ComputerInfo } from '../../model/ComputerInfo';
 import { NvHttp, LaunchConfig } from './NvHttp';
 import { CryptoUtil } from '../../utils/CryptoUtil';
 import { common, abilityAccessCtrl, bundleManager, Permissions } from '@kit.AbilityKit';
@@ -329,6 +329,7 @@ export class StreamingSession {
   private serverAppVersion: string = '';
   private serverGfeVersion: string = '';
   private serverCodecModeSupport: number = 0;
+  private cachedCurrentGame: number = 0;
   private rtspSessionUrl: string = '';
 
   // ---------------------------------------------------------------------------
@@ -475,7 +476,7 @@ export class StreamingSession {
       if (this.stageProgressCallback) {
         this.stageProgressCallback(0, '正在启动应用...');
       }
-      const cachedCurrentGame = await this.getCachedCurrentGame();
+      const cachedCurrentGame = this.getCachedCurrentGame();
       await this.launchApp(cachedCurrentGame);
       await this.connectToServer();
       this.applyPostConnectionSettings(config);
@@ -873,9 +874,7 @@ export class StreamingSession {
     const computerResult = computerManager.getComputer(computerId);
     if (!computerResult) throw new Error(`找不到电脑: ${computerId}`);
     this.computer = computerResult;
-    this.nvHttp = new NvHttp(
-      selectBestAddress(this.computer), this.computer.serverCert, context, this.computer.httpPort
-    );
+    this.nvHttp = NvHttp.fromComputer(this.computer, context);
   }
 
   private async fetchServerInfo(): Promise<void> {
@@ -884,18 +883,17 @@ export class StreamingSession {
     this.serverAppVersion = serverInfo.appVersion || '';
     this.serverGfeVersion = serverInfo.gfeVersion || '';
     this.serverCodecModeSupport = serverInfo.serverCodecModeSupport || 0;
+    this.cachedCurrentGame = serverInfo.currentGame || 0;
     console.info(`服务器版本: app=${this.serverAppVersion}, gfe=${this.serverGfeVersion}, ` +
-      `codecSupport=${this.serverCodecModeSupport}`);
+      `codecSupport=${this.serverCodecModeSupport}, currentGame=${this.cachedCurrentGame}`);
 
     if (this.stageProgressCallback) {
       this.stageProgressCallback(0, '正在初始化...');
     }
   }
 
-  private async getCachedCurrentGame(): Promise<number> {
-    if (!this.nvHttp) return 0;
-    const serverInfo = await this.nvHttp.getServerInfo();
-    return serverInfo.currentGame || 0;
+  private getCachedCurrentGame(): number {
+    return this.cachedCurrentGame;
   }
 
   private generateInputKey(): void {

--- a/entry/src/main/ets/viewmodel/ComputerViewModel.ets
+++ b/entry/src/main/ets/viewmodel/ComputerViewModel.ets
@@ -8,7 +8,7 @@
  * (at your option) any later version.
  */
 
-import { ComputerInfo, ComputerState, PairState, AddressHolder } from '../model/ComputerInfo';
+import { ComputerInfo, ComputerState, PairState, NvHttpHost } from '../model/ComputerInfo';
 import { ComputerManager } from '../service/ComputerManager';
 
 /**
@@ -17,7 +17,7 @@ import { ComputerManager } from '../service/ComputerManager';
  * 注意：避免在 @Observed 类中使用 getter，会导致性能问题
  */
 @Observed
-export class ObservableComputer implements AddressHolder {
+export class ObservableComputer implements NvHttpHost {
   uuid: string = '';
   name: string = '';
   address: string = '';
@@ -38,6 +38,8 @@ export class ObservableComputer implements AddressHolder {
   boxArtUrl: string = '';
   // 自定义 HTTP 端口
   httpPort: number | undefined = undefined;
+  // 缓存的 HTTPS 端口
+  httpsPort: number | undefined = undefined;
   
   // 缓存的状态值 - 避免使用 getter 引起的性能问题
   isOnline: boolean = false;
@@ -70,6 +72,7 @@ export class ObservableComputer implements AddressHolder {
     this.isNvidiaSoftware = info.isNvidiaSoftware;
     this.boxArtUrl = info.boxArtUrl || '';
     this.httpPort = info.httpPort;
+    this.httpsPort = info.httpsPort;
     
     // 更新缓存的计算值
     this.updateCachedValues();
@@ -112,7 +115,8 @@ export class ObservableComputer implements AddressHolder {
       maxSupportedResolution: { width: 1920, height: 1080 },
       isNvidiaSoftware: this.isNvidiaSoftware,
       boxArtUrl: this.boxArtUrl,
-      httpPort: this.httpPort
+      httpPort: this.httpPort,
+      httpsPort: this.httpsPort
     };
     return info;
   }

--- a/entry/src/main/ets/viewmodel/PcListActions.ets
+++ b/entry/src/main/ets/viewmodel/PcListActions.ets
@@ -85,7 +85,7 @@ export class PcListActions {
         return;
       }
       const context = getContext() as common.UIAbilityContext;
-      const nvHttp = new NvHttp(selectBestAddress(computerInfo), computerInfo.serverCert, context, computerInfo.httpPort);
+      const nvHttp = NvHttp.fromComputer(computerInfo, context);
       const apps = await nvHttp.getAppList();
       if (computer.runningGameId > 0) {
         const runningApp = apps.find(a => a.id === computer.runningGameId);
@@ -200,7 +200,7 @@ export class PcListActions {
           try {
             ToastQueue.show({ message: '正在退出游戏...' });
             const context = getContext() as common.UIAbilityContext;
-            const nvHttp = new NvHttp(selectBestAddress(computer), computer.serverCert || null, context, computer.httpPort);
+            const nvHttp = NvHttp.fromComputer(computer, context);
             const success = await nvHttp.quitApp();
             if (success) {
               ToastQueue.show({ message: '游戏已退出' });
@@ -236,7 +236,7 @@ export class PcListActions {
           try {
             ToastQueue.show({ message: '正在发送休眠命令...' });
             const context = getContext() as common.UIAbilityContext;
-            const nvHttp = new NvHttp(selectBestAddress(computer), computer.serverCert || null, context, computer.httpPort);
+            const nvHttp = NvHttp.fromComputer(computer, context);
             const success = await nvHttp.pcSleep();
             if (success) {
               ToastQueue.show({ message: '睡眠命令已发送' });
@@ -260,7 +260,7 @@ export class PcListActions {
       const computerInfo = this.computerManager.getComputer(computer.uuid);
       if (computerInfo) {
         const context = getContext() as common.UIAbilityContext;
-        const nvHttp = new NvHttp(selectBestAddress(computerInfo), computerInfo.serverCert, context, computerInfo.httpPort);
+        const nvHttp = NvHttp.fromComputer(computerInfo, context);
         const apps = await nvHttp.getAppList();
         const runningApp = apps.find(a => a.id === computer.runningGameId);
         const cmdList = runningApp?.cmdList;
@@ -361,7 +361,7 @@ export class PcListActions {
       for (let i = 0; i < TEST_ROUNDS; i++) {
         const startMs = Date.now();
         try {
-          const nvHttp = new NvHttp(addr, computerInfo.serverCert, undefined, computerInfo.httpPort);
+          const nvHttp = NvHttp.fromAddress(addr, computerInfo);
           const info = await nvHttp.getServerInfo();
           const elapsed = Date.now() - startMs;
           roundLatencies.push(elapsed);


### PR DESCRIPTION
## 问题

恢复串流时频繁出现「HTTPS serverinfo 请求失败 timeout」。

## 根因

HarmonyOS 端 `ComputerInfo` 缺少 `httpsPort` 字段缓存。每次创建 `NvHttp` 时 `httpsPort=0`，强制走一次 HTTP 请求发现 HTTPS 端口（3s+ 超时），导致恢复串流总延迟过高。

## 修复内容

- 缓存 httpsPort 字段，轮询成功后持久化
- getCachedCurrentGame() 改为同步读缓存，消除冗余 HTTP 请求
- NvHttp.fromComputer() / fromAddress() 工厂方法
- NvHttpHost 接口，ComputerInfo extends 它
- frp/端口转发：HTTPS 超时 + 非默认端口 → 尝试 httpPort-5
- getHttpsBaseUrl 非默认端口回退改进

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **新功能**
  * 增加了对 HTTPS 端口的支持，改进了应用与远程服务器间的连接配置

* **改进**
  * 优化了 HTTP/HTTPS 端口的自动检测和故障转移机制，提升了各种网络环境下的连接稳定性和可靠性

<!-- end of auto-generated comment: release notes by coderabbit.ai -->