### PR TITLE
fix(pc-list): manual scan button refreshes state instead of killing mDNS

### DIFF
--- a/entry/src/main/ets/pages/PcListPageV2.ets
+++ b/entry/src/main/ets/pages/PcListPageV2.ets
@@ -577,7 +577,7 @@ struct PcListPageV2 {
       Row() {
         Button({ type: ButtonType.Normal }) {
           Row() {
-            Image($r('app.media.ic_scan'))
+            Image($r('app.media.ic_refresh'))
               .width(20)
               .height(20)
               .fillColor(AppColors.TextOnPrimary)
@@ -592,6 +592,7 @@ struct PcListPageV2 {
         .padding({ left: AppSpacing.XLarge, right: AppSpacing.XLarge })
         .borderRadius(AppSizes.RadiusLarge)
         .backgroundColor(AppColors.Primary)
+        .enabled(!this.isScanning)
         .onClick(() => this.refreshKnownHosts())
 
         Button({ type: ButtonType.Normal }) {
@@ -709,7 +710,7 @@ struct PcListPageV2 {
             .height(22)
             .color(AppColors.TextSecondary)
         } else {
-          Image($r('app.media.ic_search_network'))
+          Image($r('app.media.ic_refresh'))
             .width(22)
             .height(22)
             .fillColor(AppColors.TextSecondary)
@@ -852,7 +853,7 @@ struct PcListPageV2 {
   private async scanAndImportKeys(): Promise<void> {
     if (!QrShareService.isScanQrCodeSupported()) {
       ToastQueue.show({
-        message: QrShareService.getScanUnsupportedMessage() + '，请使用扫描网络或手动添加',
+        message: QrShareService.getScanUnsupportedMessage() + '，请使用刷新或手动添加',
         duration: 2500
       });
       this.canScanQrCode = false;
@@ -985,6 +986,10 @@ struct PcListPageV2 {
    * （见 MdnsDiscovery.discover 的实现），因此按钮只做状态刷新。
    */
   private async refreshKnownHosts(): Promise<void> {
+    if (this.isScanning) {
+      return;
+    }
+
     this.isScanning = true;
     try {
       await this.computerManager.refreshAllComputers();

--- a/entry/src/main/ets/pages/PcListPageV2.ets
+++ b/entry/src/main/ets/pages/PcListPageV2.ets
@@ -562,7 +562,7 @@ struct PcListPageV2 {
         .fontColor(AppColors.Primary)
         .margin({ bottom: AppSpacing.Small })
 
-      Text('扫描网络发现运行 Foundation Sunshine 的电脑')
+      Text('自动发现局域网内运行 Foundation Sunshine 的电脑')
         .fontSize(AppSizes.FontBody)
         .fontColor(AppColors.TextSecondary)
         .textAlign(TextAlign.Center)
@@ -582,7 +582,7 @@ struct PcListPageV2 {
               .height(20)
               .fillColor(AppColors.TextOnPrimary)
               .margin({ right: 8 })
-            Text('扫描网络')
+            Text('刷新')
               .fontSize(AppSizes.FontBody)
               .fontWeight(FontWeight.Medium)
               .fontColor(AppColors.TextOnPrimary)
@@ -592,7 +592,7 @@ struct PcListPageV2 {
         .padding({ left: AppSpacing.XLarge, right: AppSpacing.XLarge })
         .borderRadius(AppSizes.RadiusLarge)
         .backgroundColor(AppColors.Primary)
-        .onClick(() => this.scanNetwork())
+        .onClick(() => this.refreshKnownHosts())
 
         Button({ type: ButtonType.Normal }) {
           Row() {
@@ -701,7 +701,7 @@ struct PcListPageV2 {
   @Builder
   BottomBar() {
     Row() {
-      // 扫描按钮 - 搜索网络电脑
+      // 刷新按钮 - 重新轮询已知主机状态
       Button({ type: ButtonType.Circle }) {
         if (this.isScanning) {
           LoadingProgress()
@@ -719,7 +719,7 @@ struct PcListPageV2 {
       .height(44)
       .backgroundColor(0x1A000000)  // 与 SaveButton 保持一致的半透明背景
       .enabled(!this.isScanning)
-      .onClick(() => this.scanNetwork())
+      .onClick(() => this.refreshKnownHosts())
 
       // 添加按钮 - 突出显示的中央大按钮
       Button({ type: ButtonType.Circle }) {
@@ -978,15 +978,21 @@ struct PcListPageV2 {
     }
   }
 
-  private async scanNetwork(): Promise<void> {
+  /**
+   * 手动刷新：重新轮询所有已知主机的在线状态（不发起 mDNS 发现）。
+   * 局域网内的新主机由 startBackgroundScan 持续自动发现；
+   * 这里若改调 mdnsDiscovery.discover() 会反过来 stopDiscovery() 把后台扫描杀掉
+   * （见 MdnsDiscovery.discover 的实现），因此按钮只做状态刷新。
+   */
+  private async refreshKnownHosts(): Promise<void> {
     this.isScanning = true;
     try {
-      await this.computerManager.scanNetwork();
+      await this.computerManager.refreshAllComputers();
       this.syncViewModelFromManager();
-      ToastQueue.show({ message: '扫描完成' });
+      ToastQueue.show({ message: '刷新完成' });
     } catch (err) {
-      console.error('扫描失败', err);
-      ToastQueue.show({ message: '扫描失败' });
+      console.error('刷新失败', err);
+      ToastQueue.show({ message: '刷新失败' });
     } finally {
       this.isScanning = false;
     }


### PR DESCRIPTION
## 问题

首页「扫描网络」按钮**不仅没用，还会把后台 mDNS 发现杀掉**。

调用链：按钮 \`scanNetwork()\` → \`ComputerManager.scanNetwork()\` → \`MdnsDiscovery.discover(5000)\`：

\`\`\`ts
async discover(timeout = 5000) {
  await this.startDiscovery();                    // (a)
  await new Promise(r => setTimeout(r, timeout)); // (b) 干等 5s
  this.stopDiscovery();                           // (c)
  return Array.from(this.discoveredComputers.values());
}
\`\`\`

而 \`startDiscovery()\` 开头：

\`\`\`ts
if (this.isDiscovering) {
  console.info('MdnsDiscovery: 已经在发现中');
  return;   // ← 后台扫描已在跑，直接返回
}
\`\`\`

由于 \`aboutToAppear → initializeAsync()\` 已经调了 \`startBackgroundScan()\`，\`isDiscovering\` 恒为 \`true\`，所以：

- **(a) 直接 early-return**，不发起新的 mDNS 查询；
- **(b) 空等 5s；**
- **(c) \`stopDiscovery()\` 把后台扫描整个干掉**（\`disposed=true\`、\`stopSearchingMDNS()\`、\`off\` 所有监听、\`discoveryService=null\`、\`isDiscovering=false\`）。

更糟的是它**恢复不了**：\`onPageShow\` 只重启 \`startPolling()\`，不重启 \`startBackgroundScan()\`（后者只在 \`aboutToAppear\` 调过一次）。所以点过一次按钮后，**当前页面生命周期内 mDNS 自动发现新主机的能力就永久失效**了，toast 却显示「扫描完成」。

## 修复

既然后台 mDNS 已经是持续发现，手动按钮对「发现新主机」本就是冗余的。把按钮改成纯状态刷新：

- \`scanNetwork()\` → 重命名 \`refreshKnownHosts()\`，改调 \`refreshAllComputers()\` 重新轮询已知主机的在线状态；
- 保留 \`isScanning\` loading 态 + toast（底部按钮的 spinner 读这个 flag）；
- 加注释说明为何不再调 \`discover()\`（避免后人重新踩坑）；
- 文案：按钮 \`扫描网络\` → \`刷新\`，空状态说明改为「自动发现局域网内运行 Foundation Sunshine 的电脑」（新主机仍由后台 mDNS 自动发现），toast \`扫描完成/失败\` → \`刷新完成/失败\`。

新主机发现仍由 \`startBackgroundScan()\` 持续负责，行为不变。

## 与安卓对比（背景）

安卓 \`ComputerManagerService\` 同样不做子网扫描，而是「持续 mDNS 发现 + 持续轮询已知主机」，架构与本仓库一致（离线阈值 2/3 等常量也是照抄）。所以这里把按钮降级为刷新，不影响与安卓的架构对齐。

## 遗留（可选后续）

\`ComputerManager.scanNetwork()\`（\`ComputerManager.ets:1091\`）现在是死代码——它就是触发上述 bug 的入口，且已无任何引用（grep 已确认）。建议单独清理（连同判断 \`MdnsDiscovery.discover()\` 是否还需要保留）。

## 测试

- [ ] 点「刷新」按钮：toast 显示「刷新完成」，已知主机状态立即更新，后台 mDNS 发现不受影响（退出再进页面仍能自动发现新主机）。
- [ ] 空状态：首次使用时仍能由后台 mDNS 自动发现新主机，「手动添加」可用。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 将空状态和底部操作栏的主要动作调整为“刷新”，支持手动更新已知主机的在线状态。
  * 刷新过程中会显示加载状态，并防止重复触发。

* **改进**
  * 更新了空列表提示文案，让引导更贴近当前的发现方式。
  * 在不支持扫码时，提示内容改为引导用户使用刷新或手动添加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->