### PR TITLE
fix(controller): align device events and hvigor version

### DIFF
--- a/entry/src/main/ets/components/test/GameControllerTestView.ets
+++ b/entry/src/main/ets/components/test/GameControllerTestView.ets
@@ -16,7 +16,7 @@
 import { gameControllerService, GameControllerService, ButtonCode } from '../../service/input/GameControllerService';
 import { GamepadManager } from '../../service/input/GamepadManager';
 import { UsbDriverService } from '../../service/usbdriver';
-import { gcButtonMap, AXIS_MAX, TRIGGER_MAX } from '../../service/input/GamepadTypes';
+import { gcButtonMap, AXIS_MAX, TRIGGER_MAX, MoonlightButton } from '../../service/input/GamepadTypes';
 import { AppColors } from '../../common/Theme';
 
 // @Builder 按引用传参接口
@@ -428,6 +428,13 @@ export struct GameControllerTestView {
       case 1: // 右摇杆
         state.rightStickX = Math.floor(x * AXIS_MAX);
         state.rightStickY = Math.floor(-y * AXIS_MAX);
+        break;
+      case 2: // D-Pad
+        state.buttons &= ~MoonlightButton.DPAD_MASK;
+        if (y < -0.5) state.buttons |= MoonlightButton.UP;
+        if (y > 0.5) state.buttons |= MoonlightButton.DOWN;
+        if (x < -0.5) state.buttons |= MoonlightButton.LEFT;
+        if (x > 0.5) state.buttons |= MoonlightButton.RIGHT;
         break;
       case 3: // 左扳机
         state.leftTrigger = Math.floor(x * TRIGGER_MAX);

--- a/hvigor/hvigor-config.json5
+++ b/hvigor/hvigor-config.json5
@@ -1,8 +1,8 @@
 {
   "modelVersion": "5.0.0",
   "dependencies": {
-    "@ohos/hvigor": "6.24.1",
-    "@ohos/hvigor-ohos-plugin": "6.24.1"
+    "@ohos/hvigor": "6.24.2",
+    "@ohos/hvigor-ohos-plugin": "6.24.2"
   },
   "execution": {
     "daemon": true,

--- a/hvigor/package.json
+++ b/hvigor/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Hvigor dependencies for CI build",
   "dependencies": {
-    "@ohos/hvigor": "6.24.1",
-    "@ohos/hvigor-ohos-plugin": "6.24.1"
+    "@ohos/hvigor": "6.24.2",
+    "@ohos/hvigor-ohos-plugin": "6.24.2"
   }
 }

--- a/nativelib/src/main/cpp/game_controller_native.cpp
+++ b/nativelib/src/main/cpp/game_controller_native.cpp
@@ -455,7 +455,7 @@ static void OnDeviceChanged(const struct GameDevice_DeviceEvent* deviceEvent) {
         free(physicalAddress);
     }
     
-    GameDevice_DeviceType deviceType;
+    GameDevice_DeviceType deviceType = (GameDevice_DeviceType)0;
     OH_GameDevice_DeviceInfo_GetDeviceType(deviceInfo, &deviceType);
     info.deviceType = (int32_t)deviceType;
     
@@ -1021,7 +1021,7 @@ int GameController_StartMonitor(void) {
                     free(physicalAddress);
                 }
 
-                GameDevice_DeviceType deviceType;
+                GameDevice_DeviceType deviceType = (GameDevice_DeviceType)0;
                 OH_GameDevice_DeviceInfo_GetDeviceType(deviceInfo, &deviceType);
                 info.deviceType = (int32_t)deviceType;
                 
@@ -1187,7 +1187,7 @@ int GameController_RefreshDevices(void) {
             free(physicalAddress);
         }
 
-        GameDevice_DeviceType deviceType;
+        GameDevice_DeviceType deviceType = (GameDevice_DeviceType)0;
         OH_GameDevice_DeviceInfo_GetDeviceType(deviceInfo, &deviceType);
         info.deviceType = (int32_t)deviceType;
 

--- a/nativelib/src/main/cpp/game_controller_native.cpp
+++ b/nativelib/src/main/cpp/game_controller_native.cpp
@@ -1005,6 +1005,25 @@ int GameController_StartMonitor(void) {
                     strncpy(info.name, name, sizeof(info.name) - 1);
                     free(name);
                 }
+
+                int product = 0;
+                OH_GameDevice_DeviceInfo_GetProduct(deviceInfo, &product);
+                info.product = product;
+
+                int version = 0;
+                OH_GameDevice_DeviceInfo_GetVersion(deviceInfo, &version);
+                info.version = version;
+
+                char* physicalAddress = nullptr;
+                OH_GameDevice_DeviceInfo_GetPhysicalAddress(deviceInfo, &physicalAddress);
+                if (physicalAddress) {
+                    strncpy(info.physicalAddress, physicalAddress, sizeof(info.physicalAddress) - 1);
+                    free(physicalAddress);
+                }
+
+                GameDevice_DeviceType deviceType;
+                OH_GameDevice_DeviceInfo_GetDeviceType(deviceInfo, &deviceType);
+                info.deviceType = (int32_t)deviceType;
                 
                 info.isConnected = true;
                 


### PR DESCRIPTION
## 改了啥呀

- 补齐控制器初始枚举事件里的 product/version/physicalAddress/deviceType，和刷新、热插拔路径保持一致
- 控制器测试页识别 axisType=2 的 D-pad 轴事件，避免测试页和串流页显示/行为对不上
- 将 Hvigor 依赖从 6.24.1 对齐到 DevEco 当前 6.24.2，别再让旧缓存小菜鸡混进来了

## 为啥要改

- 初始枚举少字段会让同一只蓝牙控制器在测试页和 stream 路径中看起来像不同设备状态
- D-pad 轴类事件之前只在部分路径被处理，测试页观察结果容易偏差
- 本机 DevEco/Hvigor 是 6.24.2，项目锁 6.24.1 会触发 Hvigor 插件/根节点加载不一致

## 验证

- `git diff --check`
- `clang++ --target=aarch64-linux-ohos --sysroot=/Applications/DevEco-Studio.app/Contents/sdk/default/openharmony/native/sysroot -D__OHOS__ -std=c++17 -I nativelib/src/main/cpp -fsyntax-only nativelib/src/main/cpp/game_controller_native.cpp`
- `NODE_PATH="$PWD/node_modules" DEVECO_SDK_HOME="/Applications/DevEco-Studio.app/Contents/sdk" OHOS_BASE_SDK_HOME="/Applications/DevEco-Studio.app/Contents/sdk/default/openharmony" JAVA_HOME="/Applications/DevEco-Studio.app/Contents/jbr/Contents/Home" PATH="/Applications/DevEco-Studio.app/Contents/jbr/Contents/Home/bin:$PATH" bash hvigorw --stacktrace --mode module -p module=entry assembleHap --no-daemon`

> 备注：没有把本机路径写进 `hvigorw`，这些只是本机验证环境变量。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **Bug Fixes**
  * 改进游戏手柄 D-Pad 的按钮位映射：根据手柄方向输入更准确更新上/下/左/右状态。
  * 完善设备连接初始化流程：在设备首次登记时补充并同步产品、版本、物理地址与设备类型等元数据，避免设备信息不完整或异常。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->