### PR TITLE
fix(stream): use measured viewport for pip sizing

### DIFF
--- a/entry/src/main/ets/pages/StreamPage.ets
+++ b/entry/src/main/ets/pages/StreamPage.ets
@@ -1253,6 +1253,7 @@ struct StreamPage {
     if (viewportSize) {
       this.viewModel.displayInfo.screenWidth = viewportSize.width;
       this.viewModel.displayInfo.screenHeight = viewportSize.height;
+      this.panZoomHandler.setParentSize(viewportSize.width, viewportSize.height);
     }
 
     // 计算 XComponent 尺寸（letterbox/pillarbox）

--- a/entry/src/main/ets/pages/StreamPage.ets
+++ b/entry/src/main/ets/pages/StreamPage.ets
@@ -25,7 +25,7 @@ import { GameMenuDialog, GameMenuCallbacks } from '../components/dialogs/GameMen
 import { StreamMenuManager } from '../components/StreamMenuManager';
 import { StreamViewModel, TouchMode } from '../viewmodel/StreamViewModel';
 import { TouchInputHandler, TouchInputMode } from '../service/input/TouchInputHandler';
-import { StreamWindowManager } from '../service/streaming/StreamWindowManager';
+import { StreamWindowManager, DisplaySize } from '../service/streaming/StreamWindowManager';
 import { ShortcutManager, Shortcut } from '../components/ShortcutManager';
 import { pickRandomConnectingTip } from '../components/StreamConnectingTips';
 import { ShortcutEditorDialog, ShortcutEditData } from '../components/dialogs/ShortcutEditorDialog';
@@ -224,6 +224,8 @@ struct StreamPage {
   // 窗口模式下 xComponentWidth/Height='100%'，实际 vp 尺寸需从 onAreaChange 获取
   private xComponentActualWidthVp: number = 0;
   private xComponentActualHeightVp: number = 0;
+  private videoViewportWidthVp: number = 0;
+  private videoViewportHeightVp: number = 0;
 
   // 组件控制器和服务
   private xComponentController: XComponentController = new XComponentController();
@@ -1042,7 +1044,8 @@ struct StreamPage {
   private async recalculateXComponentSize(): Promise<void> {
     if (!this.windowManager) return;
 
-    if (this.windowManager.isFullscreen) {
+    const measuredViewport = this.getMeasuredVideoViewportSize();
+    if (this.windowManager.isFullscreen && !measuredViewport) {
       // 全屏：按屏幕尺寸精确计算 letterbox/pillarbox
       const screenSize = await this.windowManager.updateScreenSize();
       this.viewModel.displayInfo.screenWidth = screenSize.width;
@@ -1054,8 +1057,9 @@ struct StreamPage {
       this.xComponentWidth = size.width;
       this.xComponentHeight = size.height;
     } else {
-      // 窗口/浮窗：按实际窗口内容区等比适配，避免 Surface 被父容器裁剪
-      const viewportSize = await this.windowManager.getCurrentWindowViewportSize();
+      // 窗口/浮窗/画中画：按实际 ArkUI 内容区等比适配，避免 Surface 被父容器裁剪
+      const viewportSize = measuredViewport ? measuredViewport :
+        await this.windowManager.getCurrentWindowViewportSize();
       const size = this.windowManager.calculateXComponentSizeForViewport(
         viewportSize.width,
         viewportSize.height,
@@ -1069,6 +1073,29 @@ struct StreamPage {
     }
     // 更新画面位置和偏移
     this.updateDisplayPosition();
+  }
+
+  private async handleVideoViewportAreaChange(width: number, height: number): Promise<void> {
+    if (!this.windowManager) return;
+    if (width <= 0 || height <= 0) return;
+    if (Math.abs(this.videoViewportWidthVp - width) < 0.5 &&
+      Math.abs(this.videoViewportHeightVp - height) < 0.5) {
+      return;
+    }
+
+    this.videoViewportWidthVp = width;
+    this.videoViewportHeightVp = height;
+    await this.recalculateXComponentSize();
+  }
+
+  private getMeasuredVideoViewportSize(): DisplaySize | null {
+    if (this.videoViewportWidthVp <= 0 || this.videoViewportHeightVp <= 0) {
+      return null;
+    }
+    return {
+      width: this.videoViewportWidthVp,
+      height: this.videoViewportHeightVp
+    };
   }
 
   /**
@@ -1221,13 +1248,21 @@ struct StreamPage {
 
     // 更新屏幕尺寸
     const screenSize = await this.windowManager?.updateScreenSize();
-    if (screenSize) {
-      this.viewModel.displayInfo.screenWidth = screenSize.width;
-      this.viewModel.displayInfo.screenHeight = screenSize.height;
+    const measuredViewport = this.getMeasuredVideoViewportSize();
+    const viewportSize = measuredViewport ? measuredViewport : screenSize;
+    if (viewportSize) {
+      this.viewModel.displayInfo.screenWidth = viewportSize.width;
+      this.viewModel.displayInfo.screenHeight = viewportSize.height;
     }
 
     // 计算 XComponent 尺寸（letterbox/pillarbox）
-    const xComponentSize = this.windowManager?.calculateXComponentSize(this.viewModel.displayInfo.stretchVideo);
+    const xComponentSize = measuredViewport
+      ? this.windowManager?.calculateXComponentSizeForViewport(
+        measuredViewport.width,
+        measuredViewport.height,
+        this.viewModel.displayInfo.stretchVideo
+      )
+      : this.windowManager?.calculateXComponentSize(this.viewModel.displayInfo.stretchVideo);
     if (xComponentSize) {
       this.xComponentWidth = xComponentSize.width;
       this.xComponentHeight = xComponentSize.height;
@@ -1900,6 +1935,11 @@ struct StreamPage {
       .height('100%')
       .alignContent(this.xComponentAlignment)
       .clip(true)
+      .onAreaChange((_oldArea: Area, newArea: Area) => {
+        const w = newArea.width as number;
+        const h = newArea.height as number;
+        void this.handleVideoViewportAreaChange(w, h);
+      })
       .scale({
         x: this.videoScale,
         y: this.videoScale,


### PR DESCRIPTION
## 改了啥呀
- 在串流视频根容器上记录 ArkUI 实际布局尺寸，画中画/浮窗场景优先用这个尺寸重新计算 XComponent。
- 保留原来的全屏和窗口尺寸兜底逻辑，没有把 ArkUI layout 状态塞进 service，职责更清爽一点。
- 画面尺寸变化后同步更新 displayInfo 和 PanZoom 父容器尺寸，避免缩放触控坐标继续被旧尺寸带偏。裁切小问题，别再装大尾巴狼了。

## 为啥要改
用户反馈画中画里“画面居中了但是裁切，没有缩放”。之前修复主要依赖 window/drawableRect，在 PiP 这种系统容器里可能仍然拿到偏大的窗口尺寸。ArkUI 的 `onAreaChange` 才是当前页面真实可绘制区域，用它做 XComponent 等比适配更贴近实际布局。

## 验证
- `git diff --check -- entry/src/main/ets/pages/StreamPage.ets`
- 尝试运行：`NODE_PATH=/Users/mac/Program/moonlight-harmony/node_modules DEVECO_SDK_HOME=/Users/mac/ohos-sdk-cache/6.1-Release-mac/sdk-ci-shape node /Applications/DevEco-Studio.app/Contents/tools/hvigor/hvigor/bin/hvigor.js --no-daemon --mode module -p module=entry assembleHap`
  - 当前本机阻塞在 `:nativelib:default@BuildNativeWithCmake`，缓存 SDK 的 `clang++` 链接阶段走到 macOS `ld64.lld`，不识别 OHOS linker 参数（如 `--build-id=sha1`、`--no-undefined`、`-z`）。

## 需要测试和回归
- 画中画/PiP：横屏串流进入画中画后，画面应完整等比缩小，不再居中裁切。
- 普通浮窗：拖拽/调整窗口大小后，XComponent 应继续按窗口内容区等比适配。
- 全屏串流：首次进入、横竖屏切换、服务端分辨率变化后不应出现额外黑边或拉伸。
- 缩放模式：双指缩放开启后，触控坐标不应相对画面偏移。
- `stretchVideo` 开启时：仍应按设置填满容器，不被本次 measured viewport 逻辑破坏。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 优化与修复

* **Bug Fixes**
  * 改进视频视口尺寸测量与缓存机制，减少抖动与重复计算
  * 在全屏及窗口模式下优先使用已测量的视口尺寸，缺失时自动回退
  * 容器/视口区域变化时，能更准确同步调整视频显示与映射

* **Performance**
  * 对视口变化更新进行阈值去抖，降低频繁重算带来的卡顿
<!-- end of auto-generated comment: release notes by coderabbit.ai -->