### PR TITLE
feat(report): add AI stream session summaries

### DIFF
--- a/entry/src/main/ets/components/StreamSessionReport.ets
+++ b/entry/src/main/ets/components/StreamSessionReport.ets
@@ -63,6 +63,21 @@ export interface StreamReportMetric {
   progress: number;
 }
 
+export enum StreamReportAiStatus {
+  NONE = 0,
+  LOADING = 1,
+  READY = 2
+}
+
+export class StreamReportConfigSnapshot {
+  width: number = 0;
+  height: number = 0;
+  fps: number = 0;
+  bitrate: number = 0;
+  codec: string = 'Auto';
+  hdr: boolean = false;
+}
+
 export interface StreamReportData {
   appName: string;
   title: string;
@@ -78,6 +93,22 @@ export interface StreamReportData {
   suggestions: string[];
   configLine: string;
   generatedAt: string;
+  aiStatus: StreamReportAiStatus;
+  aiBadgeText: string;
+}
+
+export function createStreamReportConfigSnapshot(config: StreamConfig | null | undefined): StreamReportConfigSnapshot | null {
+  if (!config) {
+    return null;
+  }
+  const snapshot = new StreamReportConfigSnapshot();
+  snapshot.width = config.width;
+  snapshot.height = config.height;
+  snapshot.fps = config.fps;
+  snapshot.bitrate = config.bitrate;
+  snapshot.codec = config.codec;
+  snapshot.hdr = config.hdr;
+  return snapshot;
 }
 
 export function createEmptyStreamReport(): StreamReportData {
@@ -95,8 +126,52 @@ export function createEmptyStreamReport(): StreamReportData {
     metrics: [],
     suggestions: ['保持当前设置，继续快乐串流。'],
     configLine: 'Moonlight V+',
-    generatedAt: ''
+    generatedAt: '',
+    aiStatus: StreamReportAiStatus.NONE,
+    aiBadgeText: ''
   };
+}
+
+export function copyStreamReportWithAiMeta(data: StreamReportData, aiStatus: StreamReportAiStatus,
+  aiBadgeText: string): StreamReportData {
+  const suggestions: string[] = [];
+  for (const item of data.suggestions) {
+    suggestions.push(item);
+  }
+
+  const metrics: StreamReportMetric[] = [];
+  for (const item of data.metrics) {
+    metrics.push({
+      label: item.label,
+      value: item.value,
+      hint: item.hint,
+      color: item.color,
+      progress: item.progress
+    });
+  }
+
+  return {
+    appName: data.appName,
+    title: data.title,
+    subtitle: data.subtitle,
+    grade: data.grade,
+    gradeColor: data.gradeColor,
+    score: data.score,
+    conclusion: data.conclusion,
+    moodIcon: data.moodIcon,
+    durationText: data.durationText,
+    durationTease: data.durationTease,
+    metrics,
+    suggestions,
+    configLine: data.configLine,
+    generatedAt: data.generatedAt,
+    aiStatus,
+    aiBadgeText
+  };
+}
+
+export function markStreamReportAiLoading(data: StreamReportData): StreamReportData {
+  return copyStreamReportWithAiMeta(data, StreamReportAiStatus.LOADING, '米塔复盘中');
 }
 
 function clamp(value: number, min: number, max: number): number {
@@ -237,7 +312,7 @@ function buildGradeMeta(score: number): StreamReportGradeMeta {
 
 function buildStreamReportMetrics(avgFps: number, targetFps: number, fpsRatio: number, networkLatency: number,
   decodeLatency: number, hostLatency: number, packetLoss: number, bitrateBps: number,
-  config: StreamConfig | null | undefined): StreamReportMetric[] {
+  config: StreamReportConfigSnapshot | null | undefined): StreamReportMetric[] {
   const configuredBitrateBps = Math.max(0, config?.bitrate ?? 0) * 1000;
   const bitrateProgressBase = configuredBitrateBps > 0 ? configuredBitrateBps : bitrateBps;
   return [
@@ -288,6 +363,12 @@ function buildStreamReportMetrics(avgFps: number, targetFps: number, fpsRatio: n
 
 export function buildStreamReportData(stats: StreamReportStats, config: StreamConfig | null | undefined,
   appName: string, durationMs: number = 0): StreamReportData {
+  const configSnapshot = createStreamReportConfigSnapshot(config);
+  return buildStreamReportDataFromSnapshot(stats, configSnapshot, appName, durationMs);
+}
+
+export function buildStreamReportDataFromSnapshot(stats: StreamReportStats,
+  config: StreamReportConfigSnapshot | null | undefined, appName: string, durationMs: number = 0): StreamReportData {
   const targetFps = config?.fps ?? 0;
   const avgFps = safeNumber(stats.globalAvgFps, 0) > 0 ? stats.globalAvgFps : safeNumber(stats.renderedFps, 0);
   const decodeLatency = safeNumber(stats.globalAvgDecodeLatency, 0) > 0 ? stats.globalAvgDecodeLatency : safeNumber(stats.latency, 0);
@@ -333,7 +414,9 @@ export function buildStreamReportData(stats: StreamReportStats, config: StreamCo
     metrics,
     suggestions: buildSuggestions(score, networkLatency, decodeLatency, hostLatency, packetLoss, fpsRatio, droppedFrames),
     configLine: `${resolution} · ${codec} · ${hdr}`,
-    generatedAt: getNowText()
+    generatedAt: getNowText(),
+    aiStatus: StreamReportAiStatus.NONE,
+    aiBadgeText: ''
   };
 }
 
@@ -741,11 +824,25 @@ export struct StreamSessionReport {
         }
 
         Column({ space: 8 }) {
-          Text('调教建议')
-            .fontSize(14)
-            .fontWeight(FontWeight.Bold)
-            .fontColor('#FFFFFFFF')
-            .width('100%')
+          Row({ space: 8 }) {
+            Text('调教建议')
+              .fontSize(14)
+              .fontWeight(FontWeight.Bold)
+              .fontColor('#FFFFFFFF')
+            if (this.data.aiBadgeText.length > 0) {
+              Text(this.data.aiBadgeText)
+                .fontSize(10)
+                .fontColor(this.data.aiStatus === StreamReportAiStatus.READY ? '#FF101828' : '#D8FFFFFF')
+                .padding({ left: 8, right: 8, top: 3, bottom: 3 })
+                .borderRadius(10)
+                .backgroundColor(this.data.aiStatus === StreamReportAiStatus.READY ? '#FFA8D8EA' : '#24FFFFFF')
+                .maxLines(1)
+                .textOverflow({ overflow: TextOverflow.Ellipsis })
+            }
+            Blank()
+          }
+          .width('100%')
+          .alignItems(VerticalAlign.Center)
           ForEach(this.data.suggestions, (item: string) => {
             this.SuggestionLine(item)
           }, (item: string) => item)

--- a/entry/src/main/ets/pages/StreamPage.ets
+++ b/entry/src/main/ets/pages/StreamPage.ets
@@ -44,11 +44,12 @@ import { StreamLifecycleManager } from '../service/streaming/StreamLifecycleMana
 import { StreamIMEManager } from '../service/streaming/StreamIMEManager';
 import { VirtualKeyboard } from '../components/virtual/VirtualKeyboard';
 import { CustomKeyOverlay } from '../components/CustomKeyOverlay';
-import { StreamSessionReport, StreamReportData, StreamReportStats, createEmptyStreamReport, buildStreamReportData } from '../components/StreamSessionReport';
+import { StreamSessionReport, StreamReportData, StreamReportStats, StreamReportConfigSnapshot, createEmptyStreamReport, createStreamReportConfigSnapshot, buildStreamReportDataFromSnapshot, markStreamReportAiLoading } from '../components/StreamSessionReport';
 import { CustomKeyManager, CustomKeyManagerHost, SessionLike } from '../service/customkey/CustomKeyManager';
 import { CustomKeyStore } from '../service/customkey/CustomKeyStore';
 import { PanZoomHandler, PanZoomState, PointXY } from '../service/input/PanZoomHandler';
 import { AiKeyService, AiKeyRecommendation } from '../service/AiKeyService';
+import { StreamReportAiService } from '../service/StreamReportAiService';
 import { ComputerManager } from '../service/ComputerManager';
 import { ToastQueue } from '../utils/ToastQueue';
 import { NetworkBoostService, SystemNetScene, SystemNetSceneListener } from '../service/network/NetworkBoostService';
@@ -90,6 +91,13 @@ interface StreamPageParams {
   displayGuid?: string;   // 指定的显示器 GUID
   useVdd?: boolean;       // 是否使用虚拟显示器
   posterPath?: string;    // 应用本地海报路径，连接中遮罩背景
+}
+
+class BuiltStreamReport {
+  data: StreamReportData = createEmptyStreamReport();
+  stats: StreamReportStats = new StreamReportStats();
+  config: StreamReportConfigSnapshot | null = null;
+  durationMs: number = 0;
 }
 
 /** StreamPage 对 CustomKeyManager 的宿主回调实现 */
@@ -242,6 +250,8 @@ struct StreamPage {
   private controllerTypes: Map<number, number> = new Map();  // slot → MoonlightControllerType
   private aiKeyService: AiKeyService | null = null;
   private aiKeyNvHttp: NvHttp | null = null;
+  private streamReportAiService: StreamReportAiService | null = null;
+  private streamReportAiRequestId: number = 0;
   // AI 可用性探测的延时定时器，aboutToDisappear 时需清理
   private aiProbeTimer: number | null = null;
   
@@ -305,6 +315,7 @@ struct StreamPage {
         if (computer) {
           const nvHttp = NvHttp.fromComputer(computer, this.context);
           this.aiKeyService = new AiKeyService(nvHttp, this.context);
+          this.streamReportAiService = new StreamReportAiService(nvHttp);
           this.aiKeyNvHttp = nvHttp;
         }
       } catch (err) {
@@ -726,6 +737,8 @@ struct StreamPage {
     }
     this.threeFingerImeGestureHandler.dispose();
     this.aiKeyNvHttp = null;
+    this.streamReportAiService = null;
+    this.streamReportAiRequestId++;
 
     this.stopClipboardSync();
 
@@ -1481,7 +1494,7 @@ struct StreamPage {
   /**
    * 生成当前串流战报（必须在 viewModel.stopStreaming/quitGame 清空 session 前调用）
    */
-  private buildCurrentStreamReport(): StreamReportData {
+  private buildCurrentStreamReport(): BuiltStreamReport {
     const session = this.viewModel.getSession();
     const stats = session ? session.getSummaryStats() : this.viewModel.performanceStats;
     const durationMs = this.streamStartedAtMs > 0 ? Date.now() - this.streamStartedAtMs : 0;
@@ -1503,7 +1516,44 @@ struct StreamPage {
     snapshot.droppedByL3 = stats.droppedByL3;
     snapshot.droppedByL4 = stats.droppedByL4;
     snapshot.droppedByL5 = stats.droppedByL5;
-    return buildStreamReportData(snapshot, this.viewModel.streamConfig, this.appName || '远程游戏', durationMs);
+    const result = new BuiltStreamReport();
+    result.stats = snapshot;
+    result.config = createStreamReportConfigSnapshot(this.viewModel.streamConfig);
+    result.durationMs = durationMs;
+    result.data = buildStreamReportDataFromSnapshot(snapshot, result.config, this.appName || '远程游戏', durationMs);
+    return result;
+  }
+
+  private enrichStreamReportWithAi(report: BuiltStreamReport): void {
+    const aiService = this.streamReportAiService;
+    const nvHttp = this.aiKeyNvHttp;
+    if (!aiService || !nvHttp) {
+      return;
+    }
+
+    const requestId = ++this.streamReportAiRequestId;
+    nvHttp.checkAiAvailable().then((available: boolean) => {
+      if (requestId !== this.streamReportAiRequestId || !this.showStreamReport || !this.streamReportAiService) {
+        return;
+      }
+      if (!available) {
+        return;
+      }
+      this.streamReportData = markStreamReportAiLoading(report.data);
+      aiService.summarize(report.data, report.stats, report.config, report.durationMs).then((aiReport: StreamReportData) => {
+        if (requestId !== this.streamReportAiRequestId || !this.showStreamReport || !this.streamReportAiService) {
+          return;
+        }
+        this.streamReportData = aiReport;
+      }).catch((err: Error) => {
+        console.warn(`[StreamPage] AI 串流战报总结失败: ${err.message}`);
+        if (requestId === this.streamReportAiRequestId && this.showStreamReport) {
+          this.streamReportData = report.data;
+        }
+      });
+    }).catch((err: Error) => {
+      console.warn(`[StreamPage] AI 串流战报可用性检查失败: ${err.message}`);
+    });
   }
 
   /**
@@ -1664,6 +1714,7 @@ struct StreamPage {
     this.isClosingStreamReport = true;
     try {
       await this.waitForPendingStreamShutdown();
+      this.streamReportAiRequestId++;
       this.showStreamReport = false;
       await this.exitStreamAndReturn();
     } catch (err) {
@@ -1689,8 +1740,9 @@ struct StreamPage {
 
     const report = this.buildCurrentStreamReport();
     this.prepareStreamEndUiImmediate();
-    this.streamReportData = report;
+    this.streamReportData = report.data;
     this.showStreamReport = true;
+    this.enrichStreamReportWithAi(report);
     this.runStreamShutdownInBackground('正在断开串流', async (): Promise<void> => {
       await Promise.all([
         this.lifecycleManager.stopBackgroundTask(),
@@ -1721,8 +1773,9 @@ struct StreamPage {
       return;
     }
 
-    this.streamReportData = report;
+    this.streamReportData = report.data;
     this.showStreamReport = true;
+    this.enrichStreamReportWithAi(report);
     this.runStreamShutdownInBackground('正在退出游戏', async (): Promise<void> => {
       const stopBackgroundTaskPromise = this.lifecycleManager.stopBackgroundTask();
       await this.sendLockScreenShortcutBeforeDisconnect();

--- a/entry/src/main/ets/service/StreamReportAiService.ets
+++ b/entry/src/main/ets/service/StreamReportAiService.ets
@@ -1,0 +1,155 @@
+/*
+ * Moonlight for HarmonyOS
+ * Copyright (C) 2024-2026 Moonlight/AlkaidLab
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import { NvHttp, AiMessage } from './streaming/NvHttp';
+import {
+  StreamReportData,
+  StreamReportStats,
+  StreamReportMetric,
+  StreamReportConfigSnapshot,
+  StreamReportAiStatus,
+  copyStreamReportWithAiMeta
+} from '../components/StreamSessionReport';
+
+interface StreamReportAiResponse {
+  title?: string;
+  subtitle?: string;
+  conclusion?: string;
+  durationTease?: string;
+  suggestions?: string[];
+}
+
+const SYSTEM_PROMPT =
+  '你叫米塔，是 Moonlight V+ 的智能体，负责串流结束复盘。' +
+  '你的性格是腹黑、傲娇、喜欢用“杂鱼”轻轻吐槽用户，但本质是在认真帮用户调好串流。' +
+  '请根据本次串流数据写一张更鲜活的中文战报，像米塔亲自看完数据后给出的复盘。' +
+  '语气要可爱、俏皮、略带坏心眼；可以使用“哼”“才不是”“杂鱼♡”等口癖。' +
+  '不要辱骂、不要低俗、不要恐吓，不要把用户写得真的很差。' +
+  '只输出 JSON，不要 markdown，不要解释。结构：' +
+  '{"title":"8字内标题","subtitle":"16字内副标题","conclusion":"45字内总结","durationTease":"45字内时长吐槽","suggestions":["每条45字内建议，2到3条"]}。' +
+  '建议必须基于数据，不要编造不存在的硬件、网络或游戏信息；人设不能盖过调参价值。';
+
+function clampText(value: string | undefined, fallback: string, maxLength: number): string {
+  if (!value) return fallback;
+  const text = value.trim();
+  if (!text) return fallback;
+  if (text.length <= maxLength) return text;
+  return text.substring(0, maxLength);
+}
+
+function stripThinkTags(text: string): string {
+  return text.replace(/<think>[\s\S]*?<\/think>/gi, '').trim();
+}
+
+function extractJsonObject(text: string): string {
+  let jsonText = stripThinkTags(text);
+  const codeBlockMatch = jsonText.match(/```(?:json)?\s*([\s\S]*?)```/);
+  if (codeBlockMatch) {
+    jsonText = codeBlockMatch[1].trim();
+  }
+  if (!jsonText.startsWith('{')) {
+    const objectMatch = jsonText.match(/(\{[\s\S]*\})/);
+    if (objectMatch) {
+      jsonText = objectMatch[1].trim();
+    }
+  }
+  return jsonText;
+}
+
+function compactMetrics(metrics: StreamReportMetric[]): string {
+  const parts: string[] = [];
+  for (const item of metrics) {
+    parts.push(item.label + '=' + item.value + '(' + item.hint + ')');
+  }
+  return parts.join('; ');
+}
+
+function safeFixed(value: number | null | undefined, digits: number, fallback: string): string {
+  if (value === null || value === undefined || isNaN(value)) {
+    return fallback;
+  }
+  return value.toFixed(digits);
+}
+
+function buildReportPrompt(report: StreamReportData, stats: StreamReportStats,
+  config: StreamReportConfigSnapshot | null | undefined, durationMs: number): string {
+  const targetFps = config ? config.fps : 0;
+  const resolution = config ? (config.width.toString() + 'x' + config.height.toString() + '@' + config.fps.toString()) : 'unknown';
+  const codec = config ? config.codec : 'Auto';
+  const hdr = config && config.hdr ? 'HDR' : 'SDR';
+  return '请优化这张串流战报：\n' +
+    '游戏=' + report.appName + '\n' +
+    '本地评分=' + report.score.toString() + '/' + report.grade + '\n' +
+    '本地结论=' + report.conclusion + '\n' +
+    '本地建议=' + report.suggestions.join(' | ') + '\n' +
+    '时长毫秒=' + durationMs.toString() + '\n' +
+    '配置=' + resolution + ' ' + codec + ' ' + hdr + ' 目标fps=' + targetFps.toString() + '\n' +
+    '指标=' + compactMetrics(report.metrics) + '\n' +
+    '原始stats=' +
+    'avgFps:' + safeFixed(stats.globalAvgFps, 1, '0.0') +
+    ', renderedFps:' + safeFixed(stats.renderedFps, 1, '0.0') +
+    ', bitrateBps:' + safeFixed(stats.bitrate, 0, '0') +
+    ', networkMs:' + safeFixed(stats.networkLatency, 1, '0.0') +
+    ', decodeMs:' + safeFixed(stats.globalAvgDecodeLatency, 1, '0.0') +
+    ', hostMs:' + safeFixed(stats.globalAvgHostLatency, 1, '0.0') +
+    ', packetLoss:' + safeFixed(stats.packetLoss, 2, '0.00') +
+    ', droppedFrames:' + safeFixed(stats.droppedFrames, 0, '0') +
+    ', decodedFrames:' + safeFixed(stats.decodedFrames, 0, '0') + '\n' +
+    '请让话术比模板更自然，保留可执行调参建议。';
+}
+
+function applyAiResponse(report: StreamReportData, parsed: StreamReportAiResponse): StreamReportData {
+  const next = copyStreamReportWithAiMeta(report, StreamReportAiStatus.READY, '米塔已复盘');
+  next.title = clampText(parsed.title, report.title, 10);
+  next.subtitle = clampText(parsed.subtitle, report.subtitle, 18);
+  next.conclusion = clampText(parsed.conclusion, report.conclusion, 54);
+  next.durationTease = clampText(parsed.durationTease, report.durationTease, 54);
+
+  const suggestions: string[] = [];
+  if (parsed.suggestions && Array.isArray(parsed.suggestions)) {
+    for (const item of parsed.suggestions) {
+      if (!item) continue;
+      const text = clampText(item, '', 54);
+      if (text.length > 0) {
+        suggestions.push(text);
+      }
+      if (suggestions.length >= 3) break;
+    }
+  }
+  if (suggestions.length > 0) {
+    next.suggestions = suggestions;
+  }
+  return next;
+}
+
+/**
+ * 串流结束战报 AI 复盘服务。
+ *
+ * 调用 Sunshine 的 OpenAI 兼容 LLM 代理，只返回可直接替换 UI 的短文案。
+ */
+export class StreamReportAiService {
+  private nvHttp: NvHttp;
+
+  constructor(nvHttp: NvHttp) {
+    this.nvHttp = nvHttp;
+  }
+
+  async summarize(report: StreamReportData, stats: StreamReportStats,
+    config: StreamReportConfigSnapshot | null | undefined, durationMs: number): Promise<StreamReportData> {
+    const messages: AiMessage[] = [
+      { role: 'system', content: SYSTEM_PROMPT },
+      { role: 'user', content: buildReportPrompt(report, stats, config, durationMs) }
+    ];
+    const responseText = await this.nvHttp.aiCompletion(messages, 900);
+    const jsonText = extractJsonObject(responseText);
+    const parsed: StreamReportAiResponse = JSON.parse(jsonText);
+    return applyAiResponse(report, parsed);
+  }
+}


### PR DESCRIPTION
## 改了啥呀

- 给串流结束战报加了 AI 状态徽标，能显示“AI 复盘中 / AI 已复盘”。
- 新增 `StreamReportAiService`，复用 Sunshine 的 `/ai/completions` 生成更活一点的标题、总结、时长吐槽和调参建议。
- 结束串流时先展示本地战报；LLM 可用才异步刷新，没接 AI 的杂鱼场景继续稳稳回退本地模板。

## 为啥要改

本地规则战报数据和话术都比较固定，接了 LLM 后可以让复盘更像真的看过这局数据，同时不阻塞断开流程。

## 验证

- `git diff --check`
- `DEVECO_SDK_HOME=/Applications/DevEco-Studio.app/Contents/sdk bash hvigorw assembleHap --no-daemon --stacktrace` 进入构建流程，但被既有 native 依赖挡住：`nativelib/src/main/cpp/aubio/src/fvec.c` 缺失，`nativelib:default@BuildNativeWithCmake` 失败。entry 侧 PreBuild / metadata / syscap / profile 任务已通过。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 串流战报新增 AI 复盘内容，结束后可自动生成更完整的中文总结与建议。
  * 战报页面新增 AI 状态徽标，显示当前是否已完成生成。

* **改进**
  * 战报生成过程更稳定，支持异步更新，减少旧内容覆盖当前结果的情况。
  * 复盘展示中增加了对建议数量与文本长度的控制，内容更简洁易读。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->