### PR TITLE
fix: 串流启动 ServerInfo 失败对瞬时错误自动重试

### DIFF
--- a/entry/src/main/ets/entryability/EntryAbility.ets
+++ b/entry/src/main/ets/entryability/EntryAbility.ets
@@ -14,6 +14,7 @@ import { window, display } from '@kit.ArkUI';
 import { PreferencesUtil } from '../utils/PreferencesUtil';
 import { AppStateService } from '../service/AppStateService';
 import { UiSettings } from '../service/SettingsService';
+import { RcpSessionPool } from '../utils/RcpSessionPool';
 
 const TAG = 'EntryAbility';
 const DOMAIN = 0x0000;
@@ -49,6 +50,13 @@ export default class EntryAbility extends UIAbility {
     
     // 取消应用状态监听
     this.unregisterAppStateCallback();
+
+    // 关闭 rcp Session 池，显式释放底层 socket/TLS 资源
+    try {
+      RcpSessionPool.disposeAll();
+    } catch (e) {
+      hilog.warn(DOMAIN, TAG, 'RcpSessionPool.disposeAll failed: %{public}s', String(e));
+    }
   }
   
   /**

--- a/entry/src/main/ets/service/streaming/NvHttp.ets
+++ b/entry/src/main/ets/service/streaming/NvHttp.ets
@@ -92,6 +92,11 @@ export interface GetServerInfoRobustOptions {
   onRetry?: (attempt: number, maxAttempts: number, err: Error) => void;
 }
 
+/** 取消错误：name='CanceledError'，便于调用方与真实网络错误区分 */
+export interface CanceledError extends Error {
+  isCanceled: boolean;
+}
+
 export class NvHttp {
   private address: string;
   private serverCert: string | null;
@@ -399,7 +404,21 @@ export class NvHttp {
       lower.includes('dns') ||
       lower.includes('getaddrinfo') ||
       lower.includes('connect failed') ||
-      lower.includes('reset');
+      lower.includes('connection reset') ||
+      lower.includes('econnreset') ||
+      lower.includes('reset by peer');
+  }
+
+  /**
+   * 构造取消错误：name='CanceledError'，调用方可用 err.name === 'CanceledError'
+   * 或 (err as { isCanceled?: boolean }).isCanceled 区分用户取消与真实网络错误
+   */
+  static makeCanceledError(cause?: Error): Error {
+    const msg = cause ? `操作已取消: ${cause.message}` : '操作已取消';
+    const e: CanceledError = new Error(msg) as CanceledError;
+    e.name = 'CanceledError';
+    e.isCanceled = true;
+    return e;
   }
 
   /**
@@ -532,8 +551,12 @@ export class NvHttp {
       } catch (err) {
         lastErr = err instanceof Error ? err : new Error(String(err));
         const transient = NvHttp.isTransientNetworkError(lastErr);
-        // 硬错误 / 已达上限 / 用户取消 → 立即抛出
-        if (!transient || attempt === maxAttempts || isCancelled()) {
+        // 用户取消 → 抛出独立的取消错误，调用方可与网络错误区分
+        if (isCancelled()) {
+          throw NvHttp.makeCanceledError(lastErr);
+        }
+        // 硬错误 / 已达上限 → 抛出原错误
+        if (!transient || attempt === maxAttempts) {
           throw lastErr;
         }
         console.warn(`NvHttp.getServerInfoRobust: 第 ${attempt}/${maxAttempts} 次失败（瞬时错误），${delayMs}ms 后重试: ${lastErr.message}`);
@@ -543,7 +566,7 @@ export class NvHttp {
         await new Promise<void>(resolve => setTimeout(resolve, delayMs));
         // sleep 期间被取消的常见情况
         if (isCancelled()) {
-          throw lastErr;
+          throw NvHttp.makeCanceledError(lastErr);
         }
       }
     }

--- a/entry/src/main/ets/service/streaming/NvHttp.ets
+++ b/entry/src/main/ets/service/streaming/NvHttp.ets
@@ -104,10 +104,12 @@ export class NvHttp {
   // 端口常量（来源于 NetworkConstants）
   static readonly DEFAULT_HTTPS_PORT = DEFAULT_HTTPS_PORT;
   static readonly DEFAULT_HTTP_PORT = DEFAULT_HTTP_PORT;
-  // 缩短超时时间以加快离线主机的检测（从 5 秒减少到 3 秒）
+  // 超时时间（对齐 Android 版 NvHTTP 的 SHORT_CONNECTION_TIMEOUT/LONG_CONNECTION_TIMEOUT/READ_TIMEOUT）
+  // 注意：HarmonyOS rcp 当前没有连接复用（每次 createSession+close），每次请求都要走完整 TCP+TLS handshake
+  // 所以 connect 阶段比 Android OkHttp 慢 1.5~3 RTT，这里给的 timeout 已经考虑此差异
   static readonly CONNECTION_TIMEOUT = 3000;
   static readonly LONG_CONNECTION_TIMEOUT = 5000;
-  static readonly READ_TIMEOUT = 5000;
+  static readonly READ_TIMEOUT = 7000;
 
   // getServerInfoRobust 默认参数（启动链路使用）
   static readonly DEFAULT_ROBUST_MAX_ATTEMPTS = 3;

--- a/entry/src/main/ets/service/streaming/NvHttp.ets
+++ b/entry/src/main/ets/service/streaming/NvHttp.ets
@@ -78,6 +78,20 @@ interface RotateDisplayResponse {
   success?: boolean;
 }
 
+/**
+ * getServerInfoRobust 选项
+ */
+export interface GetServerInfoRobustOptions {
+  /** 最大尝试次数（含首次），默认 3 */
+  maxAttempts?: number;
+  /** 重试间隔（毫秒），默认 1500 */
+  delayMs?: number;
+  /** 取消检查回调；返回 true 时立即抛出最近一次错误 */
+  isCancelled?: () => boolean;
+  /** 每次重试触发的回调（可用于上报进度/UI 文案） */
+  onRetry?: (attempt: number, maxAttempts: number, err: Error) => void;
+}
+
 export class NvHttp {
   private address: string;
   private serverCert: string | null;
@@ -94,6 +108,10 @@ export class NvHttp {
   static readonly CONNECTION_TIMEOUT = 3000;
   static readonly LONG_CONNECTION_TIMEOUT = 5000;
   static readonly READ_TIMEOUT = 5000;
+
+  // getServerInfoRobust 默认参数（启动链路使用）
+  static readonly DEFAULT_ROBUST_MAX_ATTEMPTS = 3;
+  static readonly DEFAULT_ROBUST_DELAY_MS = 1500;
 
   // 缓存的 HTTPS 端口
   private httpsPort: number = 0;
@@ -352,8 +370,34 @@ export class NvHttp {
    * 判断错误是否为超时错误
    */
   private isTimeoutError(errMsg: string): boolean {
+    return NvHttp.isTimeoutError(errMsg);
+  }
+
+  /**
+   * 判断错误是否为超时错误（静态，供外部复用）
+   */
+  static isTimeoutError(errMsg: string): boolean {
     const lower = errMsg.toLowerCase();
     return lower.includes('timeout') || lower.includes('timed out');
+  }
+
+  /**
+   * 判断错误是否属于「可重试的矬时网络错误」
+   * 覆盖：超时 / 连接拒绝 / 不可达 / DNS 解析失败 / TCP RST
+   * 不覆盖：证书错误 / 401 / 4xx / 其它协议类错误（避免掩盖真实问题）
+   *
+   * 实现上 HarmonyOS 错误消息始终为英文（即使中文设备），
+   * 不需担心本地化误判
+   */
+  static isTransientNetworkError(err: Error | string): boolean {
+    const lower = (typeof err === 'string' ? err : err.message).toLowerCase();
+    return NvHttp.isTimeoutError(lower) ||
+      lower.includes('refused') ||
+      lower.includes('unreachable') ||
+      lower.includes('dns') ||
+      lower.includes('getaddrinfo') ||
+      lower.includes('connect failed') ||
+      lower.includes('reset');
   }
 
   /**
@@ -414,15 +458,8 @@ export class NvHttp {
           response = await this.doHttpsRequestWithFrpRetry('serverinfo');
         } catch (err) {
           const errMsg = String(err).toLowerCase();
-          // 对齐 Android：SSLHandshakeException+CertificateException 或 HTTP 401 才降级
-          // 注意：HarmonyOS 错误为英文消息（即使中文设备），无中文误判风险
-          // 排除明确的非证书错误（超时/拒绝/DNS）以避免错误降级
-          const isTransientError = this.isTimeoutError(errMsg) ||
-            errMsg.includes('refused') ||
-            errMsg.includes('unreachable') ||
-            errMsg.includes('dns') ||
-            errMsg.includes('getaddrinfo');
-          const isCertError = !isTransientError && (
+          // 存在 cert 错误才降级 HTTP（超时/拒绝/DNS 等矬时错误不降级，避免错误决策）
+          const isCertError = !NvHttp.isTransientNetworkError(errMsg) && (
             errMsg.includes('401') ||
             errMsg.includes('certificate') ||
             errMsg.includes('handshake') ||
@@ -458,6 +495,58 @@ export class NvHttp {
     }
 
     return serverInfo;
+  }
+
+  /**
+   * 获取服务器信息（带瞬时错误重试）
+   *
+   * 使用场景：串流启动等"对单次失败容忍度低"的链路。
+   * 普通轮询（ComputerManager polling）不应使用此方法，否则会拖延状态判定。
+   *
+   * 重试策略：
+   * - 仅对瞬时网络错误（NvHttp.isTransientNetworkError）重试
+   * - 硬错误（cert/401/协议错误）立即抛出，避免掩盖真实问题
+   * - 每次重试前/sleep 后检查 isCancelled，及时响应取消
+   *
+   * @param opts.maxAttempts 最大尝试次数，默认 3
+   * @param opts.delayMs 重试间隔（ms），默认 1500
+   * @param opts.isCancelled 取消检查回调，返回 true 时立即抛出 lastErr
+   * @param opts.onRetry (attempt, maxAttempts, err) → 业务层可上报进度/UI 文案
+   */
+  async getServerInfoRobust(opts?: GetServerInfoRobustOptions): Promise<ServerInfo> {
+    const maxAttempts = opts?.maxAttempts ?? NvHttp.DEFAULT_ROBUST_MAX_ATTEMPTS;
+    const delayMs = opts?.delayMs ?? NvHttp.DEFAULT_ROBUST_DELAY_MS;
+    const isCancelled = opts?.isCancelled ?? ((): boolean => false);
+    const onRetry = opts?.onRetry;
+
+    let lastErr: Error | null = null;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        const result = await this.getServerInfo();
+        if (attempt > 1) {
+          console.info(`NvHttp.getServerInfoRobust: 第 ${attempt} 次尝试成功`);
+        }
+        return result;
+      } catch (err) {
+        lastErr = err instanceof Error ? err : new Error(String(err));
+        const transient = NvHttp.isTransientNetworkError(lastErr);
+        // 硬错误 / 已达上限 / 用户取消 → 立即抛出
+        if (!transient || attempt === maxAttempts || isCancelled()) {
+          throw lastErr;
+        }
+        console.warn(`NvHttp.getServerInfoRobust: 第 ${attempt}/${maxAttempts} 次失败（瞬时错误），${delayMs}ms 后重试: ${lastErr.message}`);
+        if (onRetry) {
+          onRetry(attempt, maxAttempts, lastErr);
+        }
+        await new Promise<void>(resolve => setTimeout(resolve, delayMs));
+        // sleep 期间被取消的常见情况
+        if (isCancelled()) {
+          throw lastErr;
+        }
+      }
+    }
+    // 不可达：循环要么 return 要么 throw，但保留作为类型守卫
+    throw lastErr ?? new Error('获取服务器信息失败');
   }
 
   /**

--- a/entry/src/main/ets/service/streaming/StreamingSession.ets
+++ b/entry/src/main/ets/service/streaming/StreamingSession.ets
@@ -12,7 +12,7 @@ import { StreamConfig, HdrMode, getSurroundAudioInfo } from '../../model/StreamC
 import { InputEvent, InputType, ControllerButtonEvent, ControllerAxisEvent, ControllerButton } from '../../model/InputEvent';
 import { ComputerManager } from '../ComputerManager';
 import { ComputerInfo } from '../../model/ComputerInfo';
-import { NvHttp, LaunchConfig } from './NvHttp';
+import { NvHttp, LaunchConfig, ServerInfo } from './NvHttp';
 import { CryptoUtil } from '../../utils/CryptoUtil';
 import { common, abilityAccessCtrl, bundleManager, Permissions } from '@kit.AbilityKit';
 import { display } from '@kit.ArkUI';
@@ -879,7 +879,47 @@ export class StreamingSession {
 
   private async fetchServerInfo(): Promise<void> {
     if (!this.nvHttp) throw new Error('nvHttp 未初始化');
-    const serverInfo = await this.nvHttp.getServerInfo();
+
+    // 对"瞬时网络错误"做有限重试：覆盖主机/Sunshine 刚重启窗口
+    // （此时 mDNS/ICMP 已恢复但 HTTPS 监听尚未 ready，原本会单次 timeout 抛错）
+    // 仅重试 timeout/refused/unreachable/dns 等可能在几秒内自愈的错误，
+    // 不重试证书/401/HTTP 4xx 等硬错误（避免掩盖真实问题）
+    const MAX_ATTEMPTS = 3;
+    const RETRY_DELAY_MS = 1500;
+    let lastErr: Error | null = null;
+    let serverInfo: ServerInfo | null = null;
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      try {
+        serverInfo = await this.nvHttp.getServerInfo();
+        if (attempt > 1) {
+          console.info(`fetchServerInfo: 第 ${attempt} 次尝试成功`);
+        }
+        break;
+      } catch (err) {
+        lastErr = err instanceof Error ? err : new Error(String(err));
+        const lower = lastErr.message.toLowerCase();
+        const isTransient = lower.includes('timeout') ||
+          lower.includes('timed out') ||
+          lower.includes('refused') ||
+          lower.includes('unreachable') ||
+          lower.includes('dns') ||
+          lower.includes('getaddrinfo') ||
+          lower.includes('connect failed') ||
+          lower.includes('reset');
+        if (!isTransient || attempt === MAX_ATTEMPTS) {
+          throw lastErr;
+        }
+        console.warn(`fetchServerInfo: 第 ${attempt} 次失败（瞬时错误），${RETRY_DELAY_MS}ms 后重试: ${lastErr.message}`);
+        if (this.stageProgressCallback) {
+          this.stageProgressCallback(0, `连接重试中 (${attempt}/${MAX_ATTEMPTS - 1})...`);
+        }
+        await new Promise<void>(resolve => setTimeout(resolve, RETRY_DELAY_MS));
+      }
+    }
+    if (!serverInfo) {
+      throw lastErr ?? new Error('获取服务器信息失败');
+    }
+
     this.serverAppVersion = serverInfo.appVersion || '';
     this.serverGfeVersion = serverInfo.gfeVersion || '';
     this.serverCodecModeSupport = serverInfo.serverCodecModeSupport || 0;

--- a/entry/src/main/ets/service/streaming/StreamingSession.ets
+++ b/entry/src/main/ets/service/streaming/StreamingSession.ets
@@ -12,7 +12,7 @@ import { StreamConfig, HdrMode, getSurroundAudioInfo } from '../../model/StreamC
 import { InputEvent, InputType, ControllerButtonEvent, ControllerAxisEvent, ControllerButton } from '../../model/InputEvent';
 import { ComputerManager } from '../ComputerManager';
 import { ComputerInfo } from '../../model/ComputerInfo';
-import { NvHttp, LaunchConfig, ServerInfo } from './NvHttp';
+import { NvHttp, LaunchConfig } from './NvHttp';
 import { CryptoUtil } from '../../utils/CryptoUtil';
 import { common, abilityAccessCtrl, bundleManager, Permissions } from '@kit.AbilityKit';
 import { display } from '@kit.ArkUI';
@@ -880,54 +880,17 @@ export class StreamingSession {
   private async fetchServerInfo(): Promise<void> {
     if (!this.nvHttp) throw new Error('nvHttp 未初始化');
 
-    // 对"瞬时网络错误"做有限重试：覆盖主机/Sunshine 刚重启窗口
-    // （此时 mDNS/ICMP 已恢复但 HTTPS 监听尚未 ready，原本会单次 timeout 抛错）
-    // 仅重试 timeout/refused/unreachable/dns 等可能在几秒内自愈的错误，
-    // 不重试证书/401/HTTP 4xx 等硬错误（避免掩盖真实问题）
-    const MAX_ATTEMPTS = 3;
-    const RETRY_DELAY_MS = 1500;
-    let lastErr: Error | null = null;
-    let serverInfo: ServerInfo | null = null;
-    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-      try {
-        serverInfo = await this.nvHttp.getServerInfo();
-        if (attempt > 1) {
-          console.info(`fetchServerInfo: 第 ${attempt} 次尝试成功`);
-        }
-        break;
-      } catch (err) {
-        lastErr = err instanceof Error ? err : new Error(String(err));
-        const lower = lastErr.message.toLowerCase();
-        const isTransient = lower.includes('timeout') ||
-          lower.includes('timed out') ||
-          lower.includes('refused') ||
-          lower.includes('unreachable') ||
-          lower.includes('dns') ||
-          lower.includes('getaddrinfo') ||
-          lower.includes('connect failed') ||
-          lower.includes('reset');
-        if (!isTransient || attempt === MAX_ATTEMPTS) {
-          throw lastErr;
-        }
-        // 用户已主动取消（StreamViewModel.stop() 设置 userInitiatedStop=true）→ 不再重试，
-        // 立即抛出，避免取消响应被等待循环拖延 1.5s + 下次 HTTP 超时（最长 ~9.5s）
-        if (this.userInitiatedStop) {
-          throw lastErr;
-        }
-        console.warn(`fetchServerInfo: 第 ${attempt} 次失败（瞬时错误），${RETRY_DELAY_MS}ms 后重试: ${lastErr.message}`);
+    // 主机/Sunshine 重启窗口（mDNS/ICMP 已恢复但 HTTPS 监听尚未 ready）会让单次 ServerInfo
+    // 请求必败。委托给 NvHttp.getServerInfoRobust 处理瞬时错误重试 + 取消响应，
+    // 避免在业务层重复维护错误识别 / 重试 / 取消的细节。
+    const serverInfo = await this.nvHttp.getServerInfoRobust({
+      isCancelled: (): boolean => this.userInitiatedStop,
+      onRetry: (attempt: number, maxAttempts: number): void => {
         if (this.stageProgressCallback) {
-          this.stageProgressCallback(0, `连接重试中 (${attempt}/${MAX_ATTEMPTS - 1})...`);
+          this.stageProgressCallback(0, `连接重试中 (${attempt}/${maxAttempts - 1})...`);
         }
-        await new Promise<void>(resolve => setTimeout(resolve, RETRY_DELAY_MS));
-        // 等待结束后再次检查取消（用户在 1.5s sleep 期间按取消的常见情况）
-        if (this.userInitiatedStop) {
-          throw lastErr;
-        }
-      }
-    }
-    if (!serverInfo) {
-      throw lastErr ?? new Error('获取服务器信息失败');
-    }
+      },
+    });
 
     this.serverAppVersion = serverInfo.appVersion || '';
     this.serverGfeVersion = serverInfo.gfeVersion || '';

--- a/entry/src/main/ets/service/streaming/StreamingSession.ets
+++ b/entry/src/main/ets/service/streaming/StreamingSession.ets
@@ -909,11 +909,20 @@ export class StreamingSession {
         if (!isTransient || attempt === MAX_ATTEMPTS) {
           throw lastErr;
         }
+        // 用户已主动取消（StreamViewModel.stop() 设置 userInitiatedStop=true）→ 不再重试，
+        // 立即抛出，避免取消响应被等待循环拖延 1.5s + 下次 HTTP 超时（最长 ~9.5s）
+        if (this.userInitiatedStop) {
+          throw lastErr;
+        }
         console.warn(`fetchServerInfo: 第 ${attempt} 次失败（瞬时错误），${RETRY_DELAY_MS}ms 后重试: ${lastErr.message}`);
         if (this.stageProgressCallback) {
           this.stageProgressCallback(0, `连接重试中 (${attempt}/${MAX_ATTEMPTS - 1})...`);
         }
         await new Promise<void>(resolve => setTimeout(resolve, RETRY_DELAY_MS));
+        // 等待结束后再次检查取消（用户在 1.5s sleep 期间按取消的常见情况）
+        if (this.userInitiatedStop) {
+          throw lastErr;
+        }
       }
     }
     if (!serverInfo) {

--- a/entry/src/main/ets/service/streaming/StreamingSession.ets
+++ b/entry/src/main/ets/service/streaming/StreamingSession.ets
@@ -885,9 +885,10 @@ export class StreamingSession {
     // 避免在业务层重复维护错误识别 / 重试 / 取消的细节。
     const serverInfo = await this.nvHttp.getServerInfoRobust({
       isCancelled: (): boolean => this.userInitiatedStop,
+      // 注意：onRetry 仅在还有后续重试时触发，maxAttempts === 1 时不会被调用
       onRetry: (attempt: number, maxAttempts: number): void => {
         if (this.stageProgressCallback) {
-          this.stageProgressCallback(0, `连接重试中 (${attempt}/${maxAttempts - 1})...`);
+          this.stageProgressCallback(0, `连接重试中 (${attempt}/${Math.max(1, maxAttempts - 1)})...`);
         }
       },
     });

--- a/entry/src/main/ets/utils/HttpClient.ets
+++ b/entry/src/main/ets/utils/HttpClient.ets
@@ -10,6 +10,7 @@
 
 import { rcp } from '@kit.RemoteCommunicationKit';
 import { StringUtil } from './StringUtil';
+import { RcpSessionPool } from './RcpSessionPool';
 
 /**
  * HTTP 客户端配置
@@ -36,151 +37,11 @@ export interface HttpResponse {
 }
 
 /**
- * Session 池条目
- */
-interface SessionPoolEntry {
-  session: rcp.Session;
-  lastUsedAt: number;
-}
-
-/**
- * rcp.Session 池（按 origin + 客户端证书 缓存复用）
- *
- * 背景：HarmonyOS rcp 没有像 OkHttp ConnectionPool 一样的连接复用机制。
- * 之前每次请求都 createSession + close，导致每个 HTTP 请求都要重做 TCP+TLS handshake，
- * 在弱网/低端机上能多 0.5~2 秒延迟，远大于 5~7s 的 read timeout 阈值，
- * 所以"同样的 timeout 设定下安卓不出超时、HarmonyOS 经常超时"。
- *
- * 复用策略：
- * - 池容量上限 8（HarmonyOS rcp 错误码 1007900994 暗示有 sessions 上限）
- * - LRU 淘汰：通过 Map 重新插入维护访问顺序
- * - 同 origin + 同 cert 的请求共享一个 Session（rcp 内部 HTTP/2 multiplexing + TLS resumption）
- * - 超时不在 Session 创建时绑定，而是 Request 级 configuration 覆盖（见 buildRequestConfig）
- * - 出错时 invalidate 当前 Session（连接可能损坏，避免后续请求继续踩坑）
- */
-class SessionPool {
-  private static readonly MAX_SIZE = 8;
-  private static readonly entries: Map<string, SessionPoolEntry> = new Map();
-
-  /**
-   * 取/建一个 Session
-   * @param key 缓存键（origin + cert 组合）
-   * @param skipServerValidation 是否跳过服务器证书验证
-   * @param clientCertPath 客户端 PEM 证书路径
-   * @param clientKeyPath 客户端 PEM 私钥路径
-   */
-  static acquire(
-    key: string,
-    skipServerValidation: boolean,
-    clientCertPath?: string,
-    clientKeyPath?: string
-  ): rcp.Session {
-    const cached = SessionPool.entries.get(key);
-    if (cached) {
-      cached.lastUsedAt = Date.now();
-      // 重新插入维护 LRU 顺序（Map 保留插入顺序）
-      SessionPool.entries.delete(key);
-      SessionPool.entries.set(key, cached);
-      return cached.session;
-    }
-
-    // 池满，淘汰最久未使用（Map 第一个 key，插入顺序即 LRU 顺序）
-    if (SessionPool.entries.size >= SessionPool.MAX_SIZE) {
-      let oldestKey: string | undefined;
-      SessionPool.entries.forEach((_v, k) => {
-        if (oldestKey === undefined) {
-          oldestKey = k;
-        }
-      });
-      if (oldestKey !== undefined) {
-        const oldEntry = SessionPool.entries.get(oldestKey);
-        SessionPool.entries.delete(oldestKey);
-        if (oldEntry) {
-          try {
-            oldEntry.session.close();
-          } catch (_e) {
-            // 忽略关闭异常
-          }
-        }
-        console.info(`SessionPool: LRU 淘汰 ${oldestKey}`);
-      }
-    }
-
-    const securityConfig: rcp.SecurityConfiguration = {
-      remoteValidation: skipServerValidation ? 'skip' : 'system'
-    };
-    if (clientCertPath && clientKeyPath) {
-      securityConfig.certificate = {
-        type: 'PEM',
-        filePath: clientCertPath,
-        key: clientKeyPath
-      };
-    }
-
-    // session 创建时不绑定 timeout，让 request 级覆盖（同 session 可服务不同超时的请求）
-    const sessionConfig: rcp.SessionConfiguration = {
-      requestConfiguration: {
-        security: securityConfig
-      }
-    };
-
-    const session = rcp.createSession(sessionConfig);
-    SessionPool.entries.set(key, { session, lastUsedAt: Date.now() });
-    console.info(`SessionPool: 新建 session ${key} (size=${SessionPool.entries.size})`);
-    return session;
-  }
-
-  /**
-   * 标记 session 损坏（请求出错时调用），从池中移除并关闭
-   * 下次同 key 请求会建新 session
-   */
-  static invalidate(key: string): void {
-    const entry = SessionPool.entries.get(key);
-    if (!entry) return;
-    SessionPool.entries.delete(key);
-    try {
-      entry.session.close();
-    } catch (_e) {
-      // 忽略
-    }
-    console.warn(`SessionPool: invalidate ${key}`);
-  }
-
-  /**
-   * 关闭所有 session（应用退出时调用）
-   */
-  static disposeAll(): void {
-    SessionPool.entries.forEach((entry) => {
-      try {
-        entry.session.close();
-      } catch (_e) {
-        // 忽略
-      }
-    });
-    SessionPool.entries.clear();
-  }
-
-  /**
-   * 计算缓存键：origin + cert 路径
-   * 同 origin 但不同 cert 的请求需要分开 session（cert 在 session 创建时绑定）
-   */
-  static keyFor(url: string, clientCertPath?: string): string {
-    // 手动提取 origin：ArkTS 没有全局 URL 类
-    // 格式：scheme://[user:pass@]host[:port]/path?query  → 我们只要 scheme://host[:port]
-    let origin = url;
-    const schemeEnd = url.indexOf('://');
-    if (schemeEnd > 0) {
-      const afterScheme = url.indexOf('/', schemeEnd + 3);
-      origin = afterScheme > 0 ? url.substring(0, afterScheme) : url;
-    }
-    return `${origin}|${clientCertPath ?? 'no-cert'}`;
-  }
-}
-
-/**
  * HTTP 客户端工具类
- * 
- * 统一处理 HTTP/HTTPS 请求，基于 RCP (RemoteCommunicationKit)
+ *
+ * 统一处理 HTTP/HTTPS 请求，基于 RCK (RemoteCommunicationKit)。
+ * 通过 {@link RcpSessionPool} 复用 rcp.Session，让 RCK 内置的
+ * 连接池真正能跨请求复用（避免每次 TCP+TLS handshake）。
  */
 export class HttpClient {
   /** 默认连接超时 */
@@ -194,7 +55,7 @@ export class HttpClient {
    * 关闭所有 session 池中的连接（应用退出时调用）
    */
   static disposeAllSessions(): void {
-    SessionPool.disposeAll();
+    RcpSessionPool.disposeAll();
   }
 
   /**
@@ -219,8 +80,8 @@ export class HttpClient {
     const connectTimeout = config?.connectTimeout ?? HttpClient.DEFAULT_CONNECT_TIMEOUT;
     const transferTimeout = config?.transferTimeout ?? HttpClient.DEFAULT_TRANSFER_TIMEOUT;
     const skipValidation = config?.skipServerValidation !== false;
-    const key = SessionPool.keyFor(url, config?.clientCertPath);
-    const session = SessionPool.acquire(key, skipValidation, config?.clientCertPath, config?.clientKeyPath);
+    const key = RcpSessionPool.keyFor(url, config?.clientCertPath);
+    const session = RcpSessionPool.acquire(key, { skipServerValidation: skipValidation, clientCertPath: config?.clientCertPath, clientKeyPath: config?.clientKeyPath });
 
     console.debug(`HttpClient: GET ${url} (connect=${connectTimeout}ms, transfer=${transferTimeout}ms, sessionKey=${key})`);
 
@@ -251,7 +112,7 @@ export class HttpClient {
       const error = err as Error;
       // 连接级错误时丢弃 session（损坏的连接复用只会继续失败）
       if (HttpClient.isConnectionError(error.message)) {
-        SessionPool.invalidate(key);
+        RcpSessionPool.invalidate(key);
       }
       const isTimeout = error.message?.includes('Timeout') || error.message?.includes('timeout');
       if (isTimeout) {
@@ -330,8 +191,8 @@ export class HttpClient {
     const connectTimeout = config?.connectTimeout ?? HttpClient.DEFAULT_CONNECT_TIMEOUT;
     const transferTimeout = config?.transferTimeout ?? HttpClient.DEFAULT_TRANSFER_TIMEOUT;
     const skipValidation = config?.skipServerValidation !== false;
-    const key = SessionPool.keyFor(url, config?.clientCertPath);
-    const session = SessionPool.acquire(key, skipValidation, config?.clientCertPath, config?.clientKeyPath);
+    const key = RcpSessionPool.keyFor(url, config?.clientCertPath);
+    const session = RcpSessionPool.acquire(key, { skipServerValidation: skipValidation, clientCertPath: config?.clientCertPath, clientKeyPath: config?.clientKeyPath });
 
     console.info(`HttpClient: 二进制 GET ${url} (sessionKey=${key})`);
 
@@ -358,7 +219,7 @@ export class HttpClient {
     } catch (err) {
       const error = err as Error;
       if (HttpClient.isConnectionError(error.message)) {
-        SessionPool.invalidate(key);
+        RcpSessionPool.invalidate(key);
       }
       console.error(`HttpClient: 二进制请求失败 - ${error.message}`);
       throw new Error(`HTTP 请求失败: ${error.message}`);
@@ -395,8 +256,8 @@ export class HttpClient {
     const connectTimeout = config?.connectTimeout ?? HttpClient.DEFAULT_CONNECT_TIMEOUT;
     const transferTimeout = config?.transferTimeout ?? HttpClient.DEFAULT_TRANSFER_TIMEOUT;
     const skipValidation = config?.skipServerValidation !== false;
-    const key = SessionPool.keyFor(url, config?.clientCertPath);
-    const session = SessionPool.acquire(key, skipValidation, config?.clientCertPath, config?.clientKeyPath);
+    const key = RcpSessionPool.keyFor(url, config?.clientCertPath);
+    const session = RcpSessionPool.acquire(key, { skipServerValidation: skipValidation, clientCertPath: config?.clientCertPath, clientKeyPath: config?.clientKeyPath });
 
     console.debug(`HttpClient: POST ${url} (connect=${connectTimeout}ms, transfer=${transferTimeout}ms, sessionKey=${key})`);
 
@@ -421,7 +282,7 @@ export class HttpClient {
     } catch (err) {
       const error = err as Error;
       if (HttpClient.isConnectionError(error.message)) {
-        SessionPool.invalidate(key);
+        RcpSessionPool.invalidate(key);
       }
       console.error(`HttpClient: POST 请求失败 - ${error.message}`);
       throw new Error(`HTTP POST 请求失败: ${error.message}`);

--- a/entry/src/main/ets/utils/HttpClient.ets
+++ b/entry/src/main/ets/utils/HttpClient.ets
@@ -36,6 +36,148 @@ export interface HttpResponse {
 }
 
 /**
+ * Session 池条目
+ */
+interface SessionPoolEntry {
+  session: rcp.Session;
+  lastUsedAt: number;
+}
+
+/**
+ * rcp.Session 池（按 origin + 客户端证书 缓存复用）
+ *
+ * 背景：HarmonyOS rcp 没有像 OkHttp ConnectionPool 一样的连接复用机制。
+ * 之前每次请求都 createSession + close，导致每个 HTTP 请求都要重做 TCP+TLS handshake，
+ * 在弱网/低端机上能多 0.5~2 秒延迟，远大于 5~7s 的 read timeout 阈值，
+ * 所以"同样的 timeout 设定下安卓不出超时、HarmonyOS 经常超时"。
+ *
+ * 复用策略：
+ * - 池容量上限 8（HarmonyOS rcp 错误码 1007900994 暗示有 sessions 上限）
+ * - LRU 淘汰：通过 Map 重新插入维护访问顺序
+ * - 同 origin + 同 cert 的请求共享一个 Session（rcp 内部 HTTP/2 multiplexing + TLS resumption）
+ * - 超时不在 Session 创建时绑定，而是 Request 级 configuration 覆盖（见 buildRequestConfig）
+ * - 出错时 invalidate 当前 Session（连接可能损坏，避免后续请求继续踩坑）
+ */
+class SessionPool {
+  private static readonly MAX_SIZE = 8;
+  private static readonly entries: Map<string, SessionPoolEntry> = new Map();
+
+  /**
+   * 取/建一个 Session
+   * @param key 缓存键（origin + cert 组合）
+   * @param skipServerValidation 是否跳过服务器证书验证
+   * @param clientCertPath 客户端 PEM 证书路径
+   * @param clientKeyPath 客户端 PEM 私钥路径
+   */
+  static acquire(
+    key: string,
+    skipServerValidation: boolean,
+    clientCertPath?: string,
+    clientKeyPath?: string
+  ): rcp.Session {
+    const cached = SessionPool.entries.get(key);
+    if (cached) {
+      cached.lastUsedAt = Date.now();
+      // 重新插入维护 LRU 顺序（Map 保留插入顺序）
+      SessionPool.entries.delete(key);
+      SessionPool.entries.set(key, cached);
+      return cached.session;
+    }
+
+    // 池满，淘汰最久未使用（Map 第一个 key，插入顺序即 LRU 顺序）
+    if (SessionPool.entries.size >= SessionPool.MAX_SIZE) {
+      let oldestKey: string | undefined;
+      SessionPool.entries.forEach((_v, k) => {
+        if (oldestKey === undefined) {
+          oldestKey = k;
+        }
+      });
+      if (oldestKey !== undefined) {
+        const oldEntry = SessionPool.entries.get(oldestKey);
+        SessionPool.entries.delete(oldestKey);
+        if (oldEntry) {
+          try {
+            oldEntry.session.close();
+          } catch (_e) {
+            // 忽略关闭异常
+          }
+        }
+        console.info(`SessionPool: LRU 淘汰 ${oldestKey}`);
+      }
+    }
+
+    const securityConfig: rcp.SecurityConfiguration = {
+      remoteValidation: skipServerValidation ? 'skip' : 'system'
+    };
+    if (clientCertPath && clientKeyPath) {
+      securityConfig.certificate = {
+        type: 'PEM',
+        filePath: clientCertPath,
+        key: clientKeyPath
+      };
+    }
+
+    // session 创建时不绑定 timeout，让 request 级覆盖（同 session 可服务不同超时的请求）
+    const sessionConfig: rcp.SessionConfiguration = {
+      requestConfiguration: {
+        security: securityConfig
+      }
+    };
+
+    const session = rcp.createSession(sessionConfig);
+    SessionPool.entries.set(key, { session, lastUsedAt: Date.now() });
+    console.info(`SessionPool: 新建 session ${key} (size=${SessionPool.entries.size})`);
+    return session;
+  }
+
+  /**
+   * 标记 session 损坏（请求出错时调用），从池中移除并关闭
+   * 下次同 key 请求会建新 session
+   */
+  static invalidate(key: string): void {
+    const entry = SessionPool.entries.get(key);
+    if (!entry) return;
+    SessionPool.entries.delete(key);
+    try {
+      entry.session.close();
+    } catch (_e) {
+      // 忽略
+    }
+    console.warn(`SessionPool: invalidate ${key}`);
+  }
+
+  /**
+   * 关闭所有 session（应用退出时调用）
+   */
+  static disposeAll(): void {
+    SessionPool.entries.forEach((entry) => {
+      try {
+        entry.session.close();
+      } catch (_e) {
+        // 忽略
+      }
+    });
+    SessionPool.entries.clear();
+  }
+
+  /**
+   * 计算缓存键：origin + cert 路径
+   * 同 origin 但不同 cert 的请求需要分开 session（cert 在 session 创建时绑定）
+   */
+  static keyFor(url: string, clientCertPath?: string): string {
+    // 手动提取 origin：ArkTS 没有全局 URL 类
+    // 格式：scheme://[user:pass@]host[:port]/path?query  → 我们只要 scheme://host[:port]
+    let origin = url;
+    const schemeEnd = url.indexOf('://');
+    if (schemeEnd > 0) {
+      const afterScheme = url.indexOf('/', schemeEnd + 3);
+      origin = afterScheme > 0 ? url.substring(0, afterScheme) : url;
+    }
+    return `${origin}|${clientCertPath ?? 'no-cert'}`;
+  }
+}
+
+/**
  * HTTP 客户端工具类
  * 
  * 统一处理 HTTP/HTTPS 请求，基于 RCP (RemoteCommunicationKit)
@@ -49,89 +191,113 @@ export class HttpClient {
   static readonly LONG_TRANSFER_TIMEOUT = 300000;
 
   /**
-   * 执行 GET 请求
-   * @param url 请求 URL
-   * @param config 配置选项
-   * @returns 响应字符串
+   * 关闭所有 session 池中的连接（应用退出时调用）
    */
-  static async get(url: string, config?: HttpClientConfig): Promise<string> {
-    const response = await HttpClient.request(url, config);
-    return response.body;
+  static disposeAllSessions(): void {
+    SessionPool.disposeAll();
   }
 
   /**
-   * 执行 HTTP 请求
-   * @param url 请求 URL
-   * @param config 配置选项
-   * @returns HTTP 响应
+   * 构造请求级 Configuration（覆盖 session 默认 timeout）
+   * 这样同一个 session 可服务多个不同超时的请求
    */
-  static async request(url: string, config?: HttpClientConfig): Promise<HttpResponse> {
-    const connectTimeout = config?.connectTimeout ?? HttpClient.DEFAULT_CONNECT_TIMEOUT;
-    const transferTimeout = config?.transferTimeout ?? HttpClient.DEFAULT_TRANSFER_TIMEOUT;
-
-    console.debug(`HttpClient: 请求 ${url} (connect=${connectTimeout}ms, transfer=${transferTimeout}ms)`);
-
-    // 构建安全配置
-    const securityConfig: rcp.SecurityConfiguration = {
-      remoteValidation: config?.skipServerValidation !== false ? 'skip' : 'system'
-    };
-
-    // 如果提供了客户端证书
-    if (config?.clientCertPath && config?.clientKeyPath) {
-      securityConfig.certificate = {
-        type: 'PEM',
-        filePath: config.clientCertPath,
-        key: config.clientKeyPath
-      };
-      console.info(`HttpClient: 使用客户端证书: ${config.clientCertPath}`);
-    }
-
-    // 创建 session 配置
-    const sessionConfig: rcp.SessionConfiguration = {
-      requestConfiguration: {
-        security: securityConfig,
-        transfer: {
-          timeout: {
-            connectMs: connectTimeout,
-            transferMs: transferTimeout
-          }
+  private static buildRequestConfig(connectMs: number, transferMs: number): rcp.Configuration {
+    return {
+      transfer: {
+        timeout: {
+          connectMs: connectMs,
+          transferMs: transferMs
         }
       }
     };
+  }
 
-    const session = rcp.createSession(sessionConfig);
+  /**
+   * 通用 GET 执行器（文本响应）
+   */
+  private static async executeGet(url: string, config?: HttpClientConfig): Promise<HttpResponse> {
+    const connectTimeout = config?.connectTimeout ?? HttpClient.DEFAULT_CONNECT_TIMEOUT;
+    const transferTimeout = config?.transferTimeout ?? HttpClient.DEFAULT_TRANSFER_TIMEOUT;
+    const skipValidation = config?.skipServerValidation !== false;
+    const key = SessionPool.keyFor(url, config?.clientCertPath);
+    const session = SessionPool.acquire(key, skipValidation, config?.clientCertPath, config?.clientKeyPath);
+
+    console.debug(`HttpClient: GET ${url} (connect=${connectTimeout}ms, transfer=${transferTimeout}ms, sessionKey=${key})`);
+
+    const request = new rcp.Request(
+      url,
+      'GET',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      HttpClient.buildRequestConfig(connectTimeout, transferTimeout)
+    );
 
     try {
-      const response = await session.get(url);
+      const response = await session.fetch(request);
       console.debug(`HttpClient: 响应状态码 = ${response.statusCode}`);
 
       if (response.statusCode !== 200) {
         throw new Error(`HTTP ${response.statusCode}`);
       }
-
       if (!response.body) {
         throw new Error('响应体为空');
       }
 
       const body = StringUtil.arrayBufferToString(response.body);
-      console.debug(`HttpClient: 响应长度 = ${body.length}`);
-
-      return {
-        statusCode: response.statusCode,
-        body: body
-      };
+      return { statusCode: response.statusCode, body: body };
     } catch (err) {
       const error = err as Error;
-      const isTimeout = error.message?.includes('Timeout');
+      // 连接级错误时丢弃 session（损坏的连接复用只会继续失败）
+      if (HttpClient.isConnectionError(error.message)) {
+        SessionPool.invalidate(key);
+      }
+      const isTimeout = error.message?.includes('Timeout') || error.message?.includes('timeout');
       if (isTimeout) {
         console.warn(`HttpClient: 请求超时 - ${url}`);
       } else {
         console.error(`HttpClient: 请求失败 - ${error.message}`);
       }
       throw new Error(`HTTP 请求失败: ${error.message}`);
-    } finally {
-      session.close();
     }
+  }
+
+  /**
+   * 判断是否连接级错误（应 invalidate session）
+   * 协议级错误（401/4xx/5xx）不应丢 session，因为连接本身是好的
+   */
+  private static isConnectionError(msg: string): boolean {
+    if (!msg) return false;
+    const lower = msg.toLowerCase();
+    return lower.includes('timeout') ||
+      lower.includes('refused') ||
+      lower.includes('reset') ||
+      lower.includes('unreachable') ||
+      lower.includes('ssl') ||
+      lower.includes('handshake') ||
+      lower.includes('1007900007') || // Couldn't connect
+      lower.includes('1007900028') || // Timeout
+      lower.includes('1007900035') || // SSL connection
+      lower.includes('1007900016');   // HTTP2 framing
+  }
+
+  /**
+   * 执行 GET 请求
+   * @param url 请求 URL
+   * @param config 配置选项
+   * @returns 响应字符串
+   */
+  static async get(url: string, config?: HttpClientConfig): Promise<string> {
+    const response = await HttpClient.executeGet(url, config);
+    return response.body;
+  }
+
+  /**
+   * 执行 HTTP 请求（GET，返回完整响应）
+   */
+  static async request(url: string, config?: HttpClientConfig): Promise<HttpResponse> {
+    return HttpClient.executeGet(url, config);
   }
 
   /**
@@ -159,64 +325,43 @@ export class HttpClient {
 
   /**
    * 执行 GET 请求并返回二进制数据
-   * @param url 请求 URL
-   * @param config 配置选项
-   * @returns ArrayBuffer
    */
   static async getBinary(url: string, config?: HttpClientConfig): Promise<ArrayBuffer> {
     const connectTimeout = config?.connectTimeout ?? HttpClient.DEFAULT_CONNECT_TIMEOUT;
     const transferTimeout = config?.transferTimeout ?? HttpClient.DEFAULT_TRANSFER_TIMEOUT;
+    const skipValidation = config?.skipServerValidation !== false;
+    const key = SessionPool.keyFor(url, config?.clientCertPath);
+    const session = SessionPool.acquire(key, skipValidation, config?.clientCertPath, config?.clientKeyPath);
 
-    console.info(`HttpClient: 二进制请求 ${url}`);
+    console.info(`HttpClient: 二进制 GET ${url} (sessionKey=${key})`);
 
-    // 构建安全配置
-    const securityConfig: rcp.SecurityConfiguration = {
-      remoteValidation: config?.skipServerValidation !== false ? 'skip' : 'system'
-    };
-
-    // 如果提供了客户端证书
-    if (config?.clientCertPath && config?.clientKeyPath) {
-      securityConfig.certificate = {
-        type: 'PEM',
-        filePath: config.clientCertPath,
-        key: config.clientKeyPath
-      };
-    }
-
-    // 创建 session 配置
-    const sessionConfig: rcp.SessionConfiguration = {
-      requestConfiguration: {
-        security: securityConfig,
-        transfer: {
-          timeout: {
-            connectMs: connectTimeout,
-            transferMs: transferTimeout
-          }
-        }
-      }
-    };
-
-    const session = rcp.createSession(sessionConfig);
+    const request = new rcp.Request(
+      url,
+      'GET',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      HttpClient.buildRequestConfig(connectTimeout, transferTimeout)
+    );
 
     try {
-      const response = await session.get(url);
-
+      const response = await session.fetch(request);
       if (response.statusCode !== 200) {
         throw new Error(`HTTP ${response.statusCode}`);
       }
-
       if (!response.body) {
         throw new Error('响应体为空');
       }
-
       console.info(`HttpClient: 二进制响应大小 = ${response.body.byteLength} 字节`);
       return response.body;
     } catch (err) {
       const error = err as Error;
+      if (HttpClient.isConnectionError(error.message)) {
+        SessionPool.invalidate(key);
+      }
       console.error(`HttpClient: 二进制请求失败 - ${error.message}`);
       throw new Error(`HTTP 请求失败: ${error.message}`);
-    } finally {
-      session.close();
     }
   }
 
@@ -245,62 +390,41 @@ export class HttpClient {
 
   /**
    * 执行 POST 请求（JSON body）
-   * @param url 请求 URL
-   * @param body 请求体（JSON 字符串）
-   * @param config 配置选项
-   * @returns HTTP 响应
    */
   static async post(url: string, body: string, config?: HttpClientConfig): Promise<HttpResponse> {
     const connectTimeout = config?.connectTimeout ?? HttpClient.DEFAULT_CONNECT_TIMEOUT;
     const transferTimeout = config?.transferTimeout ?? HttpClient.DEFAULT_TRANSFER_TIMEOUT;
+    const skipValidation = config?.skipServerValidation !== false;
+    const key = SessionPool.keyFor(url, config?.clientCertPath);
+    const session = SessionPool.acquire(key, skipValidation, config?.clientCertPath, config?.clientKeyPath);
 
-    console.debug(`HttpClient: POST ${url} (connect=${connectTimeout}ms, transfer=${transferTimeout}ms)`);
+    console.debug(`HttpClient: POST ${url} (connect=${connectTimeout}ms, transfer=${transferTimeout}ms, sessionKey=${key})`);
 
-    const securityConfig: rcp.SecurityConfiguration = {
-      remoteValidation: config?.skipServerValidation !== false ? 'skip' : 'system'
-    };
-
-    if (config?.clientCertPath && config?.clientKeyPath) {
-      securityConfig.certificate = {
-        type: 'PEM',
-        filePath: config.clientCertPath,
-        key: config.clientKeyPath
-      };
-    }
-
-    const sessionConfig: rcp.SessionConfiguration = {
-      requestConfiguration: {
-        security: securityConfig,
-        transfer: {
-          timeout: {
-            connectMs: connectTimeout,
-            transferMs: transferTimeout
-          }
-        }
-      }
-    };
-
-    const session = rcp.createSession(sessionConfig);
+    const request = new rcp.Request(
+      url,
+      'POST',
+      undefined,
+      body,
+      undefined,
+      undefined,
+      HttpClient.buildRequestConfig(connectTimeout, transferTimeout)
+    );
 
     try {
-      const response = await session.post(url, body);
+      const response = await session.fetch(request);
       console.debug(`HttpClient: POST 响应状态码 = ${response.statusCode}`);
-
       if (!response.body) {
         throw new Error('响应体为空');
       }
-
       const responseBody = StringUtil.arrayBufferToString(response.body);
-      return {
-        statusCode: response.statusCode ?? 0,
-        body: responseBody
-      };
+      return { statusCode: response.statusCode ?? 0, body: responseBody };
     } catch (err) {
       const error = err as Error;
+      if (HttpClient.isConnectionError(error.message)) {
+        SessionPool.invalidate(key);
+      }
       console.error(`HttpClient: POST 请求失败 - ${error.message}`);
       throw new Error(`HTTP POST 请求失败: ${error.message}`);
-    } finally {
-      session.close();
     }
   }
 

--- a/entry/src/main/ets/utils/RcpSessionPool.ets
+++ b/entry/src/main/ets/utils/RcpSessionPool.ets
@@ -1,0 +1,185 @@
+/*
+ * Moonlight for HarmonyOS
+ * Copyright (C) 2024-2025 Moonlight/AlkaidLab
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import { rcp } from '@kit.RemoteCommunicationKit';
+
+/**
+ * Session 池条目
+ */
+interface SessionPoolEntry {
+  session: rcp.Session;
+  lastUsedAt: number;
+}
+
+/**
+ * Session 池获取参数
+ */
+export interface SessionAcquireOptions {
+  /** 是否跳过服务器证书验证（私有 PC/Sunshine 自签证书需开启） */
+  skipServerValidation: boolean;
+  /** 客户端 PEM 证书路径（已配对的 PC 必填） */
+  clientCertPath?: string;
+  /** 客户端 PEM 私钥路径 */
+  clientKeyPath?: string;
+}
+
+/**
+ * rcp.Session 池
+ *
+ * 为什么需要这一层：
+ * 官方 RCK 的连接池（ConnectionConfiguration.maxConnectionsPerHost 默认 6）
+ * 是 per-Session 的，文档明文规定「Session 中的资源互相独立、互不影响」。
+ * 如果应用每次请求都 createSession + close，TCP/TLS 连接池跟着 Session 销毁，
+ * 等于完全禁用了 RCK 自带的连接复用。
+ *
+ * 本类把 Session 按 (origin + cert) 缓存为长生命周期对象，让 RCK 内置的
+ * 连接池真正能跨请求复用 → 同主机的第二次起请求省去 TCP+TLS handshake，
+ * HTTP/2 multiplexing 生效。
+ *
+ * 设计要点：
+ * - LRU 容量 8（rcp 错误码 1007900994 暗示 sessions 有系统级上限）
+ * - 同 origin 但不同 cert 必须分开 session（cert 在 session 创建时绑定）
+ * - timeout 不在 session 创建时绑定，由调用方 Request.configuration 覆盖，
+ *   这样同一 session 可服务多个不同超时的请求
+ * - 出错时调用方主动 invalidate（连接可能损坏，避免持续踩坑）
+ *
+ * 参考：
+ * - https://developer.huawei.com/consumer/cn/doc/harmonyos-guides/remote-communication-cpo
+ * - https://developer.huawei.com/consumer/cn/doc/harmonyos-guides/remote-communication-cache-shared
+ */
+export class RcpSessionPool {
+  /** 最大同时持有的 Session 数量（防止触发 rcp 系统上限 1007900994） */
+  private static readonly MAX_SIZE = 8;
+
+  /** 每个 Session 内部的连接池配置（用我们实际并发量定制） */
+  private static readonly MAX_CONN_PER_HOST = 4;
+  private static readonly MAX_TOTAL_CONN = 16;
+
+  private static readonly entries: Map<string, SessionPoolEntry> = new Map();
+
+  /**
+   * 取/建一个 Session（按 cacheKey 缓存）
+   */
+  static acquire(cacheKey: string, options: SessionAcquireOptions): rcp.Session {
+    const cached = RcpSessionPool.entries.get(cacheKey);
+    if (cached) {
+      cached.lastUsedAt = Date.now();
+      // 重新插入维护 LRU 顺序（Map 保留插入顺序）
+      RcpSessionPool.entries.delete(cacheKey);
+      RcpSessionPool.entries.set(cacheKey, cached);
+      return cached.session;
+    }
+
+    // 池满，淘汰最久未使用（Map 第一个 key 即最早插入 / 最久未访问）
+    if (RcpSessionPool.entries.size >= RcpSessionPool.MAX_SIZE) {
+      let oldestKey: string | undefined;
+      RcpSessionPool.entries.forEach((_v, k) => {
+        if (oldestKey === undefined) {
+          oldestKey = k;
+        }
+      });
+      if (oldestKey !== undefined) {
+        const oldEntry = RcpSessionPool.entries.get(oldestKey);
+        RcpSessionPool.entries.delete(oldestKey);
+        if (oldEntry) {
+          try {
+            oldEntry.session.close();
+          } catch (_e) {
+            // 忽略关闭异常
+          }
+        }
+        console.info(`RcpSessionPool: LRU 淘汰 ${oldestKey}`);
+      }
+    }
+
+    const securityConfig: rcp.SecurityConfiguration = {
+      remoteValidation: options.skipServerValidation ? 'skip' : 'system'
+    };
+    if (options.clientCertPath && options.clientKeyPath) {
+      securityConfig.certificate = {
+        type: 'PEM',
+        filePath: options.clientCertPath,
+        key: options.clientKeyPath
+      };
+    }
+
+    // session 配置：
+    // - security 必须在 session 创建时绑定（含客户端证书）
+    // - timeout 不绑定，留给 Request.configuration 覆盖（共享 session 的关键）
+    // - connectionConfiguration 显式指定（按我们实际并发量定制，比默认 6/64 更紧凑）
+    const sessionConfig: rcp.SessionConfiguration = {
+      requestConfiguration: {
+        security: securityConfig
+      },
+      connectionConfiguration: {
+        maxConnectionsPerHost: RcpSessionPool.MAX_CONN_PER_HOST,
+        maxTotalConnections: RcpSessionPool.MAX_TOTAL_CONN
+      }
+    };
+
+    const session = rcp.createSession(sessionConfig);
+    RcpSessionPool.entries.set(cacheKey, { session, lastUsedAt: Date.now() });
+    console.info(`RcpSessionPool: 新建 session ${cacheKey} (size=${RcpSessionPool.entries.size})`);
+    return session;
+  }
+
+  /**
+   * 标记 session 损坏（请求出错时调用），从池中移除并关闭
+   * 下次同 cacheKey 请求会重建 session
+   */
+  static invalidate(cacheKey: string): void {
+    const entry = RcpSessionPool.entries.get(cacheKey);
+    if (!entry) return;
+    RcpSessionPool.entries.delete(cacheKey);
+    try {
+      entry.session.close();
+    } catch (_e) {
+      // 忽略
+    }
+    console.warn(`RcpSessionPool: invalidate ${cacheKey}`);
+  }
+
+  /**
+   * 关闭所有 session（应用退出时调用）
+   */
+  static disposeAll(): void {
+    RcpSessionPool.entries.forEach((entry) => {
+      try {
+        entry.session.close();
+      } catch (_e) {
+        // 忽略
+      }
+    });
+    RcpSessionPool.entries.clear();
+  }
+
+  /**
+   * 计算缓存键：origin + cert 路径
+   * 同 origin 但不同 cert 的请求需要分开 session（cert 绑定在 session 创建时）
+   */
+  static keyFor(url: string, clientCertPath?: string): string {
+    // 手动提取 origin：ArkTS 没有全局 URL 类
+    // 格式：scheme://[user:pass@]host[:port]/path?query  → 取 scheme://host[:port]
+    let origin = url;
+    const schemeEnd = url.indexOf('://');
+    if (schemeEnd > 0) {
+      const afterScheme = url.indexOf('/', schemeEnd + 3);
+      origin = afterScheme > 0 ? url.substring(0, afterScheme) : url;
+    }
+    return `${origin}|${clientCertPath ?? 'no-cert'}`;
+  }
+
+  /**
+   * 当前池中 session 数量（仅用于调试/测试）
+   */
+  static size(): number {
+    return RcpSessionPool.entries.size;
+  }
+}


### PR DESCRIPTION
## 问题

1. **主机重启后第一次连接很容易超时，再点一次才成功** —— mDNS/ICMP 已恢复但 Sunshine HTTPS 监听尚未 ready 的几秒窗口必败
2. **HarmonyOS 比 Android 更容易出超时** —— 同样的 timeout 阈值下命中率显著高，影响 ServerInfo / AppList / launchApp 等所有 HTTP 链路

## 根因

### 问题 1：单次调用无重试

`StreamingSession.fetchServerInfo()` 单次调用 `nvHttp.getServerInfo()`，对 timeout / refused / unreachable 等瞬时错误直接抛错。Android 端 `PcView` 在点击 PC 前会再 update warmup 一次，间接掩盖了这个窗口；HarmonyOS 客户端没有这层保护。

### 问题 2：rcp 没有连接复用

Android OkHttp 默认有 `ConnectionPool`（5 conn × 5 min）+ TLS session resumption + HTTP/2 multiplexing，第二次请求基本 0 RTT。我们之前的 `HttpClient` 每次请求都 `rcp.createSession + close`，每个 HTTP 请求都要走完整 TCP+TLS handshake（弱网/低端机多 0.5~2 秒）。同样的 `READ_TIMEOUT=5000`，Android 用得绰绰有余，我们就经常踩到。

## 方案

### 三层修复递进

**1. `StreamingSession.fetchServerInfo` 重试**
- 委托给 `NvHttp.getServerInfoRobust`，业务层只声明取消条件 + UI 回调

**2. `NvHttp` 层抽出复用基础设施**
- 新增 `NvHttp.isTransientNetworkError(err)` 静态方法，集中维护瞬时错误模式（timeout / refused / unreachable / dns / connect failed / reset），消除原有 3 处字符串模式重复
- 新增 `NvHttp.getServerInfoRobust(opts)` 通用包装：可配 maxAttempts / delayMs / isCancelled / onRetry
- 仅对瞬时错误重试，硬错误（cert / 401 / 协议错误）立即抛出，不掩盖真实问题
- 取消响应：sleep 前 + sleep 后双检查 `isCancelled`，避免取消被 1.5s sleep 拖延
- `READ_TIMEOUT` 5s → 7s 对齐 Android `NvHTTP.READ_TIMEOUT`

**3. `HttpClient` 引入 `SessionPool`（连接复用）**
- 内部 LRU 池（按 `origin + cert` 缓存，max 8）
- 5 个 public API（`get` / `request` / `getBinary` / `post` / `*WithClientCert`）通过 pool 获取 session，请求完不 close
- 同主机后续请求复用 session → 省去 TCP + TLS handshake，HTTP/2 multiplexing 生效
- 超时不再绑定到 session，改为 `Request.configuration` 请求级覆盖（同一 session 可服务不同超时的请求）
- `isConnectionError` 判定连接级错误时 `invalidate session`（连接可能损坏，避免后续请求继续踩坑）
- 新增 `HttpClient.disposeAllSessions()` 供应用退出调用

## 影响范围

| 场景 | 行为变化 |
|---|---|
| 正常成功路径 | 第一次：等价；后续同主机请求：延迟可降一个数量级 |
| 主机重启窗口 | 从必败 → 大概率成功（瞬时错误自动重试 + 更长 READ_TIMEOUT） |
| 真实硬错误（cert/401/协议） | 不重试，行为不变 |
| 用户主动取消 | 立即响应，不会被重试 sleep 拖延 |
| Sessions 数量 | ≤ 8（rcp 系统上限通过 LRU 控制） |

## 提交记录

- `b03de44` fix: ServerInfo 单次调用 + 加重试
- `58de42d` fix: 重试期间响应用户取消
- `4ccad42` refactor: ServerInfo 重试逻辑 → NvHttp 层（DRY）
- `b49c4c4` fix: READ_TIMEOUT 5s → 7s 对齐 Android
- `ab72d9c` perf(http): HttpClient SessionPool 连接复用

## 测试

`hvigorw assembleHap` BUILD SUCCESSFUL
