### PR TITLE
feat(harmonyos): prepare API 26 follow-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,12 @@
 
 ### 开发环境
 
-- **DevEco Studio**: 5.0.0 或更高版本
-- **HarmonyOS SDK**: API 12 (HarmonyOS 5.0)
-- **Node.js**: 16.x 或更高版本
+- **DevEco Studio**: 6.1 或更高版本；已验证 HarmonyOS 26.0.0 Beta1 SDK 可进入编译流程
+- **HarmonyOS SDK**: 兼容 API 12+；当前 targetSdkVersion 保持 6.1.1(24)
+- **Node.js**: 20.x 或更高版本
+- **JDK/JBR**: 本地打包 HAP 需要可用的 Java Runtime；可直接使用 DevEco Studio 自带 JBR
+
+> 说明：暂不直接把 targetSdkVersion 升到 API 26。API 26 会启用新的 ArkUI/权限/系统行为门控，当前优先保持运行行为稳定，同时让 CI 和本地 SDK 工具链先识别 HarmonyOS 26.0.0。
 
 ### 项目结构
 

--- a/ci/normalize-sdk.sh
+++ b/ci/normalize-sdk.sh
@@ -116,6 +116,7 @@ echo "Target SDK API version: $API_VER"
 echo "SDK package version: $SDK_PKG_VERSION"
 
 case "$API_VER" in
+  26) HOS_PLATFORM_VERSION="26.0.0"; HOS_TARGET_SDK_VERSION="26.0.0" ;;
   24) HOS_PLATFORM_VERSION="6.1.1"; HOS_TARGET_SDK_VERSION="6.1.1(24)" ;;
   23) HOS_PLATFORM_VERSION="6.1.0"; HOS_TARGET_SDK_VERSION="6.1.0(23)" ;;
   22) HOS_PLATFORM_VERSION="6.0.2"; HOS_TARGET_SDK_VERSION="6.0.2(22)" ;;
@@ -180,7 +181,7 @@ write_hms_check_package "toolchains" "$SDK_HOME/toolchains/hms/toolchains"
 # Some command-line-tools only know HarmonyOS <= 5.1.0 until patched. The real
 # platform version stays 6.1.1 in sdk-pkg.json, while this alias lets those
 # tools discover the same local platform container before ci/patch-sdk.sh runs.
-for platform_alias in "hmscore/$API_VER" "hmscore/$HOS_PLATFORM_VERSION" "HarmonyOS-NEXT2" "HarmonyOS NEXT2"; do
+for platform_alias in "hmscore/$API_VER" "hmscore/$HOS_PLATFORM_VERSION" "HarmonyOS-$HOS_PLATFORM_VERSION" "HarmonyOS $HOS_PLATFORM_VERSION" "HarmonyOS-NEXT2" "HarmonyOS NEXT2"; do
   rm -rf "$SDK_HOME/$platform_alias"
   mkdir -p "$(dirname "$SDK_HOME/$platform_alias")"
   ln -sfn "$SDK_HOME/toolchains" "$SDK_HOME/$platform_alias"

--- a/ci/normalize-sdk.sh
+++ b/ci/normalize-sdk.sh
@@ -116,13 +116,17 @@ echo "Target SDK API version: $API_VER"
 echo "SDK package version: $SDK_PKG_VERSION"
 
 case "$API_VER" in
-  26) HOS_PLATFORM_VERSION="26.0.0"; HOS_TARGET_SDK_VERSION="26.0.0" ;;
-  24) HOS_PLATFORM_VERSION="6.1.1"; HOS_TARGET_SDK_VERSION="6.1.1(24)" ;;
-  23) HOS_PLATFORM_VERSION="6.1.0"; HOS_TARGET_SDK_VERSION="6.1.0(23)" ;;
-  22) HOS_PLATFORM_VERSION="6.0.2"; HOS_TARGET_SDK_VERSION="6.0.2(22)" ;;
-  20) HOS_PLATFORM_VERSION="6.0.0"; HOS_TARGET_SDK_VERSION="6.0.0(20)" ;;
+  26) HOS_PLATFORM_VERSION="26.0.0"; HOS_COMPILE_SDK_VERSION="26.0.0"; HOS_TARGET_SDK_VERSION="26.0.0" ;;
+  24) HOS_PLATFORM_VERSION="6.1.1"; HOS_COMPILE_SDK_VERSION="6.1.1"; HOS_TARGET_SDK_VERSION="6.1.1(24)" ;;
+  23) HOS_PLATFORM_VERSION="6.1.0"; HOS_COMPILE_SDK_VERSION="6.1.0"; HOS_TARGET_SDK_VERSION="6.1.0(23)" ;;
+  22) HOS_PLATFORM_VERSION="6.0.2"; HOS_COMPILE_SDK_VERSION="6.0.2"; HOS_TARGET_SDK_VERSION="6.0.2(22)" ;;
+  20) HOS_PLATFORM_VERSION="6.0.0"; HOS_COMPILE_SDK_VERSION="6.0.0"; HOS_TARGET_SDK_VERSION="6.0.0(20)" ;;
   *) echo "ERROR: Unsupported SDK API version: $API_VER"; exit 1 ;;
 esac
