### PR TITLE
feat(stream): add three-finger IME gesture

### DIFF
--- a/entry/src/main/ets/components/virtual/VirtualController.ets
+++ b/entry/src/main/ets/components/virtual/VirtualController.ets
@@ -640,6 +640,8 @@ export struct VirtualController {
 export struct VirtualControllerOverlay {
   /** 输入事件回调 */
   onInput: (input: InputEvent) => void = () => {};
+  /** 本地多指系统手势回调（如三指唤出 IME） */
+  onSystemTouchGesture: (event: TouchEvent) => boolean = () => false;
 
   /** 触摸穿透状态（双向 — 外部需读取来控制 XComponent hitTest） */
   @Link touchPassthrough: boolean;
@@ -712,6 +714,11 @@ export struct VirtualControllerOverlay {
     .width('100%')
     .height('100%')
     .hitTestBehavior(this.touchPassthrough ? HitTestMode.Transparent : HitTestMode.Default)
+    .onTouch((event: TouchEvent) => {
+      if (this.onSystemTouchGesture(event)) {
+        event.stopPropagation();
+      }
+    })
     // hitTestReady: 父层重渲染触发 ArkUI 重算命中测试区域（opacity 微变不可见）
     .opacity(this.hitTestReady > 0 ? 1 : 0.99)
   }

--- a/entry/src/main/ets/pages/StreamPage.ets
+++ b/entry/src/main/ets/pages/StreamPage.ets
@@ -200,6 +200,7 @@ struct StreamPage {
 
   /** 三指触摸唤出系统 IME：触发后吞掉本组三指，直到所有手指抬起 */
   private threeFingerImeGestureActive: boolean = false;
+  private threeFingerImeLastActiveCount: number = 0;
   private threeFingerImeResetTimer: number | null = null;
   
   // 鼠标高帧率保持（C++ Monitor 不可用时的 fallback）
@@ -1783,6 +1784,7 @@ struct StreamPage {
     }
 
     const activeFingerCount = this.getActiveFingerCount(event);
+    this.threeFingerImeLastActiveCount = activeFingerCount;
     if (this.threeFingerImeGestureActive) {
       if (activeFingerCount === 0) {
         this.resetThreeFingerImeGesture();
@@ -1808,12 +1810,21 @@ struct StreamPage {
       clearTimeout(this.threeFingerImeResetTimer);
     }
     this.threeFingerImeResetTimer = setTimeout(() => {
-      this.resetThreeFingerImeGesture();
+      this.threeFingerImeResetTimer = null;
+      if (!this.threeFingerImeGestureActive) {
+        return;
+      }
+      if (this.threeFingerImeLastActiveCount === 0) {
+        this.resetThreeFingerImeGesture();
+        return;
+      }
+      this.scheduleThreeFingerImeReset();
     }, 3000);
   }
 
   private resetThreeFingerImeGesture(): void {
     this.threeFingerImeGestureActive = false;
+    this.threeFingerImeLastActiveCount = 0;
     if (this.threeFingerImeResetTimer !== null) {
       clearTimeout(this.threeFingerImeResetTimer);
       this.threeFingerImeResetTimer = null;

--- a/entry/src/main/ets/pages/StreamPage.ets
+++ b/entry/src/main/ets/pages/StreamPage.ets
@@ -197,6 +197,10 @@ struct StreamPage {
   @State videoTranslateX: number = 0;
   /** 视频垂直平移 (vp) */
   @State videoTranslateY: number = 0;
+
+  /** 三指触摸唤出系统 IME：触发后吞掉本组三指，直到所有手指抬起 */
+  private threeFingerImeGestureActive: boolean = false;
+  private threeFingerImeResetTimer: number | null = null;
   
   // 鼠标高帧率保持（C++ Monitor 不可用时的 fallback）
   // 使用 DisplaySync 直接向系统合成器请求高刷新率，
@@ -716,6 +720,10 @@ struct StreamPage {
     if (this.aiProbeTimer !== null) {
       clearTimeout(this.aiProbeTimer);
       this.aiProbeTimer = null;
+    }
+    if (this.threeFingerImeResetTimer !== null) {
+      clearTimeout(this.threeFingerImeResetTimer);
+      this.threeFingerImeResetTimer = null;
     }
     this.aiKeyNvHttp = null;
 
@@ -1764,6 +1772,76 @@ struct StreamPage {
   }
 
   /**
+   * 处理本地系统触摸手势。
+   *
+   * 三指同时触摸用于唤出 HarmonyOS IME，优先于远端触摸输入和双指缩放。
+   * 触发后持续吞掉本组三指，避免远端收到半截多指触摸或鼠标拖拽。
+   */
+  private handleSystemTouchGesture(event: TouchEvent): boolean {
+    if (event.source === SourceType.Mouse) {
+      return false;
+    }
+
+    const activeFingerCount = this.getActiveFingerCount(event);
+    if (this.threeFingerImeGestureActive) {
+      if (activeFingerCount === 0) {
+        this.resetThreeFingerImeGesture();
+      }
+      return true;
+    }
+
+    if (!this.viewModel.isConnected || activeFingerCount < 3) {
+      return false;
+    }
+
+    this.threeFingerImeGestureActive = true;
+    this.scheduleThreeFingerImeReset();
+    this.touchInputHandler.cancelActiveInput();
+    this.panZoomHandler.cancelActiveGesture();
+    this.showVirtualKeyboard = false;
+    this.imeManager.show();
+    return true;
+  }
+
+  private scheduleThreeFingerImeReset(): void {
+    if (this.threeFingerImeResetTimer !== null) {
+      clearTimeout(this.threeFingerImeResetTimer);
+    }
+    this.threeFingerImeResetTimer = setTimeout(() => {
+      this.resetThreeFingerImeGesture();
+    }, 3000);
+  }
+
+  private resetThreeFingerImeGesture(): void {
+    this.threeFingerImeGestureActive = false;
+    if (this.threeFingerImeResetTimer !== null) {
+      clearTimeout(this.threeFingerImeResetTimer);
+      this.threeFingerImeResetTimer = null;
+    }
+  }
+
+  private getActiveFingerCount(event: TouchEvent): number {
+    if (event.type !== TouchType.Up && event.type !== TouchType.Cancel) {
+      return event.touches.length;
+    }
+
+    let count = 0;
+    for (let i = 0; i < event.touches.length; i++) {
+      let isChanged: boolean = false;
+      for (let j = 0; j < event.changedTouches.length; j++) {
+        if (event.touches[i].id === event.changedTouches[j].id) {
+          isChanged = true;
+          break;
+        }
+      }
+      if (!isChanged) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  /**
    * 设置触摸模式
    */
   setTouchMode(mode: string): void {
@@ -1825,6 +1903,7 @@ struct StreamPage {
             // 过滤鼠标源触摸事件：物理鼠标点击会同时触发 .onMouse 和 .onTouch，
             // 鼠标事件已在 .onMouse 中处理，此处跳过避免重复发送为触摸
             if (event.source === SourceType.Mouse) return;
+            if (this.handleSystemTouchGesture(event)) return;
             // 双指缩放模式：触摸事件完全由 PanZoomHandler 消费
             if (this.isTouchOverrideEnabled) {
               this.panZoomHandler.handleTouchEvent(event);
@@ -1921,6 +2000,9 @@ struct StreamPage {
           halfHeightPortrait: this.viewModel.inputSettings?.halfHeightOscPortrait ?? true,
           onInput: (input) => {
             this.viewModel.sendInput(input);
+          },
+          onSystemTouchGesture: (event: TouchEvent): boolean => {
+            return this.handleSystemTouchGesture(event);
           }
         })
       }

--- a/entry/src/main/ets/pages/StreamPage.ets
+++ b/entry/src/main/ets/pages/StreamPage.ets
@@ -55,6 +55,7 @@ import { NetworkBoostService, SystemNetScene, SystemNetSceneListener } from '../
 import { ClipboardSyncObserver, ClipboardSyncService } from '../service/clipboard/ClipboardSyncService';
 import { ClipboardSyncConfig } from '../service/clipboard/ClipboardSyncConfig';
 import { SunshineClipboardBlobTransport } from '../service/clipboard/SunshineClipboardBlobTransport';
+import { ThreeFingerImeGestureHandler, ThreeFingerImeGestureResult } from '../service/input/ThreeFingerImeGestureHandler';
 
 /** MouseEmulationCallback 的具体实现，桥接 MoonBridge 鼠标 API */
 class MoonBridgeMouseCallback implements MouseEmulationCallback {
@@ -198,11 +199,6 @@ struct StreamPage {
   /** 视频垂直平移 (vp) */
   @State videoTranslateY: number = 0;
 
-  /** 三指触摸唤出系统 IME：触发后吞掉本组三指，直到所有手指抬起 */
-  private threeFingerImeGestureActive: boolean = false;
-  private threeFingerImeLastActiveCount: number = 0;
-  private threeFingerImeResetTimer: number | null = null;
-  
   // 鼠标高帧率保持（C++ Monitor 不可用时的 fallback）
   // 使用 DisplaySync 直接向系统合成器请求高刷新率，
   // 解决无触摸时 ArkUI .onMouse 降至 ~30Hz 的问题
@@ -240,6 +236,7 @@ struct StreamPage {
   private gamepadManager: GamepadManager = GamepadManager.getInstance();
   private customKeyManager: CustomKeyManager | null = null;
   private panZoomHandler: PanZoomHandler = new PanZoomHandler();
+  private threeFingerImeGestureHandler: ThreeFingerImeGestureHandler = new ThreeFingerImeGestureHandler();
   private controllerTypes: Map<number, number> = new Map();  // slot → MoonlightControllerType
   private aiKeyService: AiKeyService | null = null;
   private aiKeyNvHttp: NvHttp | null = null;
@@ -722,10 +719,7 @@ struct StreamPage {
       clearTimeout(this.aiProbeTimer);
       this.aiProbeTimer = null;
     }
-    if (this.threeFingerImeResetTimer !== null) {
-      clearTimeout(this.threeFingerImeResetTimer);
-      this.threeFingerImeResetTimer = null;
-    }
+    this.threeFingerImeGestureHandler.dispose();
     this.aiKeyNvHttp = null;
 
     this.stopClipboardSync();
@@ -1779,77 +1773,14 @@ struct StreamPage {
    * 触发后持续吞掉本组三指，避免远端收到半截多指触摸或鼠标拖拽。
    */
   private handleSystemTouchGesture(event: TouchEvent): boolean {
-    if (event.source === SourceType.Mouse) {
-      return false;
+    const result = this.threeFingerImeGestureHandler.handleTouchEvent(event, this.viewModel.isConnected);
+    if (result === ThreeFingerImeGestureResult.TRIGGERED) {
+      this.touchInputHandler.cancelActiveInput();
+      this.panZoomHandler.cancelActiveGesture();
+      this.showVirtualKeyboard = false;
+      this.imeManager.show();
     }
-
-    const activeFingerCount = this.getActiveFingerCount(event);
-    this.threeFingerImeLastActiveCount = activeFingerCount;
-    if (this.threeFingerImeGestureActive) {
-      if (activeFingerCount === 0) {
-        this.resetThreeFingerImeGesture();
-      }
-      return true;
-    }
-
-    if (!this.viewModel.isConnected || activeFingerCount < 3) {
-      return false;
-    }
-
-    this.threeFingerImeGestureActive = true;
-    this.scheduleThreeFingerImeReset();
-    this.touchInputHandler.cancelActiveInput();
-    this.panZoomHandler.cancelActiveGesture();
-    this.showVirtualKeyboard = false;
-    this.imeManager.show();
-    return true;
-  }
-
-  private scheduleThreeFingerImeReset(): void {
-    if (this.threeFingerImeResetTimer !== null) {
-      clearTimeout(this.threeFingerImeResetTimer);
-    }
-    this.threeFingerImeResetTimer = setTimeout(() => {
-      this.threeFingerImeResetTimer = null;
-      if (!this.threeFingerImeGestureActive) {
-        return;
-      }
-      if (this.threeFingerImeLastActiveCount === 0) {
-        this.resetThreeFingerImeGesture();
-        return;
-      }
-      this.scheduleThreeFingerImeReset();
-    }, 3000);
-  }
-
-  private resetThreeFingerImeGesture(): void {
-    this.threeFingerImeGestureActive = false;
-    this.threeFingerImeLastActiveCount = 0;
-    if (this.threeFingerImeResetTimer !== null) {
-      clearTimeout(this.threeFingerImeResetTimer);
-      this.threeFingerImeResetTimer = null;
-    }
-  }
-
-  private getActiveFingerCount(event: TouchEvent): number {
-    if (event.type !== TouchType.Up && event.type !== TouchType.Cancel) {
-      return event.touches.length;
-    }
-
-    let count = 0;
-    for (let i = 0; i < event.touches.length; i++) {
-      let isChanged: boolean = false;
-      for (let j = 0; j < event.changedTouches.length; j++) {
-        if (event.touches[i].id === event.changedTouches[j].id) {
-          isChanged = true;
-          break;
-        }
-      }
-      if (!isChanged) {
-        count++;
-      }
-    }
-    return count;
+    return result !== ThreeFingerImeGestureResult.PASS_THROUGH;
   }
 
   /**

--- a/entry/src/main/ets/service/input/PanZoomHandler.ets
+++ b/entry/src/main/ets/service/input/PanZoomHandler.ets
@@ -92,7 +92,21 @@ export class PanZoomHandler {
     this.translateX = 0;
     this.translateY = 0;
     this.pointers.clear();
+    this.initialPinchDistance = 0;
     this.notifyStateChanged();
+  }
+
+  /**
+   * 取消当前缩放/平移手势，但保留已经应用的视频缩放状态。
+   */
+  cancelActiveGesture(): void {
+    this.pointers.clear();
+    this.initialPinchDistance = 0;
+    this.initialScaleFactor = this.scaleFactor;
+    this.initialTranslateX = this.translateX;
+    this.initialTranslateY = this.translateY;
+    this.lastPanX = 0;
+    this.lastPanY = 0;
   }
 
   /**

--- a/entry/src/main/ets/service/input/ThreeFingerImeGestureHandler.ets
+++ b/entry/src/main/ets/service/input/ThreeFingerImeGestureHandler.ets
@@ -1,0 +1,106 @@
+/*
+ * Moonlight for HarmonyOS
+ * Copyright (C) 2024-2025 Moonlight/AlkaidLab
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+/**
+ * 三指触摸唤出系统 IME 的本地手势状态机。
+ *
+ * 该手势优先于远端触摸输入和双指缩放。触发后持续消费本组触摸，
+ * 直到所有手指抬起，避免远端收到半截多指触摸或鼠标拖拽。
+ */
+
+export enum ThreeFingerImeGestureResult {
+  PASS_THROUGH,
+  CONSUMED,
+  TRIGGERED
+}
+
+export class ThreeFingerImeGestureHandler {
+  private static readonly RESET_WATCHDOG_MS: number = 3000;
+
+  private gestureActive: boolean = false;
+  private lastActiveCount: number = 0;
+  private resetTimer: number | null = null;
+
+  handleTouchEvent(event: TouchEvent, canTrigger: boolean): ThreeFingerImeGestureResult {
+    if (event.source === SourceType.Mouse) {
+      return ThreeFingerImeGestureResult.PASS_THROUGH;
+    }
+
+    const activeFingerCount = this.getActiveFingerCount(event);
+    this.lastActiveCount = activeFingerCount;
+
+    if (this.gestureActive) {
+      if (activeFingerCount === 0) {
+        this.reset();
+      }
+      return ThreeFingerImeGestureResult.CONSUMED;
+    }
+
+    if (!canTrigger || activeFingerCount < 3) {
+      return ThreeFingerImeGestureResult.PASS_THROUGH;
+    }
+
+    this.gestureActive = true;
+    this.scheduleResetWatchdog();
+    return ThreeFingerImeGestureResult.TRIGGERED;
+  }
+
+  dispose(): void {
+    this.reset();
+  }
+
+  private scheduleResetWatchdog(): void {
+    if (this.resetTimer !== null) {
+      clearTimeout(this.resetTimer);
+    }
+
+    this.resetTimer = setTimeout(() => {
+      this.resetTimer = null;
+      if (!this.gestureActive) {
+        return;
+      }
+      if (this.lastActiveCount === 0) {
+        this.reset();
+        return;
+      }
+      this.scheduleResetWatchdog();
+    }, ThreeFingerImeGestureHandler.RESET_WATCHDOG_MS);
+  }
+
+  private reset(): void {
+    this.gestureActive = false;
+    this.lastActiveCount = 0;
+    if (this.resetTimer !== null) {
+      clearTimeout(this.resetTimer);
+      this.resetTimer = null;
+    }
+  }
+
+  private getActiveFingerCount(event: TouchEvent): number {
+    if (event.type !== TouchType.Up && event.type !== TouchType.Cancel) {
+      return event.touches.length;
+    }
+
+    let count = 0;
+    for (let i = 0; i < event.touches.length; i++) {
+      let isChanged: boolean = false;
+      for (let j = 0; j < event.changedTouches.length; j++) {
+        if (event.touches[i].id === event.changedTouches[j].id) {
+          isChanged = true;
+          break;
+        }
+      }
+      if (!isChanged) {
+        count++;
+      }
+    }
+    return count;
+  }
+}

--- a/entry/src/main/ets/service/input/TouchInputHandler.ets
+++ b/entry/src/main/ets/service/input/TouchInputHandler.ets
@@ -297,6 +297,30 @@ export class TouchInputHandler {
   }
 
   /**
+   * 取消当前触摸/鼠标手势。
+   *
+   * 用于本地系统手势（如三指唤出 IME）接管输入前，防止远端保留
+   * 已按下的触摸点、鼠标左键/右键或触控板拖拽状态。
+   */
+  cancelActiveInput(): void {
+    this.trackpad.dispose();
+    this.resetMouseState(true);
+    this.touchStates.clear();
+    this.lastForce.clear();
+    this.lastSize.clear();
+    this.nativeInput.sendTouchEvent(
+      TOUCH_EVENT_CANCEL_ALL,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    );
+  }
+
+  /**
    * 重置 MOUSE 模式状态 + 释放可能卡住的鼠标键
    * @param releaseButtons 是否向主机发送 LEFT/RIGHT RELEASE（防御性释放）
    */

--- a/entry/src/main/ets/service/input/TrackpadGestureHandler.ets
+++ b/entry/src/main/ets/service/input/TrackpadGestureHandler.ets
@@ -140,10 +140,19 @@ export class TrackpadGestureHandler {
   }
 
   dispose(): void {
+    if (this.confirmedDrag || this.isDoubleClickDrag) {
+      this.sink.sendMouseButton(BUTTON_ACTION_RELEASE, BUTTON_LEFT);
+    }
     this.cancelDragTimer();
     this.cancelSingleTapTimer();
     this.cancelDoubleTapHoldTimer();
     this.fingers.clear();
+    this.activeCount = 0;
+    this.maxCountInGesture = 0;
+    this.resetGestureFlags();
+    this.twoFingerTapPending = false;
+    this.twoFingerMoved = false;
+    this.lastTapUpTime = 0;
   }
 
   // ==================== Down ====================


### PR DESCRIPTION
## 改了啥呀
- 在串流画面触摸入口前置三指本地手势，三指同时触摸时唤出 HarmonyOS IME。
- 触发后三指这一组事件会被吞掉到全部抬起，避免远端收到半截多指输入，杂鱼卡键状态退退退。
- 三指接管前会取消远端触摸、鼠标/触控板拖拽和缩放手势，同时保留已经应用的视频缩放状态。
- 虚拟手柄覆盖层也转发本地多指手势，尽量让手柄显示时也能唤出 IME。

## 为啥要改
- 对齐 Android 端三指触摸唤出 IME 的体验。
- 给串流中需要中文/系统输入法的场景一个稳定的客户端入口。

## 验证
- 通过：`git diff --check`
- 通过：`NODE_PATH=/Users/mac/Program/moonlight-harmony/hvigor/node_modules DEVECO_SDK_HOME=/Users/mac/ohos-sdk-cache/6.1-Release-mac/sdk-ci-shape JAVA_HOME=/Users/mac/ohos-sdk-cache/jdk17-temurin/Home PATH=/Users/mac/ohos-sdk-cache/jdk17-temurin/Home/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/opt/homebrew/bin:/Users/mac/.codex/tmp/arg0/codex-arg0IHuenb:/Users/mac/.bun/bin:/Users/mac/.nvm/versions/node/v20.20.1/bin:/Users/mac/.orbstack/bin:/Applications/Codex.app/Contents/Resources:/Users/mac/.orbstack/bin node hvigorw.js assembleHap --mode module -p module=entry@default -p product=default --no-daemon`

注：本地构建前按仓库现有流程执行过 `bash ci/patch-sdk.sh /Users/mac/ohos-sdk-cache/6.1-Release-mac/sdk-ci-shape` 来补公共 SDK stubs。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 支持三指触摸手势快速唤起系统输入法。

* **改进**
  * 优化了触摸事件和手势的响应处理逻辑，提升了输入交互的稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->