### PR TITLE
feat(render): add optional two-step precise sync

### DIFF
--- a/entry/src/main/ets/model/StreamConfig.ets
+++ b/entry/src/main/ets/model/StreamConfig.ets
@@ -91,6 +91,7 @@ export interface StreamConfig {
   enableSyncDecode: boolean;  // 同步解码模式（API 20+，主动轮询 + 仅渲染最新输出帧，低延迟优先）
   enableVrr: boolean;         // VRR 可变刷新率模式（动态调整屏幕刷新率，可能丢帧）
   enableVsync: boolean;       // VSync 渲染模式（按时间戳精确呈现，更平滑但可能增加延迟）
+  enableTwoStepPreciseSync: boolean; // 二步精确同步（host 节奏去抖 + 本地 VSync 对齐）
   enablePostProcess: boolean; // 后处理滤镜（HDR 暗区抖动补偿，适用于 OLED 面板）
   upscaleMode: number;        // 超分辨率模式 (0=OFF, 1=XENGINE, 2=FSR1, 3=AUTO)
   upscaleSharpness: number;   // 超分锐度 (0.0 - 1.0)
@@ -277,6 +278,7 @@ export function getDefaultStreamConfig(): StreamConfig {
     enableSyncDecode: false, // 默认禁用同步解码（需要 API 20+；启用后低延迟优先）
     enableVrr: false,       // 默认禁用 VRR（可能丢帧）
     enableVsync: false,     // 默认关闭（低延迟优先；开启后更平滑但可能增加 1 帧左右延迟）
+    enableTwoStepPreciseSync: false, // 默认关闭，便于与原 VSync 路径做 A/B 对比
     enablePostProcess: false, // 默认禁用后处理滤镜
     upscaleMode: 0,           // 默认不超分
     upscaleSharpness: 0.5,    // 默认锐度 50%

--- a/entry/src/main/ets/pages/SettingsPageV2.ets
+++ b/entry/src/main/ets/pages/SettingsPageV2.ets
@@ -238,6 +238,7 @@ struct SettingsPageV2 {
   @State enableSyncDecode: boolean = false;  // 同步解码模式，默认禁用
   @State enableVrr: boolean = false;  // VRR 可变刷新率，默认禁用
   @State enableVsync: boolean = false;
+  @State enableTwoStepPreciseSync: boolean = false;
   @State enablePostProcess: boolean = false;  // 后处理滤镜（暗区抖动补偿）
   @State upscaleMode: number = 0;             // 超分辨率模式
   @State upscaleSharpness: number = 50;       // 超分锐度 (0-100)
@@ -589,6 +590,7 @@ struct SettingsPageV2 {
       this.enableSyncDecode = await this.loadBoolean(SettingsKeys.ENABLE_SYNC_DECODE, false);  // 默认禁用
       this.enableVrr = await this.loadBoolean(SettingsKeys.ENABLE_VRR, false);  // VRR 默认禁用
       this.enableVsync = await this.loadBoolean(SettingsKeys.ENABLE_VSYNC, false);
+      this.enableTwoStepPreciseSync = await this.loadBoolean(SettingsKeys.ENABLE_TWO_STEP_PRECISE_SYNC, false);
       this.enablePostProcess = await this.loadBoolean(SettingsKeys.ENABLE_POST_PROCESS, false);
       this.upscaleMode = await PreferencesUtil.get<number>(SettingsKeys.UPSCALE_MODE, 0);
       this.upscaleSharpness = await PreferencesUtil.get<number>(SettingsKeys.UPSCALE_SHARPNESS, 50);
@@ -2108,6 +2110,16 @@ struct SettingsPageV2 {
                 action: () => {
                   this.enableVsync = !this.enableVsync;
                   this.saveSetting(SettingsKeys.ENABLE_VSYNC, this.enableVsync);
+                }
+              },
+              {
+                title: '二步精确同步 (实验性)',
+                subtitle: '先跟随主机出帧节奏，再对齐本地屏幕刷新',
+                type: 'toggle',
+                value: this.enableTwoStepPreciseSync,
+                action: () => {
+                  this.enableTwoStepPreciseSync = !this.enableTwoStepPreciseSync;
+                  this.saveSetting(SettingsKeys.ENABLE_TWO_STEP_PRECISE_SYNC, this.enableTwoStepPreciseSync);
                 }
               },
               {

--- a/entry/src/main/ets/service/SettingsService.ets
+++ b/entry/src/main/ets/service/SettingsService.ets
@@ -134,6 +134,7 @@ export class SettingsKeys {
   static readonly ENABLE_SYNC_DECODE: string = 'settings_enable_sync_decode';  // 同步解码模式
   static readonly ENABLE_VRR: string = 'settings_enable_vrr';  // VRR 可变刷新率模式
   static readonly ENABLE_VSYNC: string = 'settings_enable_vsync';
+  static readonly ENABLE_TWO_STEP_PRECISE_SYNC: string = 'settings_enable_two_step_precise_sync';
   static readonly ADAPTIVE_BITRATE: string = 'settings_adaptive_bitrate';  // 智能码率调节
   static readonly ABR_MODE: string = 'settings_abr_mode';  // ABR 模式: balanced | quality | lowLatency
   static readonly ENABLE_POST_PROCESS: string = 'settings_enable_post_process';  // 后处理滤镜
@@ -639,6 +640,7 @@ export class SettingsService {
     const enableSyncDecode = await this.getBoolean(SettingsKeys.ENABLE_SYNC_DECODE, false);  // 默认禁用
     const enableVrr = await this.getBoolean(SettingsKeys.ENABLE_VRR, false);  // VRR 默认禁用
     const enableVsync = await this.getBoolean(SettingsKeys.ENABLE_VSYNC, false);
+    const enableTwoStepPreciseSync = await this.getBoolean(SettingsKeys.ENABLE_TWO_STEP_PRECISE_SYNC, false);
     const enablePostProcess = await this.getBoolean(SettingsKeys.ENABLE_POST_PROCESS, false);
     const upscaleMode = await this.getNumber(SettingsKeys.UPSCALE_MODE, 0);
     const upscaleSharpness = await this.getNumber(SettingsKeys.UPSCALE_SHARPNESS, 50) / 100.0;
@@ -729,6 +731,7 @@ export class SettingsService {
       enableSyncDecode: enableSyncDecode,
       enableVrr: enableVrr,
       enableVsync: enableVsync,
+      enableTwoStepPreciseSync: enableTwoStepPreciseSync,
       enablePostProcess: enablePostProcess,
       sdrToHdrMode: sdrToHdrMode,
       sdrToHdr: sdrToHdr,

--- a/entry/src/main/ets/service/streaming/StreamingSession.ets
+++ b/entry/src/main/ets/service/streaming/StreamingSession.ets
@@ -136,6 +136,7 @@ interface NativeModule {
   isDecoderSyncMode(): boolean;
   setVsyncEnabled(enabled: boolean): void;
   isVsyncEnabled(): boolean;
+  setTwoStepPreciseSyncEnabled(enabled: boolean): void;
   setVrrEnabled(enabled: boolean): void;
   setPostProcessEnabled(enabled: boolean): void;
   setUpscaleMode(mode: number, sharpness: number): void;
@@ -1283,6 +1284,7 @@ export class StreamingSession {
     this.nativeModule.setDecoderBufferCount(this.config.decoderBufferCount);
     this.nativeModule.setDecoderSyncMode(this.config.enableSyncDecode);
     this.nativeModule.setVsyncEnabled(this.config.enableVsync);
+    this.nativeModule.setTwoStepPreciseSyncEnabled(this.config.enableTwoStepPreciseSync ?? false);
     this.nativeModule.setVrrEnabled(this.config.enableVrr);
     this.nativeModule.setPostProcessEnabled(this.config.enablePostProcess ?? false);
     this.nativeModule.setUpscaleMode(this.config.upscaleMode ?? 0, this.config.upscaleSharpness ?? 0.5);
@@ -1293,7 +1295,8 @@ export class StreamingSession {
     }
 
     console.info(`解码器: buffers=${this.config.decoderBufferCount}, sync=${this.config.enableSyncDecode}, ` +
-      `vsync=${this.config.enableVsync}, vrr=${this.config.enableVrr}`);
+      `vsync=${this.config.enableVsync}, twoStep=${this.config.enableTwoStepPreciseSync ?? false}, ` +
+      `vrr=${this.config.enableVrr}`);
 
     const callStart = async (): Promise<number> => {
       this.isStartingConnection = true;

--- a/nativelib/src/main/cpp/callbacks.cpp
+++ b/nativelib/src/main/cpp/callbacks.cpp
@@ -702,7 +702,8 @@ int BridgeDrSubmitDecodeUnit(void* decodeUnitPtr) {
         totalSize,
         decodeUnit->frameNumber, 
         decodeUnit->frameType,
-        decodeUnit->frameHostProcessingLatency
+        decodeUnit->frameHostProcessingLatency,
+        static_cast<int64_t>(decodeUnit->presentationTimeUs)
     );
     
     if (heapAllocated) {

--- a/nativelib/src/main/cpp/moonlight_bridge.cpp
+++ b/nativelib/src/main/cpp/moonlight_bridge.cpp
@@ -2017,12 +2017,6 @@ napi_value MoonBridge_SetTwoStepPreciseSyncEnabled(napi_env env, napi_callback_i
     return result;
 }
 
-napi_value MoonBridge_IsTwoStepPreciseSyncEnabled(napi_env env, napi_callback_info info) {
-    napi_value result;
-    napi_get_boolean(env, NativeRender::GetInstance()->IsTwoStepPreciseSyncEnabled(), &result);
-    return result;
-}
-
 // =============================================================================
 // 音频设置
 // =============================================================================

--- a/nativelib/src/main/cpp/moonlight_bridge.cpp
+++ b/nativelib/src/main/cpp/moonlight_bridge.cpp
@@ -1998,6 +1998,31 @@ napi_value MoonBridge_IsVsyncEnabled(napi_env env, napi_callback_info info) {
     return result;
 }
 
+napi_value MoonBridge_SetTwoStepPreciseSyncEnabled(napi_env env, napi_callback_info info) {
+    size_t argc = 1;
+    napi_value args[1];
+    napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
+
+    bool enabled = false;
+    if (argc >= 1) {
+        napi_get_value_bool(env, args[0], &enabled);
+    }
+
+    NativeRender::GetInstance()->SetTwoStepPreciseSyncEnabled(enabled);
+    OH_LOG_INFO(LOG_APP, "MoonBridge_SetTwoStepPreciseSyncEnabled: %{public}s",
+                enabled ? "true" : "false");
+
+    napi_value result;
+    napi_get_undefined(env, &result);
+    return result;
+}
+
+napi_value MoonBridge_IsTwoStepPreciseSyncEnabled(napi_env env, napi_callback_info info) {
+    napi_value result;
+    napi_get_boolean(env, NativeRender::GetInstance()->IsTwoStepPreciseSyncEnabled(), &result);
+    return result;
+}
+
 // =============================================================================
 // 音频设置
 // =============================================================================

--- a/nativelib/src/main/cpp/moonlight_bridge.h
+++ b/nativelib/src/main/cpp/moonlight_bridge.h
@@ -272,6 +272,18 @@ napi_value MoonBridge_SetVsyncEnabled(napi_env env, napi_callback_info info);
  */
 napi_value MoonBridge_IsVsyncEnabled(napi_env env, napi_callback_info info);
 
+/**
+ * 设置是否启用二步精确同步（内部自行使用 VSync）。
+ * @param enabled boolean
+ */
+napi_value MoonBridge_SetTwoStepPreciseSyncEnabled(napi_env env, napi_callback_info info);
+
+/**
+ * 获取二步精确同步开关。
+ * @return boolean
+ */
+napi_value MoonBridge_IsTwoStepPreciseSyncEnabled(napi_env env, napi_callback_info info);
+
 // =============================================================================
 // 音频设置
 // =============================================================================

--- a/nativelib/src/main/cpp/moonlight_bridge.h
+++ b/nativelib/src/main/cpp/moonlight_bridge.h
@@ -278,12 +278,6 @@ napi_value MoonBridge_IsVsyncEnabled(napi_env env, napi_callback_info info);
  */
 napi_value MoonBridge_SetTwoStepPreciseSyncEnabled(napi_env env, napi_callback_info info);
 
-/**
- * 获取二步精确同步开关。
- * @return boolean
- */
-napi_value MoonBridge_IsTwoStepPreciseSyncEnabled(napi_env env, napi_callback_info info);
-
 // =============================================================================
 // 音频设置
 // =============================================================================

--- a/nativelib/src/main/cpp/napi_init.cpp
+++ b/nativelib/src/main/cpp/napi_init.cpp
@@ -131,7 +131,6 @@ static napi_value Init(napi_env env, napi_value exports) {
         { "setVsyncEnabled", nullptr, MoonBridge_SetVsyncEnabled, nullptr, nullptr, nullptr, napi_default, nullptr },
         { "isVsyncEnabled", nullptr, MoonBridge_IsVsyncEnabled, nullptr, nullptr, nullptr, napi_default, nullptr },
         { "setTwoStepPreciseSyncEnabled", nullptr, MoonBridge_SetTwoStepPreciseSyncEnabled, nullptr, nullptr, nullptr, napi_default, nullptr },
-        { "isTwoStepPreciseSyncEnabled", nullptr, MoonBridge_IsTwoStepPreciseSyncEnabled, nullptr, nullptr, nullptr, napi_default, nullptr },
         { "setVrrEnabled", nullptr, MoonBridge_SetVrrEnabled, nullptr, nullptr, nullptr, napi_default, nullptr },
         { "setPostProcessEnabled", nullptr, MoonBridge_SetPostProcessEnabled, nullptr, nullptr, nullptr, napi_default, nullptr },
         { "setUpscaleMode", nullptr, MoonBridge_SetUpscaleMode, nullptr, nullptr, nullptr, napi_default, nullptr },

--- a/nativelib/src/main/cpp/napi_init.cpp
+++ b/nativelib/src/main/cpp/napi_init.cpp
@@ -130,6 +130,8 @@ static napi_value Init(napi_env env, napi_value exports) {
         { "isDecoderSyncMode", nullptr, MoonBridge_IsDecoderSyncMode, nullptr, nullptr, nullptr, napi_default, nullptr },
         { "setVsyncEnabled", nullptr, MoonBridge_SetVsyncEnabled, nullptr, nullptr, nullptr, napi_default, nullptr },
         { "isVsyncEnabled", nullptr, MoonBridge_IsVsyncEnabled, nullptr, nullptr, nullptr, napi_default, nullptr },
+        { "setTwoStepPreciseSyncEnabled", nullptr, MoonBridge_SetTwoStepPreciseSyncEnabled, nullptr, nullptr, nullptr, napi_default, nullptr },
+        { "isTwoStepPreciseSyncEnabled", nullptr, MoonBridge_IsTwoStepPreciseSyncEnabled, nullptr, nullptr, nullptr, napi_default, nullptr },
         { "setVrrEnabled", nullptr, MoonBridge_SetVrrEnabled, nullptr, nullptr, nullptr, napi_default, nullptr },
         { "setPostProcessEnabled", nullptr, MoonBridge_SetPostProcessEnabled, nullptr, nullptr, nullptr, napi_default, nullptr },
         { "setUpscaleMode", nullptr, MoonBridge_SetUpscaleMode, nullptr, nullptr, nullptr, napi_default, nullptr },

--- a/nativelib/src/main/cpp/native_render.cpp
+++ b/nativelib/src/main/cpp/native_render.cpp
@@ -36,6 +36,23 @@ typedef OH_AVErrCode (*PFN_RenderOutputBufferAtTime)(OH_AVCodec*, uint32_t, int6
 static PFN_RenderOutputBufferAtTime g_pfnRenderAtTime = nullptr;
 static bool g_renderAtTimeChecked = false;
 
+// VSync 回调只写入进程级原子状态，避免 Surface 销毁时回调持有悬空对象。
+static std::atomic<int64_t> g_lastVsyncTimestampNs{0};
+static std::atomic<int64_t> g_vsyncPeriodNs{0};
+
+static void OnNativeVsync(long long timestamp, void* data) {
+    (void)data;
+    if (timestamp > 0) {
+        g_lastVsyncTimestampNs.store(static_cast<int64_t>(timestamp), std::memory_order_release);
+    }
+}
+
+static int64_t GetMonotonicTimeNs() {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return static_cast<int64_t>(ts.tv_sec) * 1000000000LL + ts.tv_nsec;
+}
+
 static PFN_RenderOutputBufferAtTime GetRenderAtTimeFunc() {
     if (!g_renderAtTimeChecked) {
         g_renderAtTimeChecked = true;
@@ -136,25 +153,58 @@ NativeRender::~NativeRender() {
 // =============================================================================
 
 void NativeRender::InitNativeVSync() {
-    if (nativeVSync_ != nullptr) {
-        return;  // 已初始化
+    bool created = false;
+    {
+        std::lock_guard<std::mutex> lock(nativeVsyncMutex_);
+        if (nativeVSync_ != nullptr) {
+            return;
+        }
+
+        const char* name = "moonlight_render";
+        nativeVSync_ = OH_NativeVSync_Create(name, strlen(name));
+        if (nativeVSync_ != nullptr) {
+            long long periodNs = 0;
+            if (OH_NativeVSync_GetPeriod(nativeVSync_, &periodNs) != 0 || periodNs <= 0) {
+                const int fps = configuredFps_ > 0 ? configuredFps_ : 60;
+                periodNs = 1000000000LL / fps;
+                OH_LOG_WARN(LOG_APP,
+                    "NativeVSync period unavailable; using %{public}d FPS fallback", fps);
+            }
+            g_vsyncPeriodNs.store(static_cast<int64_t>(periodNs), std::memory_order_release);
+            created = true;
+            OH_LOG_INFO(LOG_APP, "NativeVSync created successfully, period=%{public}lldns", periodNs);
+        } else {
+            OH_LOG_WARN(LOG_APP, "Failed to create NativeVSync");
+        }
     }
-    
-    // 创建 NativeVSync 实例
-    const char* name = "moonlight_render";
-    nativeVSync_ = OH_NativeVSync_Create(name, strlen(name));
-    if (nativeVSync_ != nullptr) {
-        OH_LOG_INFO(LOG_APP, "NativeVSync created successfully");
-    } else {
-        OH_LOG_WARN(LOG_APP, "Failed to create NativeVSync");
+
+    if (created && twoStepPreciseSyncEnabled_.load()) {
+        RequestVsyncSample();
     }
 }
 
 void NativeRender::ReleaseNativeVSync() {
-    if (nativeVSync_ != nullptr) {
-        OH_NativeVSync_Destroy(nativeVSync_);
-        nativeVSync_ = nullptr;
-        OH_LOG_INFO(LOG_APP, "NativeVSync destroyed");
+    std::lock_guard<std::mutex> lock(nativeVsyncMutex_);
+    if (nativeVSync_ == nullptr) {
+        return;
+    }
+
+    OH_NativeVSync_Destroy(nativeVSync_);
+    nativeVSync_ = nullptr;
+    g_lastVsyncTimestampNs.store(0, std::memory_order_release);
+    g_vsyncPeriodNs.store(0, std::memory_order_release);
+    OH_LOG_INFO(LOG_APP, "NativeVSync destroyed");
+}
+
+void NativeRender::RequestVsyncSample() {
+    std::lock_guard<std::mutex> lock(nativeVsyncMutex_);
+    if (nativeVSync_ == nullptr) {
+        return;
+    }
+
+    int32_t ret = OH_NativeVSync_RequestFrame(nativeVSync_, OnNativeVsync, nullptr);
+    if (ret != 0) {
+        OH_LOG_DEBUG(LOG_APP, "NativeVSync sample request failed: %{public}d", ret);
     }
 }
 
@@ -163,6 +213,7 @@ void NativeRender::ReleaseNativeVSync() {
 // =============================================================================
 
 void NativeRender::SetNativeWindow(OHNativeWindow* window, uint64_t width, uint64_t height) {
+    ResetPresentationClock();
     window_ = window;
     surfaceWidth_ = width;
     surfaceHeight_ = height;
@@ -176,7 +227,7 @@ void NativeRender::SetNativeWindow(OHNativeWindow* window, uint64_t width, uint6
         
         // 如果帧率已配置，立即应用帧率范围
         // 这处理 SetConfiguredFps 在 SetNativeWindow 之前调用的情况
-        if (configuredFps_ > 0 && nativeVSync_ != nullptr) {
+        if (configuredFps_ > 0) {
             ApplyFrameRateRange();
         }
         
@@ -193,9 +244,8 @@ void NativeRender::SetNativeWindow(OHNativeWindow* window, uint64_t width, uint6
 void NativeRender::SetConfiguredFps(int fps) {
     configuredFps_ = fps;
     OH_LOG_INFO(LOG_APP, "Configured FPS set to: %{public}d", fps);
-    
-    // 重置时间基准
-    timeBaseInitialized_ = false;
+
+    ResetPresentationClock();
     
     // 应用帧率范围（NativeVSync 层）
     ApplyFrameRateRange();
@@ -207,9 +257,22 @@ void NativeRender::SetConfiguredFps(int fps) {
 void NativeRender::SetVsyncEnabled(bool enable) {
     bool wasEnabled = vsyncEnabled_.exchange(enable);
     if (wasEnabled != enable) {
-        // 重置时间基准
-        timeBaseInitialized_ = false;
+        ResetPresentationClock();
+        if (enable && twoStepPreciseSyncEnabled_.load()) {
+            RequestVsyncSample();
+        }
         OH_LOG_INFO(LOG_APP, "VSync mode %{public}s", enable ? "enabled" : "disabled");
+    }
+}
+
+void NativeRender::SetTwoStepPreciseSyncEnabled(bool enable) {
+    bool wasEnabled = twoStepPreciseSyncEnabled_.exchange(enable);
+    if (wasEnabled != enable) {
+        ResetPresentationClock();
+        if (enable) {
+            RequestVsyncSample();
+        }
+        OH_LOG_INFO(LOG_APP, "Two-step precise sync %{public}s", enable ? "enabled" : "disabled");
     }
 }
 
@@ -293,7 +356,12 @@ void NativeRender::ApplyFrameRateRange() {
     // NativeVSync SetExpectedFrameRateRange (API 20+)
     // 设置 VSync 回调的期望帧率，影响 VSync 信号频率
     // 注意：XComponent 帧率提示由 MoonBridge_SetXComponentFrameRate 通过 ArkUI_NodeHandle 独立设置
-    if (nativeVSync_ != nullptr && CheckAndLoadApi20()) {
+    std::lock_guard<std::mutex> lock(nativeVsyncMutex_);
+    if (nativeVSync_ == nullptr) {
+        return;
+    }
+
+    if (CheckAndLoadApi20()) {
         OH_NativeVSync_ExpectedRateRange range;
         range.min = configuredFps_;
         range.max = configuredFps_;
@@ -308,48 +376,53 @@ void NativeRender::ApplyFrameRateRange() {
                         configuredFps_, ret);
         }
     }
+
+    long long periodNs = 0;
+    if (OH_NativeVSync_GetPeriod(nativeVSync_, &periodNs) != 0 || periodNs <= 0) {
+        const int fps = configuredFps_ > 0 ? configuredFps_ : 60;
+        periodNs = 1000000000LL / fps;
+    }
+    g_vsyncPeriodNs.store(static_cast<int64_t>(periodNs), std::memory_order_release);
 }
 
 // =============================================================================
-// 帧呈现时间计算（VSync 模式）
+// 两步呈现时钟
 // =============================================================================
 
-int64_t NativeRender::CalculatePresentTime(int64_t pts) const {
-    // 获取当前系统时间（纳秒，单调钟）
-    struct timespec ts;
-    clock_gettime(CLOCK_MONOTONIC, &ts);
-    int64_t nowNs = static_cast<int64_t>(ts.tv_sec) * 1000000000LL + ts.tv_nsec;
+void NativeRender::ResetPresentationClockLocked() {
+    pendingPresentTargets_.clear();
+    timeBaseInitialized_ = false;
+    estimatedOffsetNs_ = 0;
+    skewNs_ = 0;
+    jitterEstNs_ = 0.0;
+    lastPtsUs_ = 0;
+}
 
-    const int64_t hostNs = pts * 1000LL;         // host 时钟(纳秒)，原点=首个被捕获帧
-    const int64_t instOffset = nowNs - hostNs;   // 本帧的"本地 - host"瞬时偏移(含网络+解码延迟)
+void NativeRender::ResetPresentationClock() {
+    std::lock_guard<std::mutex> lock(presentationMutex_);
+    ResetPresentationClockLocked();
+}
+
+int64_t NativeRender::CalculatePresentTargetLocked(int64_t pts, int64_t nowNs, bool twoStep) {
+    const int64_t hostNs = pts * 1000LL;
+    const int64_t instOffset = nowNs - hostNs;
     const int64_t frameIntervalNs = configuredFps_ > 0 ? 1000000000LL / configuredFps_ : 16666667LL;
-
-    // 检测 PTS 不连续（重连 / seek / 编码器重启）：PTS 回退，或跳变 > 2s。
     const bool discontinuity = timeBaseInitialized_ &&
         (pts < lastPtsUs_ || (pts - lastPtsUs_) > 2000000LL);
 
     if (!timeBaseInitialized_ || discontinuity) {
-        // (重新)锚定：用本帧偏移作为初值，清零 skew 与抖动估计。
-        estimatedOffsetNs_ = instOffset;
-        skewNs_ = 0;
-        jitterEstNs_ = static_cast<double>(frameIntervalNs) / 16.0;  // 抖动估计初值(约半毫秒量级)
-        timeBaseInitialized_ = true;
         if (discontinuity) {
+            pendingPresentTargets_.clear();
             vsyncResyncCount_++;
         }
+        estimatedOffsetNs_ = instOffset;
+        skewNs_ = 0;
+        jitterEstNs_ = static_cast<double>(frameIntervalNs) / 16.0;
+        timeBaseInitialized_ = true;
         OH_LOG_INFO(LOG_APP, "VSync clock (re)anchored: offset=%{public}lldus, pts=%{public}lldus%{public}s",
                     static_cast<long long>(estimatedOffsetNs_ / 1000),
-                    static_cast<long long>(pts),
-                    discontinuity ? " [discontinuity]" : "");
+                    static_cast<long long>(pts), discontinuity ? " [discontinuity]" : "");
     } else {
-        // alpha-beta / PI 时钟恢复(离线仿真验证)：
-        //   pred = offset + skew          先按上一帧的频差估计外推一帧
-        //   e    = instOffset - pred      本帧残差(网络抖动 + 频差误差)
-        //   offset += ec/64 (Kp=1/64)     小比例项：跟踪偏移均值、保持网格近似刚性(不追逐逐帧抖动)
-        //   skew   += ec/2048(Ki=1/2048)  积分项：跟踪时钟频差，消除斜坡滞后
-        // ec 为限幅残差(±8ms)，抑制网络尖峰污染 offset/skew(尖峰由 cushion 与"迟到即立即呈现"兜底)。
-        // 注：用整除(向零取整)而非算术右移——右移对负 ec 向负无穷取整，会给 offset/skew(尤其积分项)
-        //     引入每帧亚纳秒级直流偏置并随时间累积；整除无此偏置，且与上述 Kp/Ki 语义一致。
         const int64_t pred = estimatedOffsetNs_ + skewNs_;
         const int64_t e = instOffset - pred;
         int64_t ec = e;
@@ -357,75 +430,157 @@ int64_t NativeRender::CalculatePresentTime(int64_t pts) const {
         else if (ec < -8000000LL) ec = -8000000LL;
         estimatedOffsetNs_ = pred + (ec / 64);
         skewNs_ += (ec / 2048);
-        // 在线抖动估计(平均绝对偏差, EMA alpha=1/32)，用于自适应 cushion。
         const double ae = static_cast<double>(e < 0 ? -e : e);
         jitterEstNs_ += (ae - jitterEstNs_) / 32.0;
     }
     lastPtsUs_ = pts;
 
-    // 自适应 cushion：随网络抖动伸缩(净 LAN 极小→低延迟；抖动大→更深缓冲)。
-    // 3×平均绝对偏差(高斯下≈2.4σ)，夹在 [1ms, 1 帧] 之间。延迟成本可调、可观测(见统计日志)。
-    int64_t cushionNs = static_cast<int64_t>(3.0 * jitterEstNs_);
-    if (cushionNs < 1000000LL) cushionNs = 1000000LL;
-    else if (cushionNs > frameIntervalNs) cushionNs = frameIntervalNs;
+    // 二步模式的 VSync 向上取整自带约半帧余量；基线模式保留原 3×MAD + 1ms cushion。
+    int64_t cushionNs = static_cast<int64_t>((twoStep ? 0.5 : 3.0) * jitterEstNs_);
+    if (!twoStep && cushionNs < 1000000LL) cushionNs = 1000000LL;
+    if (cushionNs > frameIntervalNs) cushionNs = frameIntervalNs;
 
-    const int64_t targetPresentTimeNs = hostNs + estimatedOffsetNs_ + cushionNs;
-
-    // 迟到帧(网络抖动尖峰导致 target 已过去)：不改动网格，直接返回原网格时刻。
-    // 解码器对"过去的时间戳"即立即呈现；网格保持刚性连续，避免"弹出再弹回"的双重卡顿。
-    if (targetPresentTimeNs < nowNs) {
+    const int64_t targetNs = hostNs + estimatedOffsetNs_ + cushionNs;
+    if (targetNs < nowNs) {
         vsyncLateFrameCount_++;
     }
 
-    // 周期性统计，便于评估收益/风险（迟到率高→cushion 偏小或抖动大；重锚频繁→上游 PTS 不稳）。
     if (++vsyncFrameCount_ % 6000 == 0) {
         OH_LOG_INFO(LOG_APP,
-            "VSync clock stats: frames=%{public}lld, late=%{public}lld, resync=%{public}lld, offset=%{public}lldus, skew=%{public}lldns/f, cushion=%{public}lldus",
-            static_cast<long long>(vsyncFrameCount_),
-            static_cast<long long>(vsyncLateFrameCount_),
-            static_cast<long long>(vsyncResyncCount_),
-            static_cast<long long>(estimatedOffsetNs_ / 1000),
-            static_cast<long long>(skewNs_),
+            "VSync clock stats: mode=%{public}s, frames=%{public}lld, late=%{public}lld, resync=%{public}lld, hit=%{public}lld, fallback=%{public}lld, pending=%{public}zu, cushion=%{public}lldus",
+            twoStep ? "two-step" : "baseline",
+            static_cast<long long>(vsyncFrameCount_), static_cast<long long>(vsyncLateFrameCount_),
+            static_cast<long long>(vsyncResyncCount_), static_cast<long long>(twoStepHitCount_),
+            static_cast<long long>(twoStepFallbackCount_), pendingPresentTargets_.size(),
             static_cast<long long>(cushionNs / 1000));
     }
+    return targetNs;
+}
 
-    return targetPresentTimeNs;
+void NativeRender::PrepareFrame(int64_t pts) {
+    if (!twoStepPreciseSyncEnabled_.load()) {
+        return;
+    }
+
+    RequestVsyncSample();
+    const int64_t nowNs = GetMonotonicTimeNs();
+    std::lock_guard<std::mutex> lock(presentationMutex_);
+    pendingPresentTargets_[pts] = CalculatePresentTargetLocked(pts, nowNs, true);
+    while (pendingPresentTargets_.size() > kMaxPendingPresentTargets) {
+        pendingPresentTargets_.erase(pendingPresentTargets_.begin());
+    }
+}
+
+void NativeRender::DiscardFrame(int64_t pts) {
+    std::lock_guard<std::mutex> lock(presentationMutex_);
+    pendingPresentTargets_.erase(pts);
+}
+
+int64_t NativeRender::SnapTargetToVsync(int64_t targetNs, int64_t nowNs) const {
+    const int64_t phaseNs = g_lastVsyncTimestampNs.load(std::memory_order_acquire);
+    const int64_t periodNs = g_vsyncPeriodNs.load(std::memory_order_acquire);
+    if (phaseNs <= 0 || periodNs <= 0) {
+        return targetNs;
+    }
+
+    const int64_t phaseAgeNs = nowNs - phaseNs;
+    if (phaseAgeNs < -periodNs || phaseAgeNs > periodNs * 4) {
+        return targetNs;
+    }
+
+    const int64_t rawNs = targetNs < nowNs ? nowNs : targetNs;
+    if (rawNs <= phaseNs) {
+        return phaseNs;
+    }
+    const int64_t deltaNs = rawNs - phaseNs;
+    return phaseNs + ((deltaNs + periodNs - 1) / periodNs) * periodNs;
 }
 
 // =============================================================================
 // 帧渲染
 // =============================================================================
 
-void NativeRender::SubmitFrame(OH_AVCodec* codec, uint32_t bufferIndex, int64_t pts, int64_t enqueueTimeMs) {
-    int32_t renderResult;
-    
-    if (vsyncEnabled_.load()) {
-        // VSync 模式：使用 RenderOutputBufferAtTime 精确控制呈现时间
+OH_AVErrCode NativeRender::SubmitFrame(OH_AVCodec* codec, uint32_t bufferIndex, int64_t pts, int64_t enqueueTimeMs) {
+    (void)enqueueTimeMs;
+
+    auto renderImmediately = [codec, bufferIndex]() {
+        return OH_VideoDecoder_RenderOutputBuffer(codec, bufferIndex);
+    };
+    auto noteFallback = [this]() {
+        std::lock_guard<std::mutex> lock(presentationMutex_);
+        twoStepFallbackCount_++;
+    };
+
+    OH_AVErrCode renderResult = AV_ERR_OK;
+    if (!vsyncEnabled_.load() && !twoStepPreciseSyncEnabled_.load()) {
+        renderResult = renderImmediately();
+    } else {
         PFN_RenderOutputBufferAtTime renderAtTime = GetRenderAtTimeFunc();
-        if (renderAtTime != nullptr) {
-            int64_t presentTimeNs = CalculatePresentTime(pts);
+        if (renderAtTime == nullptr) {
+            if (twoStepPreciseSyncEnabled_.load()) {
+                DiscardFrame(pts);
+                noteFallback();
+            }
+            renderResult = renderImmediately();
+        } else if (!twoStepPreciseSyncEnabled_.load()) {
+            // A/B 基线：保留原有的解码输出时采样 + 较大 cushion，不做 VSync 相位 snap。
+            const int64_t nowNs = GetMonotonicTimeNs();
+            int64_t presentTimeNs;
+            {
+                std::lock_guard<std::mutex> lock(presentationMutex_);
+                presentTimeNs = CalculatePresentTargetLocked(pts, nowNs, false);
+            }
             renderResult = renderAtTime(codec, bufferIndex, presentTimeNs);
-            
-            if (renderResult != 0) {
-                OH_LOG_WARN(LOG_APP, "RenderOutputBufferAtTime failed: %{public}d, pts=%{public}lld, presentNs=%{public}lld",
-                            renderResult, static_cast<long long>(pts), static_cast<long long>(presentTimeNs));
+            if (renderResult != AV_ERR_OK) {
+                renderResult = renderImmediately();
             }
         } else {
-            // RenderOutputBufferAtTime 不可用，回退到直接渲染
-            renderResult = OH_VideoDecoder_RenderOutputBuffer(codec, bufferIndex);
-            if (renderResult != 0) {
-                OH_LOG_WARN(LOG_APP, "RenderOutputBuffer (vsync fallback) failed: %{public}d", renderResult);
+            int64_t targetNs = 0;
+            bool foundTarget = false;
+            {
+                std::lock_guard<std::mutex> lock(presentationMutex_);
+                auto it = pendingPresentTargets_.find(pts);
+                if (it != pendingPresentTargets_.end()) {
+                    targetNs = it->second;
+                    pendingPresentTargets_.erase(it);
+                    foundTarget = true;
+                }
+            }
+
+            if (!foundTarget) {
+                noteFallback();
+                renderResult = renderImmediately();
+            } else {
+                const int64_t nowNs = GetMonotonicTimeNs();
+                const int64_t presentTimeNs = SnapTargetToVsync(targetNs, nowNs);
+                const int64_t frameIntervalNs = configuredFps_ > 0 ?
+                    1000000000LL / configuredFps_ : 16666667LL;
+                const int64_t timeUntilPresentNs = presentTimeNs - nowNs;
+
+                if (timeUntilPresentNs < 0 || timeUntilPresentNs > frameIntervalNs * 3) {
+                    noteFallback();
+                    ResetPresentationClock();
+                    renderResult = renderImmediately();
+                } else {
+                    renderResult = renderAtTime(codec, bufferIndex, presentTimeNs);
+                    if (renderResult == AV_ERR_OK) {
+                        std::lock_guard<std::mutex> lock(presentationMutex_);
+                        twoStepHitCount_++;
+                    } else {
+                        OH_LOG_WARN(LOG_APP,
+                            "RenderOutputBufferAtTime failed: %{public}d, pts=%{public}lld, presentNs=%{public}lld; falling back",
+                            renderResult, static_cast<long long>(pts), static_cast<long long>(presentTimeNs));
+                        noteFallback();
+                        renderResult = renderImmediately();
+                    }
+                }
             }
         }
-    } else {
-        // 低延迟模式：直接渲染
-        renderResult = OH_VideoDecoder_RenderOutputBuffer(codec, bufferIndex);
-        
-        if (renderResult != 0) {
-            OH_LOG_WARN(LOG_APP, "RenderOutputBuffer failed: %{public}d", renderResult);
-        }
     }
-    
-    // 更新上一帧时间
+
+    if (renderResult != AV_ERR_OK) {
+        OH_LOG_WARN(LOG_APP, "RenderOutputBuffer failed: %{public}d", renderResult);
+    }
     lastFrameTime_ = std::chrono::steady_clock::now();
+    return renderResult;
 }

--- a/nativelib/src/main/cpp/native_render.cpp
+++ b/nativelib/src/main/cpp/native_render.cpp
@@ -202,6 +202,15 @@ void NativeRender::RequestVsyncSample() {
         return;
     }
 
+    // GetPeriod only becomes valid after the first VSync callback. Query it on
+    // the following frame while the instance is protected from destruction.
+    if (g_lastVsyncTimestampNs.load(std::memory_order_acquire) > 0) {
+        long long periodNs = 0;
+        if (OH_NativeVSync_GetPeriod(nativeVSync_, &periodNs) == 0 && periodNs > 0) {
+            g_vsyncPeriodNs.store(static_cast<int64_t>(periodNs), std::memory_order_release);
+        }
+    }
+
     int32_t ret = OH_NativeVSync_RequestFrame(nativeVSync_, OnNativeVsync, nullptr);
     if (ret != 0) {
         OH_LOG_DEBUG(LOG_APP, "NativeVSync sample request failed: %{public}d", ret);

--- a/nativelib/src/main/cpp/native_render.cpp
+++ b/nativelib/src/main/cpp/native_render.cpp
@@ -509,9 +509,7 @@ int64_t NativeRender::SnapTargetToVsync(int64_t targetNs, int64_t nowNs) const {
 // 帧渲染
 // =============================================================================
 
-OH_AVErrCode NativeRender::SubmitFrame(OH_AVCodec* codec, uint32_t bufferIndex, int64_t pts, int64_t enqueueTimeMs) {
-    (void)enqueueTimeMs;
-
+OH_AVErrCode NativeRender::SubmitFrame(OH_AVCodec* codec, uint32_t bufferIndex, int64_t pts) {
     auto renderImmediately = [codec, bufferIndex]() {
         return OH_VideoDecoder_RenderOutputBuffer(codec, bufferIndex);
     };

--- a/nativelib/src/main/cpp/native_render.h
+++ b/nativelib/src/main/cpp/native_render.h
@@ -34,6 +34,7 @@
 #include <mutex>
 #include <atomic>
 #include <chrono>
+#include <map>
 
 /**
  * NativeRender 类
@@ -82,15 +83,33 @@ public:
      * 获取 VSync 是否启用
      */
     bool IsVsyncEnabled() const { return vsyncEnabled_; }
+
+    /**
+     * 启用/禁用二步精确同步；开启时内部自行使用 VSync，不依赖 VSync 设置开关。
+     */
+    void SetTwoStepPreciseSyncEnabled(bool enable);
+    bool IsTwoStepPreciseSyncEnabled() const { return twoStepPreciseSyncEnabled_; }
     
     /**
-     * 提交渲染帧
-     * @param codec 解码器实例
-     * @param bufferIndex 缓冲区索引
-     * @param pts 呈现时间戳（微秒）
-     * @param enqueueTimeMs 入队时间（毫秒）
+     * step1：帧到达解码管线时，用 host PTS 生成去抖的本地呈现目标。
      */
-    void SubmitFrame(OH_AVCodec* codec, uint32_t bufferIndex, int64_t pts, int64_t enqueueTimeMs);
+    void PrepareFrame(int64_t pts);
+
+    /**
+     * 丢弃尚未呈现的帧目标。
+     */
+    void DiscardFrame(int64_t pts);
+
+    /**
+     * 清空帧目标并强制下一帧重新锚定（Flush/重连/Surface 切换）。
+     */
+    void ResetPresentationClock();
+
+    /**
+     * step2：解码输出时将 step1 目标对齐到最近 VSync 并呈现。
+     * 无效目标、不支持定时呈现或 API 失败时立即回退直接呈现。
+     */
+    OH_AVErrCode SubmitFrame(OH_AVCodec* codec, uint32_t bufferIndex, int64_t pts, int64_t enqueueTimeMs);
     
     // Surface 尺寸
     uint64_t GetSurfaceWidth() const { return surfaceWidth_; }
@@ -99,9 +118,6 @@ public:
     // 检查 Surface 是否就绪
     bool IsSurfaceReady() const { return surfaceReady_; }
     
-    // 计算 VSync 呈现时间（供 VideoDecoder 同步模式使用）
-    int64_t CalculatePresentTime(int64_t pts) const;
-
 private:
     NativeRender();
     ~NativeRender();
@@ -125,6 +141,16 @@ private:
     // 释放 NativeVSync
     void ReleaseNativeVSync();
 
+    // 请求一次 VSync 样本，供 step2 做相位对齐
+    void RequestVsyncSample();
+
+    // 已持有 presentationMutex_ 时使用
+    int64_t CalculatePresentTargetLocked(int64_t pts, int64_t nowNs, bool twoStep);
+    void ResetPresentationClockLocked();
+
+    // 将目标向上对齐到最近的真实 VSync；无有效相位时返回原目标
+    int64_t SnapTargetToVsync(int64_t targetNs, int64_t nowNs) const;
+
 private:
     // 单例
     static NativeRender* instance_;
@@ -141,35 +167,33 @@ private:
     
     // VSync 模式
     std::atomic<bool> vsyncEnabled_{false};
+    std::atomic<bool> twoStepPreciseSyncEnabled_{false};
     
     // 帧率范围已经应用过（NativeVSync）
     bool frameRateApplied_ = false;
     
-    // 时间同步（用于 VSync 模式）——去抖时钟（alpha-beta / PI 时钟恢复）
-    // 用平滑的 offset(+skew) 估计 + 自适应 cushion 替代朴素首帧锚点：
-    //   target = pts*1000 + estimatedOffsetNs_ + cushion
-    // 经离线仿真(steady/WiFi/jittery/120fps)验证，相较旧朴素锚点：
-    //   硬重置 resync 由每 20s 一次降为 0；可见卡顿(>半帧)由每场景数次降为 0；
-    //   最大间隔跳变 31ms→<4ms；代价是自适应缓冲延迟(净 LAN≈1.2ms，WiFi≈8ms，远端≈16ms)。
-    // 设计要点：
-    //   - estimatedOffsetNs_ 以小比例项(Kp=1/64)跟踪"本地单调钟 - host PTS"偏移的均值，
-    //     保持网格近似刚性、不追逐逐帧抖动(抖动交由 cushion 吸收)；
-    //   - skewNs_ 为每帧频差积分项(Ki=1/2048)，消除主机/客户端时钟频差造成的斜坡滞后；
-    //   - jitterEstNs_ 在线估计抖动幅度(平均绝对偏差)，cushion 随之自适应；
-    //   - 迟到帧(target<now)直接按原网格时刻送解码器(过去时间戳=立即呈现)，绝不把网格拽到
-    //     到达时刻——避免"弹出网格再弹回"的双重卡顿(旧硬重置的根因)。
-    mutable int64_t estimatedOffsetNs_ = 0;  // 平滑后的 (本地 - host) 偏移均值(纳秒)
-    mutable int64_t skewNs_ = 0;             // 每帧频差估计(纳秒/帧)，消除时钟 skew 斜坡滞后
-    mutable double  jitterEstNs_ = 0.0;      // 在线抖动估计(平均绝对偏差, 纳秒)，驱动自适应 cushion
-    mutable int64_t lastPtsUs_ = 0;          // 上一帧 host PTS(微秒)，用于检测不连续(重连/跳变)
-    mutable bool timeBaseInitialized_ = false;
+    // 两步呈现状态：step1 host-PI 去抖，step2 对齐本地 VSync
+    mutable std::mutex presentationMutex_;
+    std::map<int64_t, int64_t> pendingPresentTargets_;
+    static constexpr size_t kMaxPendingPresentTargets = 64;
+
+    // Host PTS 去抖时钟。旧 VSync 模式在解码输出时计算目标；二步模式在输入时预计算，
+    // 再于输出时向上对齐真实 VSync。两者共享 offset/skew 与在线抖动估计。
+    int64_t estimatedOffsetNs_ = 0;  // 平滑后的 (本地 - host) 偏移均值(纳秒)
+    int64_t skewNs_ = 0;             // 每帧频差估计(纳秒/帧)，消除时钟 skew 斜坡滞后
+    double  jitterEstNs_ = 0.0;      // 在线抖动估计(平均绝对偏差, 纳秒)，驱动自适应 cushion
+    int64_t lastPtsUs_ = 0;          // 上一帧 host PTS(微秒)，用于检测不连续(重连/跳变)
+    bool timeBaseInitialized_ = false;
 
     // VSync 去抖时钟的运行统计(用于评估收益/风险)
-    mutable int64_t vsyncFrameCount_ = 0;      // 已呈现帧数
-    mutable int64_t vsyncLateFrameCount_ = 0;  // 目标时刻已过去、被迫前推的帧数(判断延迟/cushion 是否偏小)
-    mutable int64_t vsyncResyncCount_ = 0;     // 因 PTS 不连续而重锚定的次数(判断硬跳变是否仍在发生)
+    int64_t vsyncFrameCount_ = 0;      // step1 生成目标的帧数
+    int64_t vsyncLateFrameCount_ = 0;  // step1 目标在生成时已过期的帧数
+    int64_t vsyncResyncCount_ = 0;     // 因 PTS 不连续而重锚定的次数
+    int64_t twoStepHitCount_ = 0;      // step2 命中预计算目标的帧数
+    int64_t twoStepFallbackCount_ = 0; // 缺失/无效目标或定时 API 失败的回退次数
     
     // NativeVSync（用于设置期望帧率范围，API 20+）
+    std::mutex nativeVsyncMutex_;
     OH_NativeVSync* nativeVSync_ = nullptr;
     
     // 上一帧渲染时间（用于帧率控制）

--- a/nativelib/src/main/cpp/native_render.h
+++ b/nativelib/src/main/cpp/native_render.h
@@ -109,7 +109,7 @@ public:
      * step2：解码输出时将 step1 目标对齐到最近 VSync 并呈现。
      * 无效目标、不支持定时呈现或 API 失败时立即回退直接呈现。
      */
-    OH_AVErrCode SubmitFrame(OH_AVCodec* codec, uint32_t bufferIndex, int64_t pts, int64_t enqueueTimeMs);
+    OH_AVErrCode SubmitFrame(OH_AVCodec* codec, uint32_t bufferIndex, int64_t pts);
     
     // Surface 尺寸
     uint64_t GetSurfaceWidth() const { return surfaceWidth_; }

--- a/nativelib/src/main/cpp/video_decoder.cpp
+++ b/nativelib/src/main/cpp/video_decoder.cpp
@@ -162,13 +162,11 @@ static void SetupDecodeThreadPriority() {
 // =============================================================================
 typedef OH_AVErrCode (*PFN_OH_VideoDecoder_QueryInputBuffer)(OH_AVCodec*, uint32_t*, int64_t);
 typedef OH_AVErrCode (*PFN_OH_VideoDecoder_QueryOutputBuffer)(OH_AVCodec*, uint32_t*, int64_t);
-typedef OH_AVErrCode (*PFN_OH_VideoDecoder_RenderOutputBufferAtTime)(OH_AVCodec*, uint32_t, int64_t);
 typedef OH_AVBuffer* (*PFN_OH_VideoDecoder_GetInputBuffer)(OH_AVCodec*, uint32_t);
 typedef OH_AVBuffer* (*PFN_OH_VideoDecoder_GetOutputBuffer)(OH_AVCodec*, uint32_t);
 
 static PFN_OH_VideoDecoder_QueryInputBuffer  pfn_QueryInputBuffer = nullptr;
 static PFN_OH_VideoDecoder_QueryOutputBuffer pfn_QueryOutputBuffer = nullptr;
-static PFN_OH_VideoDecoder_RenderOutputBufferAtTime pfn_RenderOutputBufferAtTime = nullptr;
 static PFN_OH_VideoDecoder_GetInputBuffer pfn_GetInputBuffer = nullptr;
 static PFN_OH_VideoDecoder_GetOutputBuffer pfn_GetOutputBuffer = nullptr;
 static bool g_syncApiLoaded = false;
@@ -268,8 +266,6 @@ static bool TryLoadSyncModeApis() {
         dlsym(RTLD_DEFAULT, "OH_VideoDecoder_QueryInputBuffer");
     pfn_QueryOutputBuffer = (PFN_OH_VideoDecoder_QueryOutputBuffer)
         dlsym(RTLD_DEFAULT, "OH_VideoDecoder_QueryOutputBuffer");
-    pfn_RenderOutputBufferAtTime = (PFN_OH_VideoDecoder_RenderOutputBufferAtTime)
-        dlsym(RTLD_DEFAULT, "OH_VideoDecoder_RenderOutputBufferAtTime");
     pfn_GetInputBuffer = (PFN_OH_VideoDecoder_GetInputBuffer)
         dlsym(RTLD_DEFAULT, "OH_VideoDecoder_GetInputBuffer");
     pfn_GetOutputBuffer = (PFN_OH_VideoDecoder_GetOutputBuffer)
@@ -287,9 +283,6 @@ static bool TryLoadSyncModeApis() {
             if (pfn_QueryOutputBuffer == nullptr)
                 pfn_QueryOutputBuffer = (PFN_OH_VideoDecoder_QueryOutputBuffer)
                     dlsym(vdecHandle, "OH_VideoDecoder_QueryOutputBuffer");
-            if (pfn_RenderOutputBufferAtTime == nullptr)
-                pfn_RenderOutputBufferAtTime = (PFN_OH_VideoDecoder_RenderOutputBufferAtTime)
-                    dlsym(vdecHandle, "OH_VideoDecoder_RenderOutputBufferAtTime");
             if (pfn_GetInputBuffer == nullptr)
                 pfn_GetInputBuffer = (PFN_OH_VideoDecoder_GetInputBuffer)
                     dlsym(vdecHandle, "OH_VideoDecoder_GetInputBuffer");
@@ -306,11 +299,9 @@ static bool TryLoadSyncModeApis() {
                           && pfn_GetInputBuffer != nullptr);
     
     OH_LOG_INFO(LOG_APP, "Sync mode API availability: QueryInputBuffer=%{public}s, "
-                "QueryOutputBuffer=%{public}s, RenderOutputBufferAtTime=%{public}s, "
-                "GetInputBuffer=%{public}s, GetOutputBuffer=%{public}s",
+                "QueryOutputBuffer=%{public}s, GetInputBuffer=%{public}s, GetOutputBuffer=%{public}s",
                 pfn_QueryInputBuffer ? "YES" : "NO",
                 pfn_QueryOutputBuffer ? "YES" : "NO",
-                pfn_RenderOutputBufferAtTime ? "YES" : "NO",
                 pfn_GetInputBuffer ? "YES" : "NO",
                 pfn_GetOutputBuffer ? "YES" : "NO");
     

--- a/nativelib/src/main/cpp/video_decoder.cpp
+++ b/nativelib/src/main/cpp/video_decoder.cpp
@@ -898,6 +898,7 @@ int VideoDecoder::Start() {
         return -1;
     }
     
+    NativeRender::GetInstance()->ResetPresentationClock();
     int32_t ret = OH_VideoDecoder_Start(decoder_);
     if (ret != AV_ERR_OK) {
         OH_LOG_ERROR(LOG_APP, "Failed to start decoder: %{public}d", ret);
@@ -920,6 +921,7 @@ int VideoDecoder::Start() {
 
 int VideoDecoder::Stop() {
     running_ = false;
+    NativeRender::GetInstance()->ResetPresentationClock();
     
     // 同步模式：停止解码线程
     // 必须先 join 线程（等待 shared_lock 释放），再获取 unique_lock
@@ -964,6 +966,8 @@ int VideoDecoder::Flush() {
     if (decoder_ == nullptr) {
         return -1;
     }
+
+    NativeRender::GetInstance()->ResetPresentationClock();
     
     // 参考官方文档：使用 unique_lock 保护 Flush 操作，防止解码线程并发访问
     std::unique_lock<std::shared_mutex> codecLock(codecMutex_);
@@ -1052,6 +1056,32 @@ static OH_AVCodecBufferAttr MakeInputBufferAttr(int32_t size, int64_t pts, Video
     return attr;
 }
 
+class PresentationTargetGuard {
+public:
+    PresentationTargetGuard(int64_t pts, bool prepare)
+        : render_(NativeRender::GetInstance()), pts_(pts) {
+        if (prepare) {
+            render_->PrepareFrame(pts_);
+        }
+    }
+
+    ~PresentationTargetGuard() {
+        if (!committed_) {
+            render_->DiscardFrame(pts_);
+        }
+    }
+
+    void Commit() { committed_ = true; }
+
+    PresentationTargetGuard(const PresentationTargetGuard&) = delete;
+    PresentationTargetGuard& operator=(const PresentationTargetGuard&) = delete;
+
+private:
+    NativeRender* render_;
+    int64_t pts_;
+    bool committed_ = false;
+};
+
 void VideoDecoder::RecordEnqueueTimestamp(int64_t timestamp) {
     auto enqueueTimeMs = std::chrono::duration_cast<std::chrono::milliseconds>(
         std::chrono::steady_clock::now().time_since_epoch()).count();
@@ -1110,6 +1140,7 @@ int VideoDecoder::SubmitDecodeUnitScatter(const BufferSegment* segments, int seg
                         OH_LOG_WARN(LOG_APP, "L4 burst flush: cleared %{public}d queued frames", cleared);
                     }
                 }
+                NativeRender::GetInstance()->ResetPresentationClock();
                 latencyRecoveryActive_.store(true);
                 UpdateReceivedStats(totalSize, frameNumber, hostProcessingLatency);
                 {
@@ -1132,6 +1163,9 @@ int VideoDecoder::SubmitDecodeUnitScatter(const BufferSegment* segments, int seg
     if (recoveryResult < 0) {
         return recoveryResult;  // -1 = DR_NEED_IDR
     }
+
+    // step1 在网络帧进入解码管线的时刻完成；未能提交的帧由 guard 自动清理。
+    PresentationTargetGuard presentationTarget(timestamp, true);
     
     // 同步模式：直接提交到解码器（scatter-gather 直写 AVBuffer）
     if (config_.decoderMode == DecoderMode::SYNC) {
@@ -1173,6 +1207,7 @@ int VideoDecoder::SubmitDecodeUnitScatter(const BufferSegment* segments, int seg
                         if (ret == AV_ERR_OK) {
                             // 唤醒解码线程立即轮询输出，避免 wait_for(halfFrame) 空等
                             pendingFrameCond_.notify_one();
+                            presentationTarget.Commit();
                             return 0;  // 直接提交成功
                         }
                     }
@@ -1189,6 +1224,7 @@ int VideoDecoder::SubmitDecodeUnitScatter(const BufferSegment* segments, int seg
             std::lock_guard<std::mutex> lock(pendingFrameMutex_);
             while (pendingFrameQueue_.size() >= maxPendingFrames_) {
                 hadOverflow = true;
+                NativeRender::GetInstance()->DiscardFrame(pendingFrameQueue_.front().timestamp);
                 pendingFrameQueue_.pop();
                 std::lock_guard<std::mutex> statsLock(statsMutex_);
                 stats_.droppedFrames++;
@@ -1213,7 +1249,8 @@ int VideoDecoder::SubmitDecodeUnitScatter(const BufferSegment* segments, int seg
                 OH_LOG_WARN(LOG_APP, "Scatter sync: queue overflow, requesting IDR recovery");
             }
         }
-        
+
+        presentationTarget.Commit();
         return 0;
     }
     
@@ -1280,6 +1317,8 @@ int VideoDecoder::SubmitDecodeUnitScatter(const BufferSegment* segments, int seg
         OH_LOG_ERROR(LOG_APP, "Failed to push input buffer: %{public}d", ret);
         return -1;
     }
+
+    presentationTarget.Commit();
     
     UpdateReceivedStats(totalSize, frameNumber, hostProcessingLatency);
     
@@ -1452,6 +1491,7 @@ void VideoDecoder::OnOutputBufferAvailable(OH_AVCodec* codec, uint32_t index,
         // 跳过条件：解码时间 > 3倍帧间隔 且 非关键帧 且 已过启动阶段
         if (instantDecodeTimeMs > expectedFrameTimeMs * kAsyncSkipThresholdMultiplier &&
             !isKeyframe && self->stats_.decodedFrames > kLatencyRecoveryMinFrames) {
+            NativeRender::GetInstance()->DiscardFrame(pts);
             OH_VideoDecoder_FreeOutputBuffer(codec, index);
             {
                 std::lock_guard<std::mutex> lock(self->statsMutex_);
@@ -1483,6 +1523,7 @@ void VideoDecoder::OnOutputBufferAvailable(OH_AVCodec* codec, uint32_t index,
             if (outputInterval < static_cast<int64_t>(expectedFrameTimeMs * intervalRatio) &&
                 instantDecodeTimeMs > static_cast<int64_t>(expectedFrameTimeMs * latencyRatio) &&
                 meetsAbsoluteFloor) {
+                NativeRender::GetInstance()->DiscardFrame(pts);
                 OH_VideoDecoder_FreeOutputBuffer(codec, index);
                 {
                     std::lock_guard<std::mutex> lock(self->statsMutex_);
@@ -1521,8 +1562,9 @@ void VideoDecoder::OnOutputBufferAvailable(OH_AVCodec* codec, uint32_t index,
     if (g_useAsyncRender) {
         NativeRender* render = NativeRender::GetInstance();
         if (render != nullptr && render->IsSurfaceReady()) {
-            // 异步渲染：将帧提交到渲染队列
-            render->SubmitFrame(codec, index, pts, enqueueTimeMs);
+            if (render->SubmitFrame(codec, index, pts, enqueueTimeMs) != AV_ERR_OK) {
+                OH_VideoDecoder_FreeOutputBuffer(codec, index);
+            }
             // 后处理：如果启用，从代理 surface 读取并处理到显示 surface
             GLPostProcessor* postProc = GLPostProcessor::GetInstance();
             if (postProc->IsActive()) {
@@ -1532,16 +1574,10 @@ void VideoDecoder::OnOutputBufferAvailable(OH_AVCodec* codec, uint32_t index,
         }
     }
     
-    // 同步渲染（fallback）
-    // 检查是否启用 VSync 模式
+    // 非 NativeRender surface 路径也使用同一呈现控制器，保持两步语义一致。
     NativeRender* render = NativeRender::GetInstance();
-    if (render != nullptr && render->IsVsyncEnabled() && pfn_RenderOutputBufferAtTime != nullptr) {
-        // VSync 模式：使用 RenderOutputBufferAtTime 计算呈现时间
-        int64_t presentTimeNs = render->CalculatePresentTime(pts);
-        pfn_RenderOutputBufferAtTime(codec, index, presentTimeNs);
-    } else {
-        // 低延迟模式：直接渲染
-        OH_VideoDecoder_RenderOutputBuffer(codec, index);
+    if (render->SubmitFrame(codec, index, pts, enqueueTimeMs) != AV_ERR_OK) {
+        OH_VideoDecoder_FreeOutputBuffer(codec, index);
     }
     
     // 后处理：非异步路径也需要处理
@@ -1828,6 +1864,7 @@ void VideoDecoder::SyncDecodeLoop() {
             if (firstFrameRendered && timeSinceLastOutput >= kFreezeDetectionMs) {
                 OH_LOG_WARN(LOG_APP, "Sync decode: no output for %{public}lldms, flushing decoder + requesting IDR",
                             static_cast<long long>(timeSinceLastOutput));
+                NativeRender::GetInstance()->ResetPresentationClock();
                 
                 // Flush 清空解码器内部缓冲 + 请求 IDR 关键帧
                 // 使用 unique_lock 独占解码器操作
@@ -1948,6 +1985,7 @@ int VideoDecoder::SyncProcessInput(int64_t timeoutUs) {
         frame = std::move(pendingFrameQueue_.front());
         pendingFrameQueue_.pop();
     }
+    PresentationTargetGuard presentationTarget(frame.timestamp, false);
     
     // 成功获得输入 buffer，继续处理帧
     static bool firstInputLog = true;
@@ -1992,7 +2030,8 @@ int VideoDecoder::SyncProcessInput(int64_t timeoutUs) {
         OH_LOG_ERROR(LOG_APP, "Sync PushInputBuffer failed: %{public}d", ret);
         return -1;  // API 错误
     }
-    
+
+    presentationTarget.Commit();
     return 1;  // 成功处理了一帧
 }
 
@@ -2044,6 +2083,7 @@ int VideoDecoder::SyncProcessOutput(int64_t timeoutUs) {
     // 检查 EOS
     if (attr.flags & AVCODEC_BUFFER_FLAGS_EOS) {
         OH_LOG_INFO(LOG_APP, "Sync: received EOS");
+        NativeRender::GetInstance()->DiscardFrame(attr.pts);
         OH_VideoDecoder_FreeOutputBuffer(decoder_, outputIndex);
         return 0;  // EOS 不是错误
     }
@@ -2086,6 +2126,7 @@ int VideoDecoder::SyncProcessOutput(int64_t timeoutUs) {
         
         // EOS 帧不参与收集
         if (nextAttr.flags & AVCODEC_BUFFER_FLAGS_EOS) {
+            NativeRender::GetInstance()->DiscardFrame(nextAttr.pts);
             OH_VideoDecoder_FreeOutputBuffer(decoder_, nextOutputIndex);
             break;
         }
@@ -2104,6 +2145,7 @@ int VideoDecoder::SyncProcessOutput(int64_t timeoutUs) {
                 std::lock_guard<std::mutex> lock(timestampMutex_);
                 timestampToEnqueueTime_.erase(frame.attr.pts);
             }
+            NativeRender::GetInstance()->DiscardFrame(frame.attr.pts);
             OH_VideoDecoder_FreeOutputBuffer(decoder_, frame.index);
         }
         {
@@ -2133,8 +2175,11 @@ int VideoDecoder::SyncProcessOutput(int64_t timeoutUs) {
     // 更新解码统计
     UpdateDecodedStats(pts, enqueueTimeMs, latestFrame.attr.flags);
     
-    // 渲染帧 - 同步模式：立即渲染确保最低延迟
-    ret = OH_VideoDecoder_RenderOutputBuffer(decoder_, latestFrame.index);
+    // 开关关闭时保留同步模式原有的立即呈现基线；开启后仅对最新帧执行 step2。
+    NativeRender* render = NativeRender::GetInstance();
+    ret = render->IsTwoStepPreciseSyncEnabled()
+        ? render->SubmitFrame(decoder_, latestFrame.index, pts, enqueueTimeMs)
+        : OH_VideoDecoder_RenderOutputBuffer(decoder_, latestFrame.index);
     if (ret != AV_ERR_OK) {
         OH_LOG_WARN(LOG_APP, "Sync: render failed (%{public}d), freeing buffer", ret);
         OH_VideoDecoder_FreeOutputBuffer(decoder_, latestFrame.index);
@@ -2329,37 +2374,42 @@ int Init(int videoFormat, int width, int height, double fps, void* window) {
     return Setup(videoFormat, width, height, fps);
 }
 
-// 辅助函数：转换帧类型 + 计算时间戳（全局包装器共用）
-static void PrepareFrameSubmitParams(int frameType, int frameNumber,
+// 辅助函数：转换帧类型 + 选择 common-c host PTS（全局包装器共用）
+static void PrepareFrameSubmitParams(int frameType, int frameNumber, int64_t presentationTimeUs,
                                       VideoFrameType& outType, int64_t& outTimestamp) {
     // FRAME_TYPE_IDR = 1, FRAME_TYPE_I = 2
     outType = (frameType == 1 || frameType == 2) ? VideoFrameType::I_FRAME : VideoFrameType::P_FRAME;
-    double fps = (g_savedFps > 0) ? g_savedFps : 60.0;
-    outTimestamp = static_cast<int64_t>(static_cast<double>(frameNumber) * 1000000.0 / fps);
+    if (presentationTimeUs >= 0 && NativeRender::GetInstance()->IsTwoStepPreciseSyncEnabled()) {
+        outTimestamp = presentationTimeUs;
+    } else {
+        double fps = (g_savedFps > 0) ? g_savedFps : 60.0;
+        outTimestamp = static_cast<int64_t>(static_cast<double>(frameNumber) * 1000000.0 / fps);
+    }
 }
 
-int SubmitDecodeUnit(const uint8_t* data, int size, int frameNumber, int frameType, uint16_t hostProcessingLatency) {
+int SubmitDecodeUnit(const uint8_t* data, int size, int frameNumber, int frameType,
+                     uint16_t hostProcessingLatency, int64_t presentationTimeUs) {
     if (g_videoDecoder == nullptr) {
         return -1;
     }
     
     VideoFrameType type;
     int64_t timestamp;
-    PrepareFrameSubmitParams(frameType, frameNumber, type, timestamp);
+    PrepareFrameSubmitParams(frameType, frameNumber, presentationTimeUs, type, timestamp);
     
     return g_videoDecoder->SubmitDecodeUnit(data, size, frameNumber, type, timestamp, hostProcessingLatency);
 }
 
 int SubmitDecodeUnitScatter(const BufferSegment* segments, int segmentCount,
                             int totalSize, int frameNumber, int frameType,
-                            uint16_t hostProcessingLatency) {
+                            uint16_t hostProcessingLatency, int64_t presentationTimeUs) {
     if (g_videoDecoder == nullptr) {
         return -1;
     }
     
     VideoFrameType type;
     int64_t timestamp;
-    PrepareFrameSubmitParams(frameType, frameNumber, type, timestamp);
+    PrepareFrameSubmitParams(frameType, frameNumber, presentationTimeUs, type, timestamp);
     
     return g_videoDecoder->SubmitDecodeUnitScatter(segments, segmentCount, totalSize,
                                                     frameNumber, type, timestamp, hostProcessingLatency);

--- a/nativelib/src/main/cpp/video_decoder.cpp
+++ b/nativelib/src/main/cpp/video_decoder.cpp
@@ -1553,7 +1553,7 @@ void VideoDecoder::OnOutputBufferAvailable(OH_AVCodec* codec, uint32_t index,
     if (g_useAsyncRender) {
         NativeRender* render = NativeRender::GetInstance();
         if (render != nullptr && render->IsSurfaceReady()) {
-            if (render->SubmitFrame(codec, index, pts, enqueueTimeMs) != AV_ERR_OK) {
+            if (render->SubmitFrame(codec, index, pts) != AV_ERR_OK) {
                 OH_VideoDecoder_FreeOutputBuffer(codec, index);
             }
             // 后处理：如果启用，从代理 surface 读取并处理到显示 surface
@@ -1567,7 +1567,7 @@ void VideoDecoder::OnOutputBufferAvailable(OH_AVCodec* codec, uint32_t index,
     
     // 非 NativeRender surface 路径也使用同一呈现控制器，保持两步语义一致。
     NativeRender* render = NativeRender::GetInstance();
-    if (render->SubmitFrame(codec, index, pts, enqueueTimeMs) != AV_ERR_OK) {
+    if (render->SubmitFrame(codec, index, pts) != AV_ERR_OK) {
         OH_VideoDecoder_FreeOutputBuffer(codec, index);
     }
     
@@ -2169,7 +2169,7 @@ int VideoDecoder::SyncProcessOutput(int64_t timeoutUs) {
     // 开关关闭时保留同步模式原有的立即呈现基线；开启后仅对最新帧执行 step2。
     NativeRender* render = NativeRender::GetInstance();
     ret = render->IsTwoStepPreciseSyncEnabled()
-        ? render->SubmitFrame(decoder_, latestFrame.index, pts, enqueueTimeMs)
+        ? render->SubmitFrame(decoder_, latestFrame.index, pts)
         : OH_VideoDecoder_RenderOutputBuffer(decoder_, latestFrame.index);
     if (ret != AV_ERR_OK) {
         OH_LOG_WARN(LOG_APP, "Sync: render failed (%{public}d), freeing buffer", ret);

--- a/nativelib/src/main/cpp/video_decoder.h
+++ b/nativelib/src/main/cpp/video_decoder.h
@@ -519,8 +519,10 @@ namespace VideoDecoderInstance {
     /**
      * 提交解码单元
      * @param hostProcessingLatency 主机处理延迟（1/10 ms 单位）
+     * @param presentationTimeUs common-c 生成的 host PTS（微秒），-1 时回退帧号推导
      */
-    int SubmitDecodeUnit(const uint8_t* data, int size, int frameNumber, int frameType, uint16_t hostProcessingLatency = 0);
+    int SubmitDecodeUnit(const uint8_t* data, int size, int frameNumber, int frameType,
+                         uint16_t hostProcessingLatency = 0, int64_t presentationTimeUs = -1);
     
     /**
      * 提交解码单元（scatter-gather 零拷贝模式）
@@ -531,11 +533,13 @@ namespace VideoDecoderInstance {
      * @param frameNumber 帧号
      * @param frameType 帧类型
      * @param hostProcessingLatency 主机处理延迟（1/10 ms 单位）
+     * @param presentationTimeUs common-c 生成的 host PTS（微秒），-1 时回退帧号推导
      * @return 0 成功，负数失败
      */
     int SubmitDecodeUnitScatter(const BufferSegment* segments, int segmentCount,
                                 int totalSize, int frameNumber, int frameType,
-                                uint16_t hostProcessingLatency = 0);
+                                uint16_t hostProcessingLatency = 0,
+                                int64_t presentationTimeUs = -1);
     
     /**
      * 启动解码器


### PR DESCRIPTION
## 改了啥呀

- 新增“二步精确同步（实验性）”开关，默认关闭，方便真机 A/B 对比
- 第一步使用 common-c 的真实 host PTS，在帧进入解码管线时生成平滑的呈现目标
- 第二步在解码输出时将目标对齐到本地 VSync，统一覆盖同步与异步解码路径
- 新开关内部自动使用 VSync，不要求用户同时开启旧 VSync 选项

## 为啥要改

网络突发和解码耗时会让连续帧一起到达。只在解码输出时决定呈现时间，已经来不及恢复主机原本的节奏；只按目标时间呈现，又可能落在两个屏幕刷新点之间。

这次把两件事分开做：先把主机帧节奏整理平，再落到真实屏幕刷新点。这样帧不会因为一阵快、一阵慢就忽快忽慢，杂鱼抖动乖乖排队啦。

## 安全边界

- 开关关闭时保留原有低延迟、旧 VSync、同步解码行为，避免污染基线
- 预计算目标有 64 帧上限，丢帧、Flush、重连、Surface 切换时同步清理
- VSync 周期、目标或定时呈现 API 异常时立即回退直接呈现，避免等待导致画面卡住
- 系统周期不可用时按配置帧率生成保守周期

## 验证

- `node hvigorw.js assembleHar --mode module -p module=nativelib@default -p product=default -p buildMode=debug --no-daemon --stacktrace`
- `node hvigorw.js assembleApp --mode project -p product=default -p buildMode=debug --no-daemon --stacktrace`
- `git diff --check`

以上均通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增“二步精确同步（实验性）”开关，默认关闭，可在“性能与调试”中启用或关闭并自动保存设置。
  * 启用后，串流画面将结合主机节奏与本地 VSync 进行更精准的呈现时序控制。
* **性能优化**
  * 优化解码/呈现时间戳处理与 VSync 对齐，降低抖动、提升画面播放节奏。
  * 当条件不满足或出现失败时会自动回退，保障播放稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->