+
+# GitHub Actions writes this value into both compileSdkVersion and targetSdkVersion.
+# Older command-line tools reject decorated values such as 6.1.1(24) for compileSdkVersion.
+[ "${GITHUB_ACTIONS:-}" = "true" ] && HOS_TARGET_SDK_VERSION="$HOS_COMPILE_SDK_VERSION"
 
 # ─── Step 1: Flatten nested openharmony/<ver> layout to root ───
 # hvigor 6.24 treats a sdk-pkg.json with apiVersion as a platform container and
@@ -200,5 +204,6 @@ done
 echo "SDK_API_VERSION=$API_VER"
 echo "SDK_SOURCE_API_VERSION=$SOURCE_API_VER"
 echo "HOS_PLATFORM_VERSION=$HOS_PLATFORM_VERSION"
+echo "HOS_COMPILE_SDK_VERSION=$HOS_COMPILE_SDK_VERSION"
 echo "HOS_TARGET_SDK_VERSION=$HOS_TARGET_SDK_VERSION"
 echo "✅ SDK layout normalized"

--- a/ci/patch-sdk.sh
+++ b/ci/patch-sdk.sh
@@ -47,6 +47,53 @@ TOOLCHAINS="$OH_TOOLCHAINS"
 
 echo "=== Applying SDK patches ==="
 
