### PR TITLE
fix+refactor: 网络切换 getAppList 失败 + frp 重试通用化

### DIFF
--- a/entry/src/main/ets/service/streaming/NvHttp.ets
+++ b/entry/src/main/ets/service/streaming/NvHttp.ets
@@ -131,11 +131,17 @@ export class NvHttp {
    * 这避免了切换网络（如 LAN→公网/frp）时使用 stale 的 httpsPort 导致 getAppList 超时。
    */
   static fromAddress(address: string, computer: NvHttpHost, context?: common.UIAbilityContext): NvHttp {
-    const targetPort = parseAddressAndPort(address).port || computer.httpPort || NvHttp.DEFAULT_HTTP_PORT;
-    const activePort = computer.address ? (parseAddressAndPort(computer.address).port || computer.httpPort || NvHttp.DEFAULT_HTTP_PORT) : 0;
+    const httpFallback = computer.httpPort || NvHttp.DEFAULT_HTTP_PORT;
+    const targetPort = NvHttp.resolveHttpPort(address, httpFallback);
+    const activePort = computer.address ? NvHttp.resolveHttpPort(computer.address, httpFallback) : 0;
     const portMatches = activePort > 0 && activePort === targetPort;
     const reusedHttpsPort = portMatches ? computer.httpsPort : undefined;
     return new NvHttp(address, computer.serverCert || null, context, computer.httpPort, reusedHttpsPort);
+  }
+
+  /** 解析地址中的端口，缺省时回退 fallback */
+  private static resolveHttpPort(address: string, fallback: number): number {
+    return parseAddressAndPort(address).port || fallback;
   }
 
   constructor(address: string, serverCert: string | null, context?: common.UIAbilityContext, httpPort?: number, httpsPort?: number) {
@@ -393,16 +399,15 @@ export class NvHttp {
       // 如果有服务器证书且客户端证书文件存在（已配对），尝试 HTTPS 并使用客户端证书
       if (this.serverCert && this.hasCertificateFiles()) {
         try {
-          console.debug(`NvHttp: getServerInfo 尝试 HTTPS + 客户端证书`);
-          const url = this.buildUrl(await this.getHttpsBaseUrl(), 'serverinfo');
-          response = await this.doRequest(url, NvHttp.READ_TIMEOUT, true);
+          console.debug(`NvHttp: getServerInfo 尝试 HTTPS + 客户端证书（含 frp 重试）`);
+          // 复用通用 helper：超时 + 自定义端口会按 Sunshine 规则 (httpPort - 5) 重试
+          response = await this.doHttpsRequestWithFrpRetry('serverinfo');
         } catch (err) {
           const errMsg = String(err).toLowerCase();
           // 对齐 Android：SSLHandshakeException+CertificateException 或 HTTP 401 才降级
           // 注意：HarmonyOS 错误为英文消息（即使中文设备），无中文误判风险
           // 排除明确的非证书错误（超时/拒绝/DNS）以避免错误降级
-          const timeoutError = this.isTimeoutError(errMsg);
-          const isTransientError = timeoutError ||
+          const isTransientError = this.isTimeoutError(errMsg) ||
             errMsg.includes('refused') ||
             errMsg.includes('unreachable') ||
             errMsg.includes('dns') ||
@@ -419,26 +424,6 @@ export class NvHttp {
             console.warn(`NvHttp: HTTPS serverinfo 证书错误: ${err}, 降级到 HTTP`);
             const url = this.buildUrl(this.getHttpBaseUrl(), 'serverinfo');
             response = await this.doRequest(url);
-          } else if (timeoutError && this.httpPort !== NvHttp.DEFAULT_HTTP_PORT) {
-            // frp/端口转发场景：serverInfo 报告的 HTTPS 端口是服务端本地端口，
-            // 可能与外部转发端口不同。用 Sunshine 端口规则（httpPort - 5）重试一次
-            const guessedPort = this.httpPort - 5;
-            if (guessedPort > 0 && guessedPort !== this.httpsPort) {
-              console.info(`NvHttp: HTTPS 超时，尝试推算端口 ${guessedPort} (httpPort=${this.httpPort} - 5)`);
-              try {
-                const retryBaseUrl = `https://${formatAddressForUrl(this.address)}:${guessedPort}`;
-                const retryUrl = this.buildUrl(retryBaseUrl, 'serverinfo');
-                response = await this.doRequest(retryUrl, NvHttp.READ_TIMEOUT, true);
-                // 推算端口成功，缓存
-                this.httpsPort = guessedPort;
-                console.info(`NvHttp: 推算 HTTPS 端口 ${guessedPort} 连接成功`);
-              } catch {
-                console.warn(`NvHttp: 推算端口 ${guessedPort} 也失败，放弃 HTTPS`);
-                throw new Error(`HTTPS serverinfo 失败: ${err}`);
-              }
-            } else {
-              throw new Error(`HTTPS serverinfo 失败: ${err}`);
-            }
           } else {
             console.warn(`NvHttp: HTTPS serverinfo 失败 (非证书错误，不降级): ${err}`);
             throw new Error(`HTTPS serverinfo 失败: ${err}`);

--- a/entry/src/main/ets/service/streaming/NvHttp.ets
+++ b/entry/src/main/ets/service/streaming/NvHttp.ets
@@ -150,8 +150,10 @@ export class NvHttp {
     const parsed = parseAddressAndPort(address);
     this.address = parsed.host;
     this.serverCert = serverCert;
-    // 优先使用显式传入的端口，其次使用地址中解析的端口，最后使用默认端口
-    this.httpPort = httpPort || parsed.port || NvHttp.DEFAULT_HTTP_PORT;
+    // 端口优先级：address 中显式端口 > 显式传入 httpPort > 默认
+    // address 端口优先：避免 fromComputer(computer) 中 selectBestAddress 返回 'host:30000'
+    //   被陈旧的 computer.httpPort（如 LAN 47989）覆盖的 bug
+    this.httpPort = parsed.port || httpPort || NvHttp.DEFAULT_HTTP_PORT;
     // 使用缓存的 HTTPS 端口（轮询阶段从 serverinfo 获取）
     this.httpsPort = httpsPort || 0;
     if (context) {

--- a/entry/src/main/ets/service/streaming/NvHttp.ets
+++ b/entry/src/main/ets/service/streaming/NvHttp.ets
@@ -136,7 +136,8 @@ export class NvHttp {
     const activePort = computer.address ? NvHttp.resolveHttpPort(computer.address, httpFallback) : 0;
     const portMatches = activePort > 0 && activePort === targetPort;
     const reusedHttpsPort = portMatches ? computer.httpsPort : undefined;
-    return new NvHttp(address, computer.serverCert || null, context, computer.httpPort, reusedHttpsPort);
+    // 必须传 targetPort 而非 computer.httpPort：address 中显式端口（如 frp 'host:30000'）应优先于电脑缓存端口
+    return new NvHttp(address, computer.serverCert || null, context, targetPort, reusedHttpsPort);
   }
 
   /** 解析地址中的端口，缺省时回退 fallback */
@@ -364,7 +365,8 @@ export class NvHttp {
    * @param timeout 超时时间
    */
   private async doHttpsRequestWithFrpRetry(path: string, query?: string, timeout: number = NvHttp.READ_TIMEOUT): Promise<string> {
-    const url = this.buildUrl(await this.getHttpsBaseUrl(), path, query);
+    const baseUrl = await this.getHttpsBaseUrl();
+    const url = this.buildUrl(baseUrl, path, query);
     try {
       return await this.doRequest(url, timeout, true);
     } catch (err) {
@@ -375,6 +377,12 @@ export class NvHttp {
       }
       const guessedPort = this.httpPort - 5;
       if (guessedPort <= 0 || guessedPort === this.httpsPort) {
+        throw err;
+      }
+      // 避免重复请求：getHttpsBaseUrl 在自定义端口未缓存时已直接返回 httpPort-5，
+      // 此时 baseUrl 端口与 guessedPort 相同，重试无意义
+      const usedPort = parseAddressAndPort(baseUrl.replace(/^https?:\/\//, '')).port;
+      if (usedPort === guessedPort) {
         throw err;
       }
       console.info(`NvHttp: ${path} HTTPS 超时，尝试推算端口 ${guessedPort} (httpPort=${this.httpPort} - 5)`);

--- a/entry/src/main/ets/service/streaming/NvHttp.ets
+++ b/entry/src/main/ets/service/streaming/NvHttp.ets
@@ -375,17 +375,17 @@ export class NvHttp {
       const errMsg = String(err);
       // 仅对「超时 + 自定义 HTTP 端口」做 frp 推算重试
       if (!this.isTimeoutError(errMsg) || this.httpPort === NvHttp.DEFAULT_HTTP_PORT) {
-        throw err;
+        throw err instanceof Error ? err : new Error(errMsg);
       }
       const guessedPort = this.httpPort - 5;
       if (guessedPort <= 0 || guessedPort === this.httpsPort) {
-        throw err;
+        throw err instanceof Error ? err : new Error(errMsg);
       }
       // 避免重复请求：getHttpsBaseUrl 在自定义端口未缓存时已直接返回 httpPort-5，
       // 此时 baseUrl 端口与 guessedPort 相同，重试无意义
       const usedPort = parseAddressAndPort(baseUrl.replace(/^https?:\/\//, '')).port;
       if (usedPort === guessedPort) {
-        throw err;
+        throw err instanceof Error ? err : new Error(errMsg);
       }
       console.info(`NvHttp: ${path} HTTPS 超时，尝试推算端口 ${guessedPort} (httpPort=${this.httpPort} - 5)`);
       const retryBaseUrl = `https://${formatAddressForUrl(this.address)}:${guessedPort}`;

--- a/entry/src/main/ets/service/streaming/NvHttp.ets
+++ b/entry/src/main/ets/service/streaming/NvHttp.ets
@@ -136,8 +136,8 @@ export class NvHttp {
     const activePort = computer.address ? NvHttp.resolveHttpPort(computer.address, httpFallback) : 0;
     const portMatches = activePort > 0 && activePort === targetPort;
     const reusedHttpsPort = portMatches ? computer.httpsPort : undefined;
-    // 必须传 targetPort 而非 computer.httpPort：address 中显式端口（如 frp 'host:30000'）应优先于电脑缓存端口
-    return new NvHttp(address, computer.serverCert || null, context, targetPort, reusedHttpsPort);
+    // 构造函数已优先 address 中解析的端口，传 computer.httpPort 仅作为 address 无端口时的回退
+    return new NvHttp(address, computer.serverCert || null, context, computer.httpPort, reusedHttpsPort);
   }
 
   /** 解析地址中的端口，缺省时回退 fallback */

--- a/entry/src/main/ets/service/streaming/NvHttp.ets
+++ b/entry/src/main/ets/service/streaming/NvHttp.ets
@@ -123,9 +123,19 @@ export class NvHttp {
 
   /**
    * 从指定地址 + 电脑信息创建 NvHttp（用于轮询/测试指定地址）
+   *
+   * 对齐 Android `tryPollIp` 的 `portMatchesActiveAddress` 逻辑：
+   * 仅当指定 address 的端口与 computer.address 缓存端口一致时，才复用缓存的 httpsPort；
+   * 否则置 0，让 NvHttp 在 HTTPS 请求时通过 HTTP serverinfo 重新探测。
+   *
+   * 这避免了切换网络（如 LAN→公网/frp）时使用 stale 的 httpsPort 导致 getAppList 超时。
    */
   static fromAddress(address: string, computer: NvHttpHost, context?: common.UIAbilityContext): NvHttp {
-    return new NvHttp(address, computer.serverCert || null, context, computer.httpPort, computer.httpsPort);
+    const targetPort = parseAddressAndPort(address).port || computer.httpPort || NvHttp.DEFAULT_HTTP_PORT;
+    const activePort = computer.address ? (parseAddressAndPort(computer.address).port || computer.httpPort || NvHttp.DEFAULT_HTTP_PORT) : 0;
+    const portMatches = activePort > 0 && activePort === targetPort;
+    const reusedHttpsPort = portMatches ? computer.httpsPort : undefined;
+    return new NvHttp(address, computer.serverCert || null, context, computer.httpPort, reusedHttpsPort);
   }
 
   constructor(address: string, serverCert: string | null, context?: common.UIAbilityContext, httpPort?: number, httpsPort?: number) {
@@ -330,6 +340,49 @@ export class NvHttp {
   }
 
   /**
+   * 判断错误是否为超时错误
+   */
+  private isTimeoutError(errMsg: string): boolean {
+    const lower = errMsg.toLowerCase();
+    return lower.includes('timeout') || lower.includes('timed out');
+  }
+
+  /**
+   * 执行 HTTPS 请求，超时且使用自定义端口时按 Sunshine 规则（httpPort - 5）重试
+   *
+   * 适用场景：frp/端口转发下，缓存的 httpsPort 是服务端本地端口，与外部转发端口不同
+   * 应用范围：getAppList / launchApp / resumeApp / quitApp 等仅 HTTPS 的请求
+   *
+   * @param path API 路径（如 'applist', 'launch'）
+   * @param query 可选查询参数
+   * @param timeout 超时时间
+   */
+  private async doHttpsRequestWithFrpRetry(path: string, query?: string, timeout: number = NvHttp.READ_TIMEOUT): Promise<string> {
+    const url = this.buildUrl(await this.getHttpsBaseUrl(), path, query);
+    try {
+      return await this.doRequest(url, timeout, true);
+    } catch (err) {
+      const errMsg = String(err);
+      // 仅对「超时 + 自定义 HTTP 端口」做 frp 推算重试
+      if (!this.isTimeoutError(errMsg) || this.httpPort === NvHttp.DEFAULT_HTTP_PORT) {
+        throw err;
+      }
+      const guessedPort = this.httpPort - 5;
+      if (guessedPort <= 0 || guessedPort === this.httpsPort) {
+        throw err;
+      }
+      console.info(`NvHttp: ${path} HTTPS 超时，尝试推算端口 ${guessedPort} (httpPort=${this.httpPort} - 5)`);
+      const retryBaseUrl = `https://${formatAddressForUrl(this.address)}:${guessedPort}`;
+      const retryUrl = this.buildUrl(retryBaseUrl, path, query);
+      const response = await this.doRequest(retryUrl, timeout, true);
+      // 推算端口成功，缓存（后续请求自动使用）
+      this.httpsPort = guessedPort;
+      console.info(`NvHttp: ${path} 推算 HTTPS 端口 ${guessedPort} 连接成功，已缓存`);
+      return response;
+    }
+  }
+
+  /**
    * 获取服务器信息
    * 优先使用 HTTPS（如果已配对），失败后尝试 HTTP
    */
@@ -348,8 +401,8 @@ export class NvHttp {
           // 对齐 Android：SSLHandshakeException+CertificateException 或 HTTP 401 才降级
           // 注意：HarmonyOS 错误为英文消息（即使中文设备），无中文误判风险
           // 排除明确的非证书错误（超时/拒绝/DNS）以避免错误降级
-          const isTimeoutError = errMsg.includes('timeout') || errMsg.includes('timed out');
-          const isTransientError = isTimeoutError ||
+          const timeoutError = this.isTimeoutError(errMsg);
+          const isTransientError = timeoutError ||
             errMsg.includes('refused') ||
             errMsg.includes('unreachable') ||
             errMsg.includes('dns') ||
@@ -366,7 +419,7 @@ export class NvHttp {
             console.warn(`NvHttp: HTTPS serverinfo 证书错误: ${err}, 降级到 HTTP`);
             const url = this.buildUrl(this.getHttpBaseUrl(), 'serverinfo');
             response = await this.doRequest(url);
-          } else if (isTimeoutError && this.httpPort !== NvHttp.DEFAULT_HTTP_PORT) {
+          } else if (timeoutError && this.httpPort !== NvHttp.DEFAULT_HTTP_PORT) {
             // frp/端口转发场景：serverInfo 报告的 HTTPS 端口是服务端本地端口，
             // 可能与外部转发端口不同。用 Sunshine 端口规则（httpPort - 5）重试一次
             const guessedPort = this.httpPort - 5;
@@ -414,14 +467,12 @@ export class NvHttp {
 
   /**
    * 获取应用列表（仅 HTTPS，匹配 Android 行为）
-   * HTTPS 端口通过 getHttpsBaseUrl() 自动解析
+   * HTTPS 端口通过 getHttpsBaseUrl() 自动解析；超时时按 frp 规则重试
    */
   async getAppList(): Promise<AppEntry[]> {
-    const url = this.buildUrl(await this.getHttpsBaseUrl(), 'applist');
-    console.info(`NvHttp.getAppList: url=${url}, serverCert=${this.serverCert ? '有(长度' + this.serverCert.length + ')' : '无'}, hasCertFiles=${this.hasCertificateFiles()}`);
-
+    console.info(`NvHttp.getAppList: serverCert=${this.serverCert ? '有(长度' + this.serverCert.length + ')' : '无'}, hasCertFiles=${this.hasCertificateFiles()}`);
     // 与 Android 一致：只使用 HTTPS + 客户端证书，不 fallback 到 HTTP
-    const response = await this.doRequest(url, NvHttp.READ_TIMEOUT, true);
+    const response = await this.doHttpsRequestWithFrpRetry('applist');
     console.info(`NvHttp.getAppList: HTTPS 请求成功`);
     return this.parseAppList(response);
   }


### PR DESCRIPTION
## 背景

PR #15 修复了 HTTPS 端口缓存的整体问题，但遗留两个边界 case：

1. **网络切换 stale port**：LAN 配对后切到公网/frp，`computer.address` 端口已变，但缓存的 `httpsPort` 仍是 LAN 值，导致 `getAppList` 持续超时。重新配对会触发 `getServerInfo` 刷新 `httpsPort`，所以现象上「重新配对就好」。
2. **frp 推算只覆盖 serverinfo**：`getServerInfo` 有 frp 端口推算 (`httpPort - 5`) 重试，但 `getAppList` 没有。

## 改动

### fix: 网络切换后 getAppList 失败 + frp 重试通用化 (87688aa)

- **NvHttp.fromAddress 引入 portMatchesActiveAddress 判断**：对齐 Android tryPollIp 行为，仅当 address 端口与 computer.address 端口一致时才复用 httpsPort，否则置空让 getServerInfo 重新探测
- **提取 doHttpsRequestWithFrpRetry 通用方法**：getAppList 超时也按 Sunshine 规则 (httpPort - 5) 重试一次，推算成功端口自动缓存
- **isTimeoutError 辅助方法去重**

### refactor: NvHttp 端口解析与 frp 重试去重 (93c5e42)

- 抽取 NvHttp.resolveHttpPort(address, fallback) 静态辅助
- getServerInfo 复用 doHttpsRequestWithFrpRetry，原内联 frp 推算分支删除
- catch 块只保留证书错误降级 HTTP 的特殊路径

## 行为不变验证

- LAN 默认端口 → 不会触发 frp 重试
- 证书错误 → 仍降级 HTTP
- frp 推算成功 → 仍缓存 httpsPort
- 其他非证书错误 → 仍直接抛错


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug修复**
  * 改进了服务器连接的HTTPS端口缓存逻辑，确保不同地址间的缓存不会相互干扰。
  * 增强了HTTPS连接的超时处理和自动重试机制，提高连接可靠性。
  * 优化了服务器信息和应用列表的获取流程。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->