### PR TITLE
fix: 自动码率推荐未识别本机分辨率导致显示偏低

### DIFF
--- a/entry/src/main/ets/pages/SettingsPageV2.ets
+++ b/entry/src/main/ets/pages/SettingsPageV2.ets
@@ -418,6 +418,13 @@ struct SettingsPageV2 {
       case '1080p': width = 1920; height = 1080; break;
       case '1440p': width = 2560; height = 1440; break;
       case '4K': width = 3840; height = 2160; break;
+      case 'native':
+        // 本机分辨率：始终横屏方向
+        if (this.nativeWidth > 0 && this.nativeHeight > 0) {
+          width = Math.max(this.nativeWidth, this.nativeHeight);
+          height = Math.min(this.nativeWidth, this.nativeHeight);
+        }
+        break;
       default:
         // 尝试解析自定义分辨率格式 WIDTHxHEIGHT
         const match = this.resolution.match(/^(\d+)x(\d+)$/);


### PR DESCRIPTION
## 问题

设置页「码率」开启「自动」时，推荐码率显示出现非单调反常：

- 1440p @ 120fps → 推荐 **57 Mbps**（正确）
- 2880×1920（本机分辨率）@ 120fps → 推荐 **28 Mbps**（错误，比 1440p 还低）

## 根因

`SettingsPageV2.getRecommendedBitrateForCurrentSettings()` 的 `switch` 只覆盖了 `720p / 1080p / 1440p / 4K` 预设和 `WIDTHxHEIGHT` 自定义字符串。当用户选「本机分辨率」时，`this.resolution = 'native'`，既不命中预设也不命中正则，于是 `width/height` 保留默认初值 `1920/1080`。在 120fps 下，1080p 推荐码率恰好 ≈ 28 Mbps。

`SettingsService.parseResolution()` 对 `'native'` 处理是正确的，所以下发给串流的码率没问题，**仅 UI 显示错误**，但仍会误导用户。

## 修复

在 switch 中补 `'native'` 分支，使用 `nativeWidth/nativeHeight`，并强制横屏方向（与 `parseResolution` 一致）。

## 验证（120fps）

| 分辨率 | 修复前 | 修复后 |
|---|---|---|
| 1440p | 57 | 57 |
| 本机 2880×1920 | 28 | **79** |
| 4K | 113 | 113 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新功能

* 在视频设置中新增原生分辨率模式。当选择此模式时，系统将自动根据设备的原生分辨率计算最优的推荐比特率，确保视频质量与设备性能相匹配。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->