### PR TITLE
fix: 修复自定义按键字色不生效

### DIFF
--- a/entry/src/main/ets/components/CustomKeyBtn.ets
+++ b/entry/src/main/ets/components/CustomKeyBtn.ets
@@ -32,6 +32,10 @@ import {
   getButtonIconResource,
 } from './CustomKeyConstants';
 
+function resolveCustomKeyForegroundColor(isActive: boolean, textColor: string): ResourceColor {
+  return isActive ? OV_TEXT_WHITE : textColor;
+}
+
 @Component
 export struct CustomKeyBtn {
   // ── 配置属性 ──
@@ -80,27 +84,33 @@ export struct CustomKeyBtn {
     return this.keyDef.icon ? getButtonIconResource(this.keyDef.icon) : undefined;
   }
 
-  /** 按下/切换态的前景色 */
-  private get fgColor(): ResourceColor {
-    return this.isPressed || this.isToggled ? OV_TEXT_WHITE : this.keyDef.textColor;
+  private getForegroundColor(): ResourceColor {
+    return resolveCustomKeyForegroundColor(
+      this.isPressed || this.isToggled,
+      this.keyDef.textColor);
+  }
+
+  @Builder
+  KeyFace() {
+    if (this.getIconRes()) {
+      Image(this.getIconRes()!)
+        .width(this.keyDef.fontSize + 6)
+        .height(this.keyDef.fontSize + 6)
+        .fillColor(this.getForegroundColor())
+        .objectFit(ImageFit.Contain)
+    } else {
+      Text(this.keyDef.label)
+        .fontSize(this.keyDef.fontSize)
+        .fontColor(this.getForegroundColor())
+        .fontWeight(FontWeight.Bold)
+        .textAlign(TextAlign.Center)
+    }
   }
 
   @Builder
   NormalBtn() {
     Stack() {
-      if (this.getIconRes()) {
-        Image(this.getIconRes()!)
-          .width(this.keyDef.fontSize + 6)
-          .height(this.keyDef.fontSize + 6)
-          .fillColor(this.fgColor)
-          .objectFit(ImageFit.Contain)
-      } else {
-        Text(this.keyDef.label)
-          .fontSize(this.keyDef.fontSize)
-          .fontColor(this.fgColor)
-          .fontWeight(FontWeight.Bold)
-          .textAlign(TextAlign.Center)
-      }
+      this.KeyFace()
     }
     .width(this.keyDef.width)
     .height(this.keyDef.height)
@@ -159,19 +169,7 @@ export struct CustomKeyBtn {
         .height(this.keyDef.height)
 
       // 标签/图标
-      if (this.getIconRes()) {
-        Image(this.getIconRes()!)
-          .width(this.keyDef.fontSize + 6)
-          .height(this.keyDef.fontSize + 6)
-          .fillColor(this.fgColor)
-          .objectFit(ImageFit.Contain)
-      } else {
-        Text(this.keyDef.label)
-          .fontSize(this.keyDef.fontSize)
-          .fontColor(this.fgColor)
-          .fontWeight(FontWeight.Bold)
-          .textAlign(TextAlign.Center)
-      }
+      this.KeyFace()
     }
     .width(this.keyDef.width)
     .height(this.keyDef.height)


### PR DESCRIPTION
## 修复内容

- 移除 `CustomKeyBtn` 中不可靠的 `private get fgColor` 访问器
- 改为组件普通方法 `getForegroundColor()` 读取按下/切换态与 `keyDef.textColor`
- 提取 `resolveCustomKeyForegroundColor()` 纯函数表达前景色选择规则
- 提取 `KeyFace()` builder，统一普通按钮和六边形按钮的文字/图标渲染，减少重复代码

## 根因

配置保存链路能正确更新 `keyDef.textColor`，但渲染端在 ArkUI `@Component struct` 中通过 `private get fgColor` 再传给 UI modifier，实际表现为未稳定使用用户配置颜色，导致文字颜色回退为随系统深浅色变化。

## 验证

- `CustomKeyBtn.ets`：无编辑器错误
- `hvigor assembleHap --mode module -p product=default --no-daemon`：BUILD SUCCESSFUL

## 注意

工作树中已有 native 子目录无关变更未包含在本提交中。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **重构**
  * 优化了按钮组件的前景色逻辑，减少了代码重复。

* **其他更新**
  * 更新了依赖项版本。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->