### PR TITLE
feat(pcview): add host webui access

### DIFF
--- a/entry/src/main/ets/pages/HostWebUiPage.ets
+++ b/entry/src/main/ets/pages/HostWebUiPage.ets
@@ -117,14 +117,14 @@ struct HostWebUiPage {
     ToastQueue.show({ message: 'WebUI 地址已复制' });
   }
 
-  private openInBrowser(): void {
+  private async openInBrowser(): Promise<void> {
     if (!this.webUiUrl) {
       return;
     }
     try {
       const context = getContext(this) as common.UIAbilityContext;
       const want: Want = { action: 'ohos.want.action.viewData', uri: this.webUiUrl };
-      context.startAbility(want);
+      await context.startAbility(want);
     } catch (_e) {
       ToastQueue.show({ message: '无法打开外部浏览器' });
     }
@@ -176,7 +176,7 @@ struct HostWebUiPage {
             .height('100%')
             .javaScriptAccess(true)
             .domStorageAccess(true)
-            .mixedMode(MixedMode.All)
+            .mixedMode(MixedMode.None)
             .zoomAccess(true)
             .onPageBegin(() => {
               this.isLoading = true;
@@ -193,9 +193,6 @@ struct HostWebUiPage {
             .onHttpAuthRequest((event) => this.requestHttpAuth(event))
             .onErrorReceive((event) => {
               if (event?.request && !event.request.isMainFrame()) {
-                return;
-              }
-              if (this.acceptedSslError) {
                 return;
               }
               this.isLoading = false;

--- a/entry/src/main/ets/pages/HostWebUiPage.ets
+++ b/entry/src/main/ets/pages/HostWebUiPage.ets
@@ -1,0 +1,480 @@
+/*
+ * Moonlight for HarmonyOS
+ * Copyright (C) 2024-2025 Moonlight/AlkaidLab
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import { router } from '@kit.ArkUI';
+import { common, Want } from '@kit.AbilityKit';
+import { pasteboard } from '@kit.BasicServicesKit';
+import { webview } from '@kit.ArkWeb';
+import { ComputerInfo } from '../model/ComputerInfo';
+import { ComputerManager } from '../service/ComputerManager';
+import { AppColors, AppSizes, AppSpacing, AppShadows } from '../common/Theme';
+import { buildHostWebUiUrl } from '../utils/HostWebUiUtil';
+import { ToastQueue } from '../utils/ToastQueue';
+
+interface HostWebUiPageParams {
+  computerId: string;
+}
+
+@Entry
+@Component
+struct HostWebUiPage {
+  @StorageProp('topSafeHeight') topSafeHeight: number = 56;
+  @State computerName: string = 'Host WebUI';
+  @State webUiUrl: string = '';
+  @State isLoading: boolean = true;
+  @State loadError: string = '';
+  @State acceptedSslError: boolean = false;
+  @State showAuthDialog: boolean = false;
+  @State authHost: string = '';
+  @State authRealm: string = '';
+  @State authUserName: string = '';
+  @State authPassword: string = '';
+
+  private controller: webview.WebviewController = new webview.WebviewController();
+  private computerManager: ComputerManager = ComputerManager.getInstance();
+  private authHandler: HttpAuthHandler | null = null;
+
+  aboutToAppear(): void {
+    this.loadHost();
+  }
+
+  onBackPress(): boolean {
+    if (this.safeCanGoBack()) {
+      this.controller.backward();
+      return true;
+    }
+    return false;
+  }
+
+  private async loadHost(): Promise<void> {
+    const params = router.getParams() as HostWebUiPageParams;
+    if (!params?.computerId) {
+      this.isLoading = false;
+      this.loadError = '缺少主机信息';
+      return;
+    }
+
+    const computer = await this.findComputer(params.computerId);
+    if (!computer) {
+      this.isLoading = false;
+      this.loadError = '找不到这台主机';
+      return;
+    }
+
+    this.computerName = computer.name;
+    this.webUiUrl = buildHostWebUiUrl(computer);
+    if (!this.webUiUrl) {
+      this.isLoading = false;
+      this.loadError = '没有可用的主机地址';
+    }
+  }
+
+  private async findComputer(computerId: string): Promise<ComputerInfo | null> {
+    try {
+      const computers = await this.computerManager.getComputers();
+      return computers.find((item: ComputerInfo) => item.uuid === computerId) || null;
+    } catch (_e) {
+      return null;
+    }
+  }
+
+  private safeCanGoBack(): boolean {
+    try {
+      return this.controller.accessBackward();
+    } catch (_e) {
+      return false;
+    }
+  }
+
+  private reload(): void {
+    this.isLoading = true;
+    this.loadError = '';
+    this.acceptedSslError = false;
+    this.authHandler = null;
+    this.showAuthDialog = false;
+    try {
+      this.controller.refresh();
+    } catch (_e) {
+      if (this.webUiUrl) {
+        this.controller.loadUrl(this.webUiUrl);
+      }
+    }
+  }
+
+  private copyUrl(): void {
+    if (!this.webUiUrl) {
+      return;
+    }
+    const pasteData = pasteboard.createData(pasteboard.MIMETYPE_TEXT_PLAIN, this.webUiUrl);
+    pasteboard.getSystemPasteboard().setDataSync(pasteData);
+    ToastQueue.show({ message: 'WebUI 地址已复制' });
+  }
+
+  private openInBrowser(): void {
+    if (!this.webUiUrl) {
+      return;
+    }
+    try {
+      const context = getContext(this) as common.UIAbilityContext;
+      const want: Want = { action: 'ohos.want.action.viewData', uri: this.webUiUrl };
+      context.startAbility(want);
+    } catch (_e) {
+      ToastQueue.show({ message: '无法打开外部浏览器' });
+    }
+  }
+
+  private requestHttpAuth(event: OnHttpAuthRequestEvent): boolean {
+    this.authHandler = event.handler;
+    this.authHost = event.host;
+    this.authRealm = event.realm;
+    this.loadError = '';
+    this.isLoading = false;
+    this.showAuthDialog = true;
+    return true;
+  }
+
+  private submitHttpAuth(): void {
+    if (!this.authHandler) {
+      this.showAuthDialog = false;
+      return;
+    }
+    const confirmed = this.authHandler.confirm(this.authUserName, this.authPassword);
+    this.authHandler = null;
+    this.showAuthDialog = false;
+    if (!confirmed) {
+      ToastQueue.show({ message: 'WebUI 登录失败' });
+    } else {
+      this.isLoading = true;
+      this.loadError = '';
+    }
+  }
+
+  private cancelHttpAuth(): void {
+    if (this.authHandler) {
+      this.authHandler.cancel();
+      this.authHandler = null;
+    }
+    this.showAuthDialog = false;
+    this.loadError = '需要 Sunshine WebUI 用户名和密码';
+  }
+
+  build() {
+    Column() {
+      this.NavBar()
+
+      if (this.webUiUrl) {
+        Stack() {
+          Web({ src: this.webUiUrl, controller: this.controller })
+            .width('100%')
+            .height('100%')
+            .javaScriptAccess(true)
+            .domStorageAccess(true)
+            .mixedMode(MixedMode.All)
+            .zoomAccess(true)
+            .onPageBegin(() => {
+              this.isLoading = true;
+              this.loadError = '';
+            })
+            .onPageEnd(() => {
+              this.isLoading = false;
+            })
+            .onSslErrorEventReceive((event) => {
+              this.acceptedSslError = true;
+              this.loadError = '';
+              event.handler.handleConfirm();
+            })
+            .onHttpAuthRequest((event) => this.requestHttpAuth(event))
+            .onErrorReceive((event) => {
+              if (event?.request && !event.request.isMainFrame()) {
+                return;
+              }
+              if (this.acceptedSslError) {
+                return;
+              }
+              this.isLoading = false;
+              const errorInfo = event?.error;
+              const description = errorInfo?.getErrorInfo ? errorInfo.getErrorInfo() : '';
+              this.loadError = description || 'WebUI 加载失败';
+            })
+
+          if (this.isLoading) {
+            this.LoadingOverlay()
+          }
+
+          if (this.loadError) {
+            this.ErrorPanel()
+          }
+        }
+        .layoutWeight(1)
+        .backgroundColor(AppColors.Background)
+      } else {
+        this.EmptyState()
+      }
+
+      if (this.showAuthDialog) {
+        HostWebUiAuthDialog({
+          host: this.authHost,
+          realm: this.authRealm,
+          userName: this.authUserName,
+          password: this.authPassword,
+          onUserNameChange: (value: string) => {
+            this.authUserName = value;
+          },
+          onPasswordChange: (value: string) => {
+            this.authPassword = value;
+          },
+          onConfirm: () => this.submitHttpAuth(),
+          onCancel: () => this.cancelHttpAuth()
+        })
+      }
+    }
+    .width('100%')
+    .height('100%')
+    .backgroundColor(AppColors.Background)
+  }
+
+  @Builder
+  private NavBar() {
+    Row() {
+      Button({ type: ButtonType.Circle }) {
+        Image($r('app.media.ic_back'))
+          .width(20)
+          .height(20)
+          .fillColor(AppColors.TextPrimary)
+      }
+      .width(36)
+      .height(36)
+      .backgroundColor(AppColors.CardBackground)
+      .shadow(AppShadows.Small)
+      .onClick(() => router.back())
+
+      Column() {
+        Text(this.computerName)
+          .fontSize(AppSizes.FontTitle)
+          .fontWeight(FontWeight.Bold)
+          .fontColor(AppColors.TextPrimary)
+          .maxLines(1)
+          .textOverflow({ overflow: TextOverflow.Ellipsis })
+
+        if (this.webUiUrl) {
+          Text(this.webUiUrl)
+            .fontSize(AppSizes.FontCaption)
+            .fontColor(AppColors.TextSecondary)
+            .fontFamily('monospace')
+            .maxLines(1)
+            .textOverflow({ overflow: TextOverflow.Ellipsis })
+        }
+      }
+      .alignItems(HorizontalAlign.Start)
+      .layoutWeight(1)
+      .margin({ left: AppSpacing.Medium, right: AppSpacing.Medium })
+
+      this.IconButton($r('app.media.ic_copy'), () => this.copyUrl())
+      this.IconButton($r('app.media.ic_refresh'), () => this.reload())
+      this.IconButton($r('app.media.ic_arrow_right'), () => this.openInBrowser())
+    }
+    .width('100%')
+    .height(64)
+    .padding({ left: AppSpacing.Large, right: AppSpacing.Large })
+    .margin({ top: this.topSafeHeight - 12 })
+    .backgroundColor(AppColors.Background)
+  }
+
+  @Builder
+  private IconButton(icon: Resource, onClick: () => void) {
+    Button({ type: ButtonType.Circle }) {
+      Image(icon)
+        .width(18)
+        .height(18)
+        .fillColor(AppColors.TextPrimary)
+    }
+    .width(36)
+    .height(36)
+    .margin({ left: AppSpacing.Small })
+    .backgroundColor(AppColors.CardBackground)
+    .shadow(AppShadows.Small)
+    .onClick(onClick)
+  }
+
+  @Builder
+  private LoadingOverlay() {
+    Column() {
+      LoadingProgress()
+        .width(40)
+        .height(40)
+        .color(AppColors.Primary)
+      Text('正在打开 WebUI...')
+        .fontSize(AppSizes.FontBody)
+        .fontColor(AppColors.TextSecondary)
+        .margin({ top: AppSpacing.Medium })
+    }
+    .width('100%')
+    .height('100%')
+    .justifyContent(FlexAlign.Center)
+    .backgroundColor(AppColors.Background)
+  }
+
+  @Builder
+  private ErrorPanel() {
+    Column() {
+      Image($r('app.media.ic_host'))
+        .width(48)
+        .height(48)
+        .fillColor(AppColors.Warning)
+        .margin({ bottom: AppSpacing.Medium })
+
+      Text(this.loadError)
+        .fontSize(AppSizes.FontBody)
+        .fontColor(AppColors.TextPrimary)
+        .textAlign(TextAlign.Center)
+        .margin({ bottom: AppSpacing.Medium })
+
+      Text(this.webUiUrl)
+        .fontSize(AppSizes.FontCaption)
+        .fontColor(AppColors.TextSecondary)
+        .fontFamily('monospace')
+        .textAlign(TextAlign.Center)
+        .margin({ bottom: AppSpacing.Large })
+
+      Row() {
+        Button('重试')
+          .height(40)
+          .fontSize(AppSizes.FontBody)
+          .fontColor(AppColors.TextOnPrimary)
+          .backgroundColor(AppColors.Primary)
+          .borderRadius(AppSizes.RadiusMedium)
+          .layoutWeight(1)
+          .onClick(() => this.reload())
+
+        Button('外部打开')
+          .height(40)
+          .fontSize(AppSizes.FontBody)
+          .fontColor(AppColors.TextPrimary)
+          .backgroundColor(AppColors.CardBackground)
+          .borderRadius(AppSizes.RadiusMedium)
+          .layoutWeight(1)
+          .margin({ left: AppSpacing.Medium })
+          .onClick(() => this.openInBrowser())
+      }
+      .width('100%')
+    }
+    .width('88%')
+    .padding(AppSpacing.XLarge)
+    .backgroundColor(AppColors.Surface)
+    .borderRadius(AppSizes.RadiusXLarge)
+    .shadow(AppShadows.Medium)
+  }
+
+  @Builder
+  private EmptyState() {
+    Column() {
+      Text(this.loadError || '无法打开 WebUI')
+        .fontSize(AppSizes.FontBody)
+        .fontColor(AppColors.TextSecondary)
+    }
+    .width('100%')
+    .layoutWeight(1)
+    .justifyContent(FlexAlign.Center)
+  }
+}
+
+@Component
+struct HostWebUiAuthDialog {
+  host: string = '';
+  realm: string = '';
+  userName: string = '';
+  password: string = '';
+  onUserNameChange: (value: string) => void = () => {};
+  onPasswordChange: (value: string) => void = () => {};
+  onConfirm: () => void = () => {};
+  onCancel: () => void = () => {};
+
+  build() {
+    Stack() {
+      Column() {
+        Column() {
+          Text('登录 Sunshine WebUI')
+            .fontSize(AppSizes.FontTitle)
+            .fontWeight(FontWeight.Bold)
+            .fontColor(AppColors.TextPrimary)
+            .margin({ bottom: AppSpacing.Small })
+
+          Text(this.realm || this.host)
+            .fontSize(AppSizes.FontCaption)
+            .fontColor(AppColors.TextSecondary)
+            .maxLines(1)
+            .textOverflow({ overflow: TextOverflow.Ellipsis })
+            .margin({ bottom: AppSpacing.Large })
+
+          TextInput({ placeholder: '用户名', text: this.userName })
+            .width('100%')
+            .height(48)
+            .fontSize(AppSizes.FontBody)
+            .fontColor(AppColors.TextPrimary)
+            .caretColor(AppColors.Primary)
+            .placeholderColor(AppColors.TextTertiary)
+            .backgroundColor(AppColors.Surface)
+            .borderRadius(AppSizes.RadiusMedium)
+            .padding({ left: AppSpacing.Medium, right: AppSpacing.Medium })
+            .margin({ bottom: AppSpacing.Medium })
+            .onChange((value: string) => this.onUserNameChange(value))
+
+          TextInput({ placeholder: '密码', text: this.password })
+            .type(InputType.Password)
+            .width('100%')
+            .height(48)
+            .fontSize(AppSizes.FontBody)
+            .fontColor(AppColors.TextPrimary)
+            .caretColor(AppColors.Primary)
+            .placeholderColor(AppColors.TextTertiary)
+            .backgroundColor(AppColors.Surface)
+            .borderRadius(AppSizes.RadiusMedium)
+            .padding({ left: AppSpacing.Medium, right: AppSpacing.Medium })
+            .margin({ bottom: AppSpacing.Large })
+            .onChange((value: string) => this.onPasswordChange(value))
+            .onSubmit(() => this.onConfirm())
+
+          Row({ space: AppSpacing.Medium }) {
+            Button('取消')
+              .layoutWeight(1)
+              .height(44)
+              .fontSize(AppSizes.FontBody)
+              .fontColor(AppColors.TextSecondary)
+              .backgroundColor(AppColors.Surface)
+              .borderRadius(AppSizes.RadiusMedium)
+              .onClick(() => this.onCancel())
+
+            Button('登录')
+              .layoutWeight(1)
+              .height(44)
+              .fontSize(AppSizes.FontBody)
+              .fontColor(AppColors.TextOnPrimary)
+              .backgroundColor(AppColors.Primary)
+              .borderRadius(AppSizes.RadiusMedium)
+              .onClick(() => this.onConfirm())
+          }
+          .width('100%')
+        }
+        .width('88%')
+        .padding(AppSpacing.XLarge)
+        .backgroundColor(AppColors.Background)
+        .borderRadius(AppSizes.RadiusXLarge)
+        .shadow(AppShadows.Medium)
+      }
+      .width('100%')
+      .height('100%')
+      .justifyContent(FlexAlign.Center)
+      .alignItems(HorizontalAlign.Center)
+    }
+    .width('100%')
+    .height('100%')
+    .backgroundColor('#66000000')
+  }
+}

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -61,7 +61,7 @@ struct Index {
       title: '3. 网络通信',
       content: '• 应用仅在您的本地网络内与电脑建立连接，传输游戏音视频流和输入指令\n' +
         '• 使用 mDNS 协议在局域网内自动发现运行 GameStream/Sunshine 的电脑\n' +
-        '• 不涉及任何互联网数据上传'
+        '• 仅当您主动使用开发者模式的 GitHub Star 验证时，应用会连接 GitHub OAuth 与 GitHub API'
     } as PrivacySection,
     {
       title: '4. 权限使用',
@@ -74,7 +74,7 @@ struct Index {
     } as PrivacySection,
     {
       title: '5. 第三方服务',
-      content: '本应用不集成任何第三方分析、广告或数据追踪服务。'
+      content: '本应用不集成任何第三方分析、广告或数据追踪服务。GitHub OAuth Device Flow 和 GitHub API 仅用于可选的开发者模式 Star 验证。'
     } as PrivacySection,
     {
       title: '6. 开源合规',

--- a/entry/src/main/ets/pages/PcListPageV2.ets
+++ b/entry/src/main/ets/pages/PcListPageV2.ets
@@ -984,6 +984,10 @@ struct PcListPageV2 {
         url: 'pages/AppListPageV2',
         params: { computerId: c.uuid }
       }),
+      onHostWebUi: (c) => router.pushUrl({
+        url: 'pages/HostWebUiPage',
+        params: { computerId: c.uuid }
+      }),
       onUnpair: (c) => this.actions!.unpairComputer(c),
       onSleep: (c) => this.actions!.sleepComputer(c),
       onTestNetwork: (c) => this.actions!.testNetwork(c),

--- a/entry/src/main/ets/pages/SettingsPageV2.ets
+++ b/entry/src/main/ets/pages/SettingsPageV2.ets
@@ -3883,6 +3883,9 @@ struct SettingsPageV2 {
       case DeveloperUnlockStatus.PENDING:
         if (showPendingToast) {
           ToastQueue.show({ message: '仍在等待 GitHub 授权，请稍后再试', duration: 2500 });
+          if (result.deviceCode && !this.devKeyActivated && !this.developerMode) {
+            this.showDeveloperDeviceCodeDialog(result.deviceCode);
+          }
         }
         break;
       case DeveloperUnlockStatus.VERIFIED:

--- a/entry/src/main/ets/utils/HostWebUiUtil.ets
+++ b/entry/src/main/ets/utils/HostWebUiUtil.ets
@@ -1,0 +1,30 @@
+/*
+ * Moonlight for HarmonyOS
+ * Copyright (C) 2024-2025 Moonlight/AlkaidLab
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import { NvHttpHost, selectBestAddress } from '../model/ComputerInfo';
+import { formatAddressForUrl, parseAddressAndPort } from './NetHelper';
+
+/**
+ * Sunshine Web UI 默认使用 HTTPS 47990；如果用户使用了自定义
+ * GameStream HTTP 端口，则按 Sunshine 相邻端口规则推导 Web UI 端口。
+ */
+export const DEFAULT_HOST_WEBUI_PORT = 47990;
+
+export function buildHostWebUiUrl(computer: NvHttpHost): string {
+  const selectedAddress = selectBestAddress(computer);
+  const parsed = parseAddressAndPort(selectedAddress);
+  if (!parsed.host) {
+    return '';
+  }
+
+  const configuredHttpPort = parsed.port || computer.httpPort;
+  const webUiPort = configuredHttpPort ? configuredHttpPort + 1 : DEFAULT_HOST_WEBUI_PORT;
+  return `https://${formatAddressForUrl(parsed.host)}:${webUiPort}`;
+}

--- a/entry/src/main/ets/viewmodel/ComputerMenuHelper.ets
+++ b/entry/src/main/ets/viewmodel/ComputerMenuHelper.ets
@@ -30,6 +30,8 @@ export interface ComputerMenuCallbacks {
   onQuitGame: (computer: ObservableComputer) => void;
   /** 应用列表 */
   onAppList: (computer: ObservableComputer) => void;
+  /** 访问主机 WebUI */
+  onHostWebUi: (computer: ObservableComputer) => void;
   /** 取消配对 */
   onUnpair: (computer: ObservableComputer) => void;
   /** 休眠电脑 */
@@ -112,6 +114,14 @@ export class ComputerMenuHelper {
         title: '应用列表',
         subtitle: '查看可串流的应用',
         value: appListKey
+      });
+
+      const hostWebUiKey = `action_${actionIndex++}`;
+      actionMap.set(hostWebUiKey, () => callbacks.onHostWebUi(computer));
+      options.push({
+        title: 'host Settings',
+        subtitle: '打开 Sunshine 主机管理页面',
+        value: hostWebUiKey
       });
       
       // 取消配对

--- a/entry/src/main/resources/base/profile/main_pages.json
+++ b/entry/src/main/resources/base/profile/main_pages.json
@@ -4,6 +4,7 @@
     "pages/StreamPage",
     "pages/PcListPageV2",
     "pages/AppListPageV2",
+    "pages/HostWebUiPage",
     "pages/SettingsPageV2",
     "pages/AddPcPageV2",
     "pages/ControllerTestPage"


### PR DESCRIPTION
## 改了啥呀
- 在 PCView 主机菜单里加了 host Settings 入口，直达 Sunshine Host WebUI。
- 新增 ArkWeb 承载页，支持复制地址、刷新、外部打开和返回。
- WebUI URL 会按主机地址推导到 HTTPS 47990，并兼容自定义 GameStream HTTP 端口的相邻端口。
- 自动确认 Sunshine 自签名/主机名不匹配证书错误，还补了 Basic Auth 登录弹窗，空白页杂鱼状态退退退。

## 为啥要改
- 用户在主机菜单里就能直接管理 Sunshine，不用手动复制 IP 再切浏览器。
- Sunshine WebUI 常见自签名证书和 401 Basic Auth，ArkWeb 需要应用侧接住，不然就会报证书错或白屏。

## 验证
- `git diff --check`
- `NODE_PATH=/Users/mac/Program/moonlight-harmony/node_modules JAVA_HOME=/Applications/DevEco-Studio.app/Contents/jbr/Contents/Home DEVECO_SDK_HOME=/Applications/DevEco-Studio.app/Contents/sdk node hvigorw.js assembleApp --no-daemon`
- 模拟器安装 HAP 并打开主机菜单，点击 host Settings 后进入 `https://192.168.18.42:47990`，出现 Sunshine WebUI 登录弹窗。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增主机 WebUI 页面，可在电脑菜单中通过“访问主机设置”打开
  * 支持自动生成并加载 WebUI 地址，提供返回、重新加载
  * 支持 HTTP 基础认证登录弹窗、复制 WebUI 地址与外部浏览器打开
  * 支持处理 WebUI 证书/SSL 错误的加载流程
* **Bug修复**
  * 修复开发者认证处于 PENDING 状态时返回设置页能恢复授权对话框显示
* **文档**
  * 更新隐私政策，说明 GitHub OAuth 仅用于开发者模式 Star 验证且不集成数据追踪
<!-- end of auto-generated comment: release notes by coderabbit.ai -->