+patch_ci_build_profile_versions() {
+  [ "${GITHUB_ACTIONS:-}" = "true" ] || return 0
+  [ -f "build-profile.json5" ] || return 0
+
+  local target_version
+  case "${CI_TARGET_API_VERSION:-}" in
+    26) target_version="26.0.0" ;;
+    24) target_version="6.1.1(24)" ;;
+    23) target_version="6.1.0(23)" ;;
+    22) target_version="6.0.2(22)" ;;
+    20) target_version="6.0.0(20)" ;;
+    *) return 0 ;;
+  esac
+
+  TARGET_SDK_VERSION="$target_version" python3 - <<'PY'
+import os
+import re
+
+path = "build-profile.json5"
+with open(path, encoding="utf-8") as f:
+    text = f.read()
+
+target_version = os.environ["TARGET_SDK_VERSION"]
+text = re.sub(
+    r'("compileSdkVersion"\s*:\s*")[^"]+(")',
+    rf'\g<1>{target_version}\2',
+    text,
+)
+text = re.sub(
+    r'("targetSdkVersion"\s*:\s*")[^"]+(")',
+    rf'\g<1>{target_version}\2',
+    text,
+)
+text = re.sub(
+    r'("compatibleSdkVersion"\s*:\s*")([0-9]+\.[0-9]+\.[0-9]+)(?:\([0-9]+\))?(")',
+    r'\g<1>\2(12)\3',
+    text,
+)
+
+with open(path, "w", encoding="utf-8") as f:
+    f.write(text)
+print(f"  Patched CI build-profile.json5 SDK versions: compile={target_version}, target={target_version}")
+PY
+}
+
+patch_ci_build_profile_versions
+
 kit_decl_exists() {
   local kit_name="$1"
   [ -f "$OH_ETS_KITS/$kit_name.d.ts" ] || [ -f "$OH_ETS_KITS/$kit_name.d.ets" ] || \
@@ -85,14 +132,16 @@ p = os.environ['CONFIG_PATH']
 with open(p) as f:
     c = json.load(f)
 before = json.dumps(c, sort_keys=True)
+target_api = os.environ.get('CI_TARGET_API_VERSION', '24')
 os_versions = c.setdefault('osVersionMapper', {})
 os_names = c.setdefault('osNameMapper', {})
 path_versions = c.setdefault('pathVersionMapper', {})
 
-# Keep older CI command-line-tools aware of the latest local HarmonyOS Beta SDK.
-os_versions.setdefault('26.0.0', '26')
-os_names.setdefault('26.0.0', 'HarmonyOS 26.0.0')
-path_versions.setdefault('26.0.0', 'HarmonyOS-26.0.0')
+if target_api == '26':
+    # Keep older CI command-line-tools aware of the latest local HarmonyOS Beta SDK.
+    os_versions.setdefault('26.0.0', '26')
+    os_names.setdefault('26.0.0', 'HarmonyOS 26.0.0')
+    path_versions.setdefault('26.0.0', 'HarmonyOS-26.0.0')
 
 # Keep older CI command-line-tools aware of the API 24 target used by build-profile.json5.
 os_versions.setdefault('6.1.1', '24')
@@ -281,16 +330,31 @@ fi
 
 # ─── @kit.NetworkBoostKit ───
 if ! kit_decl_exists "@kit.NetworkBoostKit"; then
-  [ ! -f "$HMS_KIT_CONFIGS/@kit.NetworkBoostKit.json" ] && \
-    cp "$STUBS_DIR/kit.NetworkBoostKit.json" "$HMS_KIT_CONFIGS/@kit.NetworkBoostKit.json"
+  cp "$STUBS_DIR/kit.NetworkBoostKit.json" "$HMS_KIT_CONFIGS/@kit.NetworkBoostKit.json"
   [ ! -f "$HMS_ETS_API/@ohos.networkBoost.netQuality.d.ts" ] && \
     cp "$STUBS_DIR/ohos.networkBoost.netQuality.d.ts" "$HMS_ETS_API/@ohos.networkBoost.netQuality.d.ts"
   [ ! -f "$HMS_ETS_API/@ohos.networkBoost.netBoost.d.ts" ] && \
     cp "$STUBS_DIR/ohos.networkBoost.netBoost.d.ts" "$HMS_ETS_API/@ohos.networkBoost.netBoost.d.ts"
   cp "$STUBS_DIR/kit.NetworkBoostKit.d.ts" "$HMS_ETS_API/@kit.NetworkBoostKit.d.ts"
+  cp "$STUBS_DIR/kit.NetworkBoostKit.d.ts" "$HMS_ETS_KITS/@kit.NetworkBoostKit.d.ts"
   echo "  Applied NetworkBoostKit stubs"
 else
   echo "  Using SDK NetworkBoostKit declarations"
+  KIT_NETWORKBOOST_DTS="$HMS_ETS_KITS/@kit.NetworkBoostKit.d.ts"
+  KIT_NETWORKBOOST_CONFIG="$HMS_KIT_CONFIGS/@kit.NetworkBoostKit.json"
+  if [ -f "$KIT_NETWORKBOOST_DTS" ] && ! grep -q "netBoost" "$KIT_NETWORKBOOST_DTS"; then
+    cp "$STUBS_DIR/kit.NetworkBoostKit.d.ts" "$KIT_NETWORKBOOST_DTS"
+    echo "  Patched NetworkBoostKit netBoost export"
+  fi
+  if [ -f "$HMS_ETS_API/@kit.NetworkBoostKit.d.ts" ] && ! grep -q "netBoost" "$HMS_ETS_API/@kit.NetworkBoostKit.d.ts"; then
+    cp "$STUBS_DIR/kit.NetworkBoostKit.d.ts" "$HMS_ETS_API/@kit.NetworkBoostKit.d.ts"
+  fi
+  if [ -f "$KIT_NETWORKBOOST_CONFIG" ] && ! grep -q '"netBoost"' "$KIT_NETWORKBOOST_CONFIG"; then
+    cp "$STUBS_DIR/kit.NetworkBoostKit.json" "$KIT_NETWORKBOOST_CONFIG"
+    echo "  Patched NetworkBoostKit netBoost kit config"
+  fi
+  [ ! -f "$HMS_ETS_API/@ohos.networkBoost.netBoost.d.ts" ] && \
+    cp "$STUBS_DIR/ohos.networkBoost.netBoost.d.ts" "$HMS_ETS_API/@ohos.networkBoost.netBoost.d.ts"
   NETBOOST_DTS=""
   for candidate in "$HMS_ETS_API/@hms.networkboost.netBoost.d.ts" "$HMS_ETS_API/@ohos.networkBoost.netBoost.d.ts"; do
     [ -f "$candidate" ] && NETBOOST_DTS="$candidate" && break

--- a/ci/patch-sdk.sh
+++ b/ci/patch-sdk.sh
@@ -4,7 +4,7 @@
 #   1. Copies type declaration stubs from ci/sdk-stubs/
 #   2. Creates missing shared libraries
 #   3. Deduplicates id_defined.json
-#   4. Patches hos-config.json for HarmonyOS 6.1.1(API 24)
+#   4. Patches hos-config.json for HarmonyOS 26.0.0(API 26) / 6.x targets
 set -euo pipefail
 
 SDK_HOME="${1:-$HOME/ohos-sdk}"
@@ -72,7 +72,7 @@ loader_patch_roots() {
   done
 }
 
-# ─── Patch hos-config.json for API 24 targetSdkVersion ───
+# ─── Patch hos-config.json for HarmonyOS targetSdkVersion aliases ───
 echo "Patching hos-config.json..."
 CMDLINE_ROOTS="$(cmdline_tool_roots || true)"
 if [ -n "$CMDLINE_ROOTS" ]; then
@@ -88,6 +88,11 @@ before = json.dumps(c, sort_keys=True)
 os_versions = c.setdefault('osVersionMapper', {})
 os_names = c.setdefault('osNameMapper', {})
 path_versions = c.setdefault('pathVersionMapper', {})
+
+# Keep older CI command-line-tools aware of the latest local HarmonyOS Beta SDK.
+os_versions.setdefault('26.0.0', '26')
+os_names.setdefault('26.0.0', 'HarmonyOS 26.0.0')
+path_versions.setdefault('26.0.0', 'HarmonyOS-26.0.0')
 
 # Keep older CI command-line-tools aware of the API 24 target used by build-profile.json5.
 os_versions.setdefault('6.1.1', '24')
@@ -280,10 +285,20 @@ if ! kit_decl_exists "@kit.NetworkBoostKit"; then
     cp "$STUBS_DIR/kit.NetworkBoostKit.json" "$HMS_KIT_CONFIGS/@kit.NetworkBoostKit.json"
   [ ! -f "$HMS_ETS_API/@ohos.networkBoost.netQuality.d.ts" ] && \
     cp "$STUBS_DIR/ohos.networkBoost.netQuality.d.ts" "$HMS_ETS_API/@ohos.networkBoost.netQuality.d.ts"
+  [ ! -f "$HMS_ETS_API/@ohos.networkBoost.netBoost.d.ts" ] && \
+    cp "$STUBS_DIR/ohos.networkBoost.netBoost.d.ts" "$HMS_ETS_API/@ohos.networkBoost.netBoost.d.ts"
   cp "$STUBS_DIR/kit.NetworkBoostKit.d.ts" "$HMS_ETS_API/@kit.NetworkBoostKit.d.ts"
   echo "  Applied NetworkBoostKit stubs"
 else
   echo "  Using SDK NetworkBoostKit declarations"
+  NETBOOST_DTS=""
+  for candidate in "$HMS_ETS_API/@hms.networkboost.netBoost.d.ts" "$HMS_ETS_API/@ohos.networkBoost.netBoost.d.ts"; do
+    [ -f "$candidate" ] && NETBOOST_DTS="$candidate" && break
+  done
+  if [ -n "$NETBOOST_DTS" ] && ! grep -q "setDataFlowDesc" "$NETBOOST_DTS"; then
+    cat "$STUBS_DIR/networkboost-dataflow-patch.d.ts" >> "$NETBOOST_DTS"
+    echo "  Patched NetworkBoost data-flow declarations"
+  fi
 fi
 
 # ─── Socket stub (only if SDK is missing the file) ───

--- a/ci/patch-sdk.sh
+++ b/ci/patch-sdk.sh
@@ -70,21 +70,27 @@ with open(path, encoding="utf-8") as f:
     text = f.read()
 
 target_version = os.environ["TARGET_SDK_VERSION"]
-text = re.sub(
+has_compile_sdk_version = re.search(r'"compileSdkVersion"\s*:', text) is not None
+text, compile_hits = re.subn(
     r'("compileSdkVersion"\s*:\s*")[^"]+(")',
     rf'\g<1>{target_version}\2',
     text,
 )
-text = re.sub(
+text, target_hits = re.subn(
     r'("targetSdkVersion"\s*:\s*")[^"]+(")',
     rf'\g<1>{target_version}\2',
     text,
 )
-text = re.sub(
+text, compatible_hits = re.subn(
     r'("compatibleSdkVersion"\s*:\s*")([0-9]+\.[0-9]+\.[0-9]+)(?:\([0-9]+\))?(")',
     r'\g<1>\2(12)\3',
     text,
 )
+if target_hits == 0 or compatible_hits == 0 or (has_compile_sdk_version and compile_hits == 0):
+    raise SystemExit(
+        "build-profile.json5 patch failed: "
+        f"compile_hits={compile_hits}, target_hits={target_hits}, compatible_hits={compatible_hits}"
+    )
 
 with open(path, "w", encoding="utf-8") as f:
     f.write(text)

--- a/ci/sdk-stubs/kit.NetworkBoostKit.d.ts
+++ b/ci/sdk-stubs/kit.NetworkBoostKit.d.ts
@@ -1,3 +1,4 @@
 declare module '@kit.NetworkBoostKit' {
   export { default as netQuality } from '@ohos.networkBoost.netQuality';
+  export { default as netBoost } from '@ohos.networkBoost.netBoost';
 }

--- a/ci/sdk-stubs/kit.NetworkBoostKit.json
+++ b/ci/sdk-stubs/kit.NetworkBoostKit.json
@@ -3,6 +3,10 @@
     "netQuality": {
       "source": "@ohos.networkBoost.netQuality.d.ts",
       "bindings": "default"
+    },
+    "netBoost": {
+      "source": "@ohos.networkBoost.netBoost.d.ts",
+      "bindings": "default"
     }
   }
 }

--- a/ci/sdk-stubs/networkboost-dataflow-patch.d.ts
+++ b/ci/sdk-stubs/networkboost-dataflow-patch.d.ts
@@ -1,0 +1,43 @@
+
+declare namespace netBoost {
+  interface DataFlowDesc {
+    dataFlowInfo: DataFlowInfo | SocketFd;
+    scene: netQuality.ServiceType;
+    sceneEvent: SceneEvent;
+    expectations?: ExpectedDescription;
+  }
+
+  type SocketFd = number;
+
+  interface DataFlowInfo {
+    protocol: ProtocolType;
+    local: NetAddress;
+    remote: NetAddress;
+  }
+
+  interface ExpectedDescription {
+    uplinkBandwidth?: number;
+    downlinkBandwidth?: number;
+    latency?: number;
+    objectSize?: number;
+    priority?: PriorityLevel;
+    lowPowerMode?: boolean;
+  }
+
+  interface NetAddress {
+    address: string;
+    port: number;
+  }
+
+  enum ProtocolType {
+    PROTOCOL_UDP = 0,
+    PROTOCOL_TCP = 1
+  }
+
+  enum PriorityLevel {
+    PRIO_NORMAL = 0,
+    PRIO_HIGH = 1
+  }
+
+  function setDataFlowDesc(dataFlowDesc: DataFlowDesc): void;
+}

--- a/ci/sdk-stubs/ohos.networkBoost.netBoost.d.ts
+++ b/ci/sdk-stubs/ohos.networkBoost.netBoost.d.ts
@@ -1,0 +1,67 @@
+/**
+ * @ohos.networkBoost.netBoost stub
+ * Public OpenHarmony SDK lacks the HMS Network Boost Kit; this stub provides
+ * the small netBoost surface used by CI builds. Real device runtime loads the
+ * actual HMS implementation.
+ */
+import netQuality from '@ohos.networkBoost.netQuality';
+
+declare namespace netBoost {
+  interface SceneDesc {
+    scene: netQuality.ServiceType;
+    sceneEvent: SceneEvent;
+    startTime?: number;
+    duration?: number;
+  }
+
+  enum SceneEvent {
+    SCENE_EVENT_ENTER = 0,
+    SCENE_EVENT_UPDATE = 1,
+    SCENE_EVENT_LEAVE = 2
+  }
+
+  interface DataFlowDesc {
+    dataFlowInfo: DataFlowInfo | SocketFd;
+    scene: netQuality.ServiceType;
+    sceneEvent: SceneEvent;
+    expectations?: ExpectedDescription;
+  }
+
+  type SocketFd = number;
+
+  interface DataFlowInfo {
+    protocol: ProtocolType;
+    local: NetAddress;
+    remote: NetAddress;
+  }
+
+  interface ExpectedDescription {
+    uplinkBandwidth?: number;
+    downlinkBandwidth?: number;
+    latency?: number;
+    objectSize?: number;
+    priority?: PriorityLevel;
+    lowPowerMode?: boolean;
+  }
+
+  interface NetAddress {
+    address: string;
+    port: number;
+  }
+
+  enum ProtocolType {
+    PROTOCOL_UDP = 0,
+    PROTOCOL_TCP = 1
+  }
+
+  enum PriorityLevel {
+    PRIO_NORMAL = 0,
+    PRIO_HIGH = 1
+  }
+
+  function setSceneDesc(sceneDesc: SceneDesc): void;
+  function setDataFlowDesc(dataFlowDesc: DataFlowDesc): void;
+  function setLowPowerMode(isEnable: boolean): void;
+}
+
+export default netBoost;

--- a/ci/sdk-stubs/ohos.networkBoost.netQuality.d.ts
+++ b/ci/sdk-stubs/ohos.networkBoost.netQuality.d.ts
@@ -4,7 +4,8 @@
  * just enough surface for the codebase to compile under CI. Real device runtime
  * loads the actual HMS implementation (richer than this stub).
  *
- * Field set kept aligned with HarmonyOS NEXT3 SDK 6.0.0 (API 20):
+ * Field set kept aligned with HarmonyOS NetworkBoostKit APIs used by this repo
+ * through HarmonyOS 26.0.0 (API 26):
  *   NetworkQos: linkUp/DownBandwidth, linkUp/DownRate, rttMs,
  *               linkUpBufferDelayMs, linkUpBufferCongestionPercent.
  */

--- a/entry/src/main/ets/components/AppCard.ets
+++ b/entry/src/main/ets/components/AppCard.ets
@@ -73,7 +73,7 @@ export struct AppCard {
         // 运行中指示器
         if (this.app.isRunning) {
           Row() {
-            Circle()
+            Ellipse()
               .width(6)
               .height(6)
               .fill(AppColors.Online)

--- a/entry/src/main/ets/components/AppListItem.ets
+++ b/entry/src/main/ets/components/AppListItem.ets
@@ -60,7 +60,7 @@ export struct AppListItem {
   @Builder
   private RunningIndicator() {
     Row() {
-      Circle()
+      Ellipse()
         .width(6)
         .height(6)
         .fill(AppColors.Online)

--- a/entry/src/main/ets/components/ComputerCard.ets
+++ b/entry/src/main/ets/components/ComputerCard.ets
@@ -191,7 +191,7 @@ export struct ComputerCard {
 
       // 第三行：状态圆点 + 状态文本
       Row() {
-        Circle()
+        Ellipse()
           .width(8)
           .height(8)
           .fill(this.getStatusDotColor())

--- a/entry/src/main/ets/components/PcListTitleBar.ets
+++ b/entry/src/main/ets/components/PcListTitleBar.ets
@@ -70,7 +70,7 @@ export struct PcListTitleBar {
 
             if (this.config.totalCount > 0) {
               Row() {
-                Circle()
+                Ellipse()
                   .width(6)
                   .height(6)
                   .fill(AppColors.Online)

--- a/entry/src/main/ets/components/test/GameControllerTestView.ets
+++ b/entry/src/main/ets/components/test/GameControllerTestView.ets
@@ -457,7 +457,7 @@ export struct GameControllerTestView {
       Column({ space: 16 }) {
         // 状态标题
         Row({ space: 8 }) {
-          Circle()
+          Ellipse()
             .width(12)
             .height(12)
             .fill(this.isAvailable ? (this.isMonitoring ? AppColors.Success : AppColors.Warning) : AppColors.Error)

--- a/entry/src/main/ets/components/test/SensorTestView.ets
+++ b/entry/src/main/ets/components/test/SensorTestView.ets
@@ -345,7 +345,7 @@ export struct SensorTestView {
 
       Row({ space: 16 }) {
         Row({ space: 8 }) {
-          Circle()
+          Ellipse()
             .width(12)
             .height(12)
             .fill(this.gyroAvailable
@@ -364,7 +364,7 @@ export struct SensorTestView {
         }
 
         Row({ space: 8 }) {
-          Circle()
+          Ellipse()
             .width(12)
             .height(12)
             .fill(this.accelAvailable
@@ -383,7 +383,7 @@ export struct SensorTestView {
         }
 
         Row({ space: 8 }) {
-          Circle()
+          Ellipse()
             .width(12)
             .height(12)
             .fill('#2196F3')

--- a/entry/src/main/ets/components/test/UsbControllerTestView.ets
+++ b/entry/src/main/ets/components/test/UsbControllerTestView.ets
@@ -728,7 +728,7 @@ export struct UsbControllerTestView {
   StickVisualizer($$: StickVisualizerParams) {
     Stack() {
       // 外圈 - 柔和边框
-      Circle()
+      Ellipse()
         .width(76)
         .height(76)
         .fill('#0A808080')
@@ -746,7 +746,7 @@ export struct UsbControllerTestView {
         .backgroundColor('#15808080')
 
       // 死区范围
-      Circle()
+      Ellipse()
         .width(12)
         .height(12)
         .fill(Color.Transparent)
@@ -754,7 +754,7 @@ export struct UsbControllerTestView {
         .strokeWidth(0.5)
       
       // 指示点 — 渐变发光
-      Circle()
+      Ellipse()
         .width(18)
         .height(18)
         .fill($$.isRight ? '#E81123' : '#3D8ECF')

--- a/entry/src/main/ets/components/virtual/AnalogStick.ets
+++ b/entry/src/main/ets/components/virtual/AnalogStick.ets
@@ -80,7 +80,7 @@ export struct AnalogStick {
   build() {
     Stack() {
       // 外圈（全透明 + 细边框）
-      Circle()
+      Ellipse()
         .width(this.stickOuterRadius * 2)
         .height(this.stickOuterRadius * 2)
         .fill('transparent')
@@ -89,7 +89,7 @@ export struct AnalogStick {
         .strokeOpacity(0.15)
       
       // 摇杆头（全透明 + 轮廓）
-      Circle()
+      Ellipse()
         .width(this.stickInnerRadius * 2)
         .height(this.stickInnerRadius * 2)
         .fill(this.isPressed ? '#005090FF' : 'transparent')
@@ -107,7 +107,7 @@ export struct AnalogStick {
       
       // 点击反馈
       if (this.showClickFeedback) {
-        Circle()
+        Ellipse()
           .width(this.stickInnerRadius * 2 + 16)
           .height(this.stickInnerRadius * 2 + 16)
           .fill('transparent')

--- a/entry/src/main/ets/components/virtual/InvisibleJoystick.ets
+++ b/entry/src/main/ets/components/virtual/InvisibleJoystick.ets
@@ -118,7 +118,7 @@ export struct InvisibleJoystick {
           .borderRadius(4)
 
         // 编辑模式下在中心画预览摇杆轮廓
-        Circle()
+        Ellipse()
           .width(this.stickRadius * 2)
           .height(this.stickRadius * 2)
           .fill('transparent')
@@ -134,7 +134,7 @@ export struct InvisibleJoystick {
       // 按下时在触摸点显示摇杆
       if (this.isPressed) {
         // 外圆环
-        Circle()
+        Ellipse()
           .width(this.stickRadius * 2)
           .height(this.stickRadius * 2)
           .fill('transparent')
@@ -146,7 +146,7 @@ export struct InvisibleJoystick {
           })
 
         // 死区圆
-        Circle()
+        Ellipse()
           .width(this.stickRadius * 2 * this.deadzone)
           .height(this.stickRadius * 2 * this.deadzone)
           .fill('transparent')
@@ -159,7 +159,7 @@ export struct InvisibleJoystick {
           })
 
         // 内摇杆头
-        Circle()
+        Ellipse()
           .width(this.innerRadius * 2)
           .height(this.innerRadius * 2)
           .fill(this.pressedColor)

--- a/entry/src/main/ets/components/virtual/VirtualJoystick.ets
+++ b/entry/src/main/ets/components/virtual/VirtualJoystick.ets
@@ -103,7 +103,7 @@ export struct VirtualJoystick {
       }
 
       // 外圆环
-      Circle()
+      Ellipse()
         .width(this.stickOuterRadius * 2)
         .height(this.stickOuterRadius * 2)
         .fill('#01000000')
@@ -113,7 +113,7 @@ export struct VirtualJoystick {
         .opacity(this.invisibleMode && !this.isPressed ? 0 : 1)
 
       // 内摇杆头
-      Circle()
+      Ellipse()
         .width(this.stickInnerRadius * 2)
         .height(this.stickInnerRadius * 2)
         .fill(this.isPressed ? this.pressedColor : this.stickColor)

--- a/entry/src/main/ets/pages/AddPcPageV2.ets
+++ b/entry/src/main/ets/pages/AddPcPageV2.ets
@@ -134,7 +134,7 @@ struct AddPcPageV2 {
       // 电佬角色区域
       Stack() {
         // 底层脉冲光晕
-        Circle()
+        Ellipse()
           .width(120)
           .height(120)
           .fill(AppColors.PrimaryGlow)

--- a/entry/src/main/ets/pages/ControllerTestPage.ets
+++ b/entry/src/main/ets/pages/ControllerTestPage.ets
@@ -104,7 +104,7 @@ struct ControllerTestPage {
         
         // 模式指示器
         Row({ space: 4 }) {
-          Circle()
+          Ellipse()
             .width(8)
             .height(8)
             .fill(this.currentTabIndex === 0 ? '#4CAF50' : this.currentTabIndex === 1 ? '#2196F3' : '#FF9800')

--- a/entry/src/main/ets/service/network/NetworkBoostService.ets
+++ b/entry/src/main/ets/service/network/NetworkBoostService.ets
@@ -223,6 +223,12 @@ export class NetworkBoostService {
     if (!this.supported || !this.active || deviceInfo.sdkApiVersion < 26) {
       return false;
     }
+    if (this.activeDataFlow) {
+      const cleared = this.setDataFlowDescApi26(this.activeDataFlow, true);
+      if (!cleared) {
+        return false;
+      }
+    }
     return this.setDataFlowDescApi26(flow, false);
   }
 

--- a/entry/src/main/ets/service/network/NetworkBoostService.ets
+++ b/entry/src/main/ets/service/network/NetworkBoostService.ets
@@ -19,8 +19,8 @@
  *   Step 4: 引入 netHandover 多网切换（远程串流场景，需 LINKTURBO 受限权限）
  */
 
-import { netQuality } from '@kit.NetworkBoostKit';
-import { BusinessError } from '@kit.BasicServicesKit';
+import { netBoost, netQuality } from '@kit.NetworkBoostKit';
+import { Available, BusinessError, deviceInfo } from '@kit.BasicServicesKit';
 
 const STREAMING_SERVICE_TYPE: netQuality.ServiceType = 'realtimeGame';
 
@@ -73,6 +73,43 @@ export interface SystemNetScene {
 
 export type SystemNetSceneListener = (scene: SystemNetScene) => void;
 
+export type NetworkBoostTransportProtocol = 'udp' | 'tcp';
+export type NetworkBoostFlowPriority = 'normal' | 'high';
+
+export interface NetworkBoostEndpoint {
+  address: string;
+  port: number;
+}
+
+export interface NetworkBoostFlowExpectation {
+  /** 上行带宽，单位 Kbps */
+  uplinkBandwidthKbps?: number;
+  /** 下行带宽，单位 Kbps */
+  downlinkBandwidthKbps?: number;
+  /** 期望时延，单位毫秒 */
+  latencyMs?: number;
+  /** 请求/上传对象大小，单位 KB */
+  objectSizeKb?: number;
+  /** 流优先级 */
+  priority?: NetworkBoostFlowPriority;
+  /** 是否倾向低功耗传输 */
+  lowPowerMode?: boolean;
+}
+
+export interface NetworkBoostFiveTupleFlow {
+  flowType: 'fiveTuple';
+  protocol: NetworkBoostTransportProtocol;
+  local: NetworkBoostEndpoint;
+  remote: NetworkBoostEndpoint;
+  expectations?: NetworkBoostFlowExpectation;
+}
+
+export interface NetworkBoostSocketFlow {
+  flowType: 'socket';
+  socketFd: number;
+  expectations?: NetworkBoostFlowExpectation;
+}
+
 export class NetworkBoostService {
   private static instance: NetworkBoostService | null = null;
 
@@ -87,6 +124,7 @@ export class NetworkBoostService {
   private sceneCallback: ((list: Array<netQuality.NetworkScene>) => void) | null = null;
   private latestScene: SystemNetScene | null = null;
   private sceneListeners: Set<SystemNetSceneListener> = new Set();
+  private activeDataFlow: NetworkBoostFiveTupleFlow | NetworkBoostSocketFlow | null = null;
 
   static getInstance(): NetworkBoostService {
     if (!NetworkBoostService.instance) {
@@ -116,6 +154,7 @@ export class NetworkBoostService {
     this.lastState = null;
     this.unsubscribeQos();
     this.unsubscribeScene();
+    this.clearDataFlowDesc();
     this.latestQos = null;
     this.latestScene = null;
   }
@@ -172,6 +211,19 @@ export class NetworkBoostService {
   /** 设备是否支持 NetworkBoostKit（一次失败后置 false） */
   isSupported(): boolean {
     return this.supported;
+  }
+
+  /**
+   * HarmonyOS 26.0.0: 为关键串流 socket 标记实时游戏流。
+   *
+   * 只有在调用方能提供 native socket fd 或完整五元组时才调用；
+   * 当前 ArkTS 层没有可靠本地端口/fd，因此先作为可选入口保留。
+   */
+  setDataFlowDesc(flow: NetworkBoostFiveTupleFlow | NetworkBoostSocketFlow): boolean {
+    if (!this.supported || !this.active || deviceInfo.sdkApiVersion < 26) {
+      return false;
+    }
+    return this.setDataFlowDescApi26(flow, false);
   }
 
   // ───── reportQoe ─────
@@ -312,6 +364,69 @@ export class NetworkBoostService {
       console.warn(`[NetworkBoost] off(netSceneChange) 失败: ${(err as Error).message}`);
     }
     this.sceneCallback = null;
+  }
+
+  @Available({ minApiVersion: '26' })
+  private setDataFlowDescApi26(flow: NetworkBoostFiveTupleFlow | NetworkBoostSocketFlow, leaving: boolean): boolean {
+    try {
+      const desc: netBoost.DataFlowDesc = {
+        dataFlowInfo: this.toDataFlowInfo(flow),
+        scene: STREAMING_SERVICE_TYPE,
+        sceneEvent: leaving ? netBoost.SceneEvent.SCENE_EVENT_LEAVE : netBoost.SceneEvent.SCENE_EVENT_ENTER,
+        expectations: leaving ? undefined : this.toExpectedDescription(flow.expectations)
+      };
+      netBoost.setDataFlowDesc(desc);
+      this.activeDataFlow = leaving ? null : flow;
+      console.info('[NetworkBoost] setDataFlowDesc scene=realtimeGame event=' +
+        (leaving ? 'leave' : 'enter'));
+      return true;
+    } catch (err) {
+      this.handleErr('setDataFlowDesc', err);
+      return false;
+    }
+  }
+
+  private clearDataFlowDesc(): void {
+    if (!this.activeDataFlow || deviceInfo.sdkApiVersion < 26) {
+      this.activeDataFlow = null;
+      return;
+    }
+    this.setDataFlowDescApi26(this.activeDataFlow, true);
+  }
+
+  @Available({ minApiVersion: '26' })
+  private toDataFlowInfo(flow: NetworkBoostFiveTupleFlow | NetworkBoostSocketFlow): netBoost.DataFlowInfo | netBoost.SocketFd {
+    if (flow.flowType === 'socket') {
+      return flow.socketFd;
+    }
+    const dataFlowInfo: netBoost.DataFlowInfo = {
+      protocol: flow.protocol === 'udp' ? netBoost.ProtocolType.PROTOCOL_UDP : netBoost.ProtocolType.PROTOCOL_TCP,
+      local: {
+        address: flow.local.address,
+        port: flow.local.port
+      },
+      remote: {
+        address: flow.remote.address,
+        port: flow.remote.port
+      }
+    };
+    return dataFlowInfo;
+  }
+
+  @Available({ minApiVersion: '26' })
+  private toExpectedDescription(expectation?: NetworkBoostFlowExpectation): netBoost.ExpectedDescription | undefined {
+    if (!expectation) {
+      return undefined;
+    }
+    const desc: netBoost.ExpectedDescription = {
+      uplinkBandwidth: expectation.uplinkBandwidthKbps,
+      downlinkBandwidth: expectation.downlinkBandwidthKbps,
+      latency: expectation.latencyMs,
+      objectSize: expectation.objectSizeKb,
+      priority: expectation.priority === 'high' ? netBoost.PriorityLevel.PRIO_HIGH : netBoost.PriorityLevel.PRIO_NORMAL,
+      lowPowerMode: expectation.lowPowerMode
+    };
+    return desc;
   }
 
   private handleErr(api: string, err: object): void {


### PR DESCRIPTION
## 改了啥呀

- 让 CI SDK 归一化和 patch 脚本认识 HarmonyOS 26.0.0 / API 26，旧工具链也别迷路啦，杂鱼路径映射退散
- 补 NetworkBoostKit 的 `netBoost` stub，并在 `NetworkBoostService` 里预埋 API 26 `setDataFlowDesc` 可选入口
- 把一批 API 26 下会报警的 `Circle().fill()/stroke()` 装饰圆点改成 `Ellipse()`，减少最新 SDK 下的兼容噪音
- 更新 README 的 DevEco / SDK / JBR 开发环境说明

## 为啥要改

- 我们已经升级到最新 DevEco，先让项目能稳定识别和使用 API 26 SDK，但不直接升 `targetSdkVersion`，避免一次性打开新的 ArkUI/权限/系统行为门控
- `setDataFlowDesc` 对串流场景很香，先把接口和 CI 声明准备好，后面 native 暴露 socket fd 后就能接入

## 验证

- `bash -n ci/normalize-sdk.sh`
- `bash -n ci/patch-sdk.sh`
- `JAVA_HOME=/Applications/DevEco-Studio.app/Contents/jbr/Contents/Home PATH="/Applications/DevEco-Studio.app/Contents/jbr/Contents/Home/bin:$PATH" DEVECO_SDK_HOME=/Applications/DevEco-Studio.app/Contents/sdk NODE_PATH="$PWD/node_modules:$PWD/hvigor/node_modules" node hvigorw.js assembleHap --mode module -p module=entry@default -p product=default --no-daemon`
- 模拟器验证：无明显回归


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新特性**
  * 支持 HarmonyOS 26.0.0 SDK 编译流程（含 CI/目标版本适配与映射）
  * 网络优化工具包新增数据流描述符能力：NetworkBoostService 支持在 >=26 条件下配置并设置数据流（setDataFlowDesc）

* **改进**
  * 多处 UI 状态指示器由圆形切换为椭圆形（运行/在线/摇杆/测试等）

* **开发环境**
  * 更新开发环境依赖门槛与本地打包 HAP 相关说明；完善 HarmonyOS 26.0.0 Beta1 编译验证与目标版本文案
<!-- end of auto-generated comment: release notes by coderabbit.ai -->