### PR TITLE
[codex] Feed NetworkBoost signals into ABR

### DIFF
--- a/entry/src/main/ets/service/streaming/AdaptiveBitrateService.ets
+++ b/entry/src/main/ets/service/streaming/AdaptiveBitrateService.ets
@@ -10,8 +10,21 @@
 
 import { NvHttp, AbrConfig, NetworkFeedback, AbrCapabilities, AbrAction } from './NvHttp';
 import { StreamStats } from './StreamingSession';
+import {
+  NetworkBoostService,
+  SystemNetQos,
+  SystemNetQosListener,
+  SystemNetScene,
+  SystemNetSceneListener
+} from '../network/NetworkBoostService';
 
 const TAG = '[ABR]';
+
+interface SceneMitigation {
+  factor: number;
+  reason: string;
+  key: string;
+}
 
 /**
  * 智能码率调节服务
@@ -37,6 +50,14 @@ export class AdaptiveBitrateService {
   private lossStreak: number = 0;
   private lastAdjustTime: number = 0;
   private lastDirection: 'up' | 'down' | 'none' = 'none';
+  private lastSceneMitigationTime: number = 0;
+  private lastSceneMitigationKey: string = '';
+
+  private latestSystemQos: SystemNetQos | null = null;
+  private latestSystemScene: SystemNetScene | null = null;
+  private latestSystemSceneAt: number = 0;
+  private qosListener: SystemNetQosListener | null = null;
+  private sceneListener: SystemNetSceneListener | null = null;
 
   // 回调
   private onBitrateChange: ((bitrate: number, reason: string) => Promise<boolean>) | null = null;
@@ -50,6 +71,9 @@ export class AdaptiveBitrateService {
   private serverRetryTickCounter: number = 0;
   private static readonly MAX_SERVER_ENABLE_RETRIES = 10;
   private static readonly SERVER_RETRY_INTERVAL_TICKS = 5;
+  private static readonly SYSTEM_QOS_TTL_MS = 5_000;
+  private static readonly SYSTEM_SCENE_TTL_MS = 12_000;
+  private static readonly SCENE_MITIGATION_COOLDOWN_MS = 6_000;
 
   constructor(nvHttp: NvHttp) {
     this.nvHttp = nvHttp;
@@ -92,6 +116,7 @@ export class AdaptiveBitrateService {
     }
 
     this.enabled = true;
+    this.subscribeNetworkBoostSignals();
 
     // 启动每秒 tick（延迟 3 秒开始，让连接稳定）
     this.tickInterval = setInterval(() => {
@@ -111,6 +136,8 @@ export class AdaptiveBitrateService {
       clearInterval(this.tickInterval);
       this.tickInterval = -1;
     }
+
+    this.unsubscribeNetworkBoostSignals();
 
     // 通知服务端关闭
     if (this.serverSupported) {
@@ -188,8 +215,48 @@ export class AdaptiveBitrateService {
     this.lossStreak = 0;
     this.lastAdjustTime = 0;
     this.lastDirection = 'none';
+    this.lastSceneMitigationTime = 0;
+    this.lastSceneMitigationKey = '';
+    this.latestSystemQos = null;
+    this.latestSystemScene = null;
+    this.latestSystemSceneAt = 0;
     this.serverEnableRetries = 0;
     this.serverRetryTickCounter = 0;
+  }
+
+  private subscribeNetworkBoostSignals(): void {
+    if (this.qosListener || this.sceneListener) {
+      return;
+    }
+    const service = NetworkBoostService.getInstance();
+    const qosListener: SystemNetQosListener = (qos: SystemNetQos): void => {
+      this.latestSystemQos = qos;
+    };
+    const sceneListener: SystemNetSceneListener = (scene: SystemNetScene): void => {
+      this.latestSystemScene = scene;
+      this.latestSystemSceneAt = Date.now();
+    };
+    this.qosListener = qosListener;
+    this.sceneListener = sceneListener;
+    service.addListener(qosListener);
+    service.addSceneListener(sceneListener);
+  }
+
+  private unsubscribeNetworkBoostSignals(): void {
+    const service = NetworkBoostService.getInstance();
+    const qosListener = this.qosListener;
+    if (qosListener) {
+      service.removeListener(qosListener);
+      this.qosListener = null;
+    }
+    const sceneListener = this.sceneListener;
+    if (sceneListener) {
+      service.removeSceneListener(sceneListener);
+      this.sceneListener = null;
+    }
+    this.latestSystemQos = null;
+    this.latestSystemScene = null;
+    this.latestSystemSceneAt = 0;
   }
 
   /**
@@ -239,13 +306,28 @@ export class AdaptiveBitrateService {
    * 服务端模式：上报指标，执行服务端指令
    */
   private async tickServer(stats: StreamStats): Promise<void> {
+    const systemQos = this.getFreshSystemQos();
+    const systemScene = this.getFreshSystemScene();
     const feedback: NetworkFeedback = {
       packetLoss: stats.packetLoss,
-      rttMs: stats.networkLatency,
+      rttMs: stats.networkLatency > 0 ? stats.networkLatency : (systemQos?.rttMs ?? 0),
       decodeFps: stats.renderedFps,
       droppedFrames: stats.droppedFrames,
       currentBitrate: this.currentBitrate,
     };
+    if (systemQos) {
+      feedback.systemRttMs = systemQos.rttMs;
+      feedback.systemUpBufferDelayMs = systemQos.upBufferDelayMs;
+      feedback.systemUpBufferCongestionPercent = systemQos.upBufferCongestionPercent;
+      feedback.systemUpBandwidthBps = systemQos.upBandwidthBps;
+      feedback.systemDownBandwidthBps = systemQos.downBandwidthBps;
+    }
+    if (systemScene) {
+      feedback.systemNetworkScene = systemScene.scene;
+      feedback.systemRecommendedAction = systemScene.recommendedAction;
+      feedback.weakSignalStartSec = systemScene.weakSignalStartSec;
+      feedback.weakSignalDurationSec = systemScene.weakSignalDurationSec;
+    }
 
     const action = await this.nvHttp.reportNetworkFeedback(feedback);
     if (action?.newBitrate && action.newBitrate !== this.currentBitrate) {
@@ -256,6 +338,71 @@ export class AdaptiveBitrateService {
         this.currentBitrate = clamped;
       }
     }
+  }
+
+  private getFreshSystemQos(): SystemNetQos | null {
+    if (!this.latestSystemQos) {
+      return null;
+    }
+    if (Date.now() - this.latestSystemQos.timestampMs > AdaptiveBitrateService.SYSTEM_QOS_TTL_MS) {
+      return null;
+    }
+    return this.latestSystemQos;
+  }
+
+  private getFreshSystemScene(): SystemNetScene | null {
+    if (!this.latestSystemScene) {
+      return null;
+    }
+    if (Date.now() - this.latestSystemSceneAt > AdaptiveBitrateService.SYSTEM_SCENE_TTL_MS) {
+      return null;
+    }
+    return this.latestSystemScene;
+  }
+
+  private getSceneMitigation(now: number): SceneMitigation | null {
+    const scene = this.getFreshSystemScene();
+    if (!scene) {
+      return null;
+    }
+
+    let mitigation: SceneMitigation | null = null;
+    if (scene.weakSignalStartSec !== undefined && scene.weakSignalStartSec >= 0 && scene.weakSignalStartSec <= 8) {
+      mitigation = {
+        factor: 0.82,
+        reason: `networkBoost weakSignal in ${Math.round(scene.weakSignalStartSec)}s`,
+        key: 'weakSignal'
+      };
+    } else if (scene.scene === 'congestion' && scene.recommendedAction === 'suspendData') {
+      mitigation = {
+        factor: 0.72,
+        reason: 'networkBoost congestion suspendData',
+        key: 'congestion:suspendData'
+      };
+    } else if (scene.scene === 'congestion' && scene.recommendedAction === 'decreaseData') {
+      mitigation = {
+        factor: 0.84,
+        reason: 'networkBoost congestion decreaseData',
+        key: 'congestion:decreaseData'
+      };
+    } else if (scene.scene === 'frequentHandover') {
+      mitigation = {
+        factor: 0.90,
+        reason: 'networkBoost frequentHandover',
+        key: 'frequentHandover'
+      };
+    }
+
+    if (!mitigation) {
+      return null;
+    }
+    if (mitigation.key === this.lastSceneMitigationKey &&
+      now - this.lastSceneMitigationTime < AdaptiveBitrateService.SCENE_MITIGATION_COOLDOWN_MS) {
+      return null;
+    }
+    this.lastSceneMitigationKey = mitigation.key;
+    this.lastSceneMitigationTime = now;
+    return mitigation;
   }
 
   /**
@@ -271,7 +418,13 @@ export class AdaptiveBitrateService {
     let newBitrate = this.currentBitrate;
     let reason = '';
 
-    if (stats.packetLoss > 5) {
+    const sceneMitigation = this.getSceneMitigation(now);
+    if (sceneMitigation) {
+      newBitrate = this.currentBitrate * sceneMitigation.factor;
+      reason = sceneMitigation.reason;
+      this.stableSeconds = 0;
+      this.lossStreak++;
+    } else if (stats.packetLoss > 5) {
       // 紧急降档：丢包 > 5%
       newBitrate = this.currentBitrate * 0.7;
       reason = `loss=${stats.packetLoss.toFixed(1)}% emergency`;

--- a/entry/src/main/ets/service/streaming/AdaptiveBitrateService.ets
+++ b/entry/src/main/ets/service/streaming/AdaptiveBitrateService.ets
@@ -56,6 +56,8 @@ export class AdaptiveBitrateService {
   private latestSystemQos: SystemNetQos | null = null;
   private latestSystemScene: SystemNetScene | null = null;
   private latestSystemSceneAt: number = 0;
+  private latestWeakSignalStartAt: number = 0;
+  private latestWeakSignalEndAt: number = 0;
   private qosListener: SystemNetQosListener | null = null;
   private sceneListener: SystemNetSceneListener | null = null;
 
@@ -220,6 +222,8 @@ export class AdaptiveBitrateService {
     this.latestSystemQos = null;
     this.latestSystemScene = null;
     this.latestSystemSceneAt = 0;
+    this.latestWeakSignalStartAt = 0;
+    this.latestWeakSignalEndAt = 0;
     this.serverEnableRetries = 0;
     this.serverRetryTickCounter = 0;
   }
@@ -233,8 +237,17 @@ export class AdaptiveBitrateService {
       this.latestSystemQos = qos;
     };
     const sceneListener: SystemNetSceneListener = (scene: SystemNetScene): void => {
+      const now = Date.now();
       this.latestSystemScene = scene;
-      this.latestSystemSceneAt = Date.now();
+      this.latestSystemSceneAt = now;
+      this.latestWeakSignalStartAt = 0;
+      this.latestWeakSignalEndAt = 0;
+      if (scene.weakSignalStartSec !== undefined && scene.weakSignalStartSec >= 0) {
+        this.latestWeakSignalStartAt = now + scene.weakSignalStartSec * 1000;
+        if (scene.weakSignalDurationSec !== undefined && scene.weakSignalDurationSec > 0) {
+          this.latestWeakSignalEndAt = this.latestWeakSignalStartAt + scene.weakSignalDurationSec * 1000;
+        }
+      }
     };
     this.qosListener = qosListener;
     this.sceneListener = sceneListener;
@@ -257,6 +270,8 @@ export class AdaptiveBitrateService {
     this.latestSystemQos = null;
     this.latestSystemScene = null;
     this.latestSystemSceneAt = 0;
+    this.latestWeakSignalStartAt = 0;
+    this.latestWeakSignalEndAt = 0;
   }
 
   /**
@@ -306,6 +321,7 @@ export class AdaptiveBitrateService {
    * 服务端模式：上报指标，执行服务端指令
    */
   private async tickServer(stats: StreamStats): Promise<void> {
+    const now = Date.now();
     const systemQos = this.getFreshSystemQos();
     const systemScene = this.getFreshSystemScene();
     const feedback: NetworkFeedback = {
@@ -325,8 +341,11 @@ export class AdaptiveBitrateService {
     if (systemScene) {
       feedback.systemNetworkScene = systemScene.scene;
       feedback.systemRecommendedAction = systemScene.recommendedAction;
-      feedback.weakSignalStartSec = systemScene.weakSignalStartSec;
-      feedback.weakSignalDurationSec = systemScene.weakSignalDurationSec;
+      const weakSignalStartSec = this.getWeakSignalStartSec(now);
+      if (weakSignalStartSec !== null) {
+        feedback.weakSignalStartSec = weakSignalStartSec;
+        feedback.weakSignalDurationSec = systemScene.weakSignalDurationSec;
+      }
     }
 
     const action = await this.nvHttp.reportNetworkFeedback(feedback);
@@ -360,6 +379,16 @@ export class AdaptiveBitrateService {
     return this.latestSystemScene;
   }
 
+  private getWeakSignalStartSec(now: number): number | null {
+    if (this.latestWeakSignalStartAt <= 0) {
+      return null;
+    }
+    if (this.latestWeakSignalEndAt > 0 && now > this.latestWeakSignalEndAt) {
+      return null;
+    }
+    return Math.max(0, (this.latestWeakSignalStartAt - now) / 1000);
+  }
+
   private getSceneMitigation(now: number): SceneMitigation | null {
     const scene = this.getFreshSystemScene();
     if (!scene) {
@@ -367,10 +396,11 @@ export class AdaptiveBitrateService {
     }
 
     let mitigation: SceneMitigation | null = null;
-    if (scene.weakSignalStartSec !== undefined && scene.weakSignalStartSec >= 0 && scene.weakSignalStartSec <= 8) {
+    const weakSignalStartSec = this.getWeakSignalStartSec(now);
+    if (weakSignalStartSec !== null && weakSignalStartSec <= 8) {
       mitigation = {
         factor: 0.82,
-        reason: `networkBoost weakSignal in ${Math.round(scene.weakSignalStartSec)}s`,
+        reason: `networkBoost weakSignal in ${Math.round(weakSignalStartSec)}s`,
         key: 'weakSignal'
       };
     } else if (scene.scene === 'congestion' && scene.recommendedAction === 'suspendData') {
@@ -400,8 +430,6 @@ export class AdaptiveBitrateService {
       now - this.lastSceneMitigationTime < AdaptiveBitrateService.SCENE_MITIGATION_COOLDOWN_MS) {
       return null;
     }
-    this.lastSceneMitigationKey = mitigation.key;
-    this.lastSceneMitigationTime = now;
     return mitigation;
   }
 
@@ -470,6 +498,10 @@ export class AdaptiveBitrateService {
         console.info(`${TAG} [local] ${this.currentBitrate}→${newBitrate}kbps (${reason})`);
         this.currentBitrate = newBitrate;
         this.lastAdjustTime = now;
+        if (sceneMitigation) {
+          this.lastSceneMitigationKey = sceneMitigation.key;
+          this.lastSceneMitigationTime = now;
+        }
       }
     }
   }

--- a/entry/src/main/ets/service/streaming/NvHttp.ets
+++ b/entry/src/main/ets/service/streaming/NvHttp.ets
@@ -1348,6 +1348,15 @@ export interface NetworkFeedback {
   decodeFps: number;
   droppedFrames: number;
   currentBitrate: number;
+  systemRttMs?: number;
+  systemUpBufferDelayMs?: number;
+  systemUpBufferCongestionPercent?: number;
+  systemUpBandwidthBps?: number;
+  systemDownBandwidthBps?: number;
+  systemNetworkScene?: string;
+  systemRecommendedAction?: string;
+  weakSignalStartSec?: number;
+  weakSignalDurationSec?: number;
 }
 
 export interface AbrAction {


### PR DESCRIPTION
## Summary

- Wire NetworkBoostKit QoS and scene callbacks into the adaptive bitrate service.
- Forward fresh system QoS/scene hints to the server-side ABR feedback payload.
- Use weak-signal, congestion, and handover scene hints to proactively reduce bitrate in local ABR fallback mode.

## Why

The previous API24 NetworkBoost follow-up only surfaced net scene changes to the UI. This makes the signal actionable for streaming quality: the ABR controller can react before packet loss becomes visible in the native stream stats.

## Validation

- Ran `git diff --check` successfully.
- Attempted local hvigor build, but this workstation's HarmonyOS SDK setup is incomplete: DevEco hvigor reports `SDK component missing` / invalid `DEVECO_SDK_HOME` before reaching ArkTS compilation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  - 自适应码率决策整合系统级 QoS 与网络场景监听，缓存并校验新鲜度以优化决策
  - 网络反馈上报扩展，新增系统 RTT、上/下行带宽、上行缓冲延迟/拥塞、网络场景、推荐动作及弱信号起止与持续时长等指标
  - 本地回退新增场景缓解分支：按缓解系数调整码率、重置稳定计数并支持冷却窗口以防重复触发
<!-- end of auto-generated comment: release notes by coderabbit.ai -->