### PR TITLE
fix(stats): use rolling host latency for live overlay

### DIFF
--- a/entry/src/main/ets/service/streaming/StreamingSession.ets
+++ b/entry/src/main/ets/service/streaming/StreamingSession.ets
@@ -58,7 +58,7 @@ export interface StreamStats {
   renderedFps: number;     // 渲染帧率 (Rd)
   bitrate: number;         // Kbps
   latency: number;         // 解码延迟 ms (EMA 瞬时值)
-  hostLatency: number;     // 主机处理延迟（编码时间）ms
+  hostLatency: number;     // 最近 1 秒主机处理延迟（编码时间）ms
   networkLatency: number;  // 网络延迟（RTT）ms
   packetLoss: number;      // %
   decodedFrames: number;

--- a/nativelib/src/main/cpp/moonlight_bridge.cpp
+++ b/nativelib/src/main/cpp/moonlight_bridge.cpp
@@ -1737,7 +1737,7 @@ napi_value MoonBridge_GetVideoStats(napi_env env, napi_callback_info info) {
     napi_create_double(env, stats.currentFps, &fps);          // 接收帧率 (Rx)
     napi_create_double(env, stats.renderedFps, &renderedFps); // 渲染帧率 (Rd)
     napi_create_double(env, stats.currentBitrate, &bitrate);
-    napi_create_double(env, stats.avgHostProcessingLatency, &hostLatency);  // 主机处理延迟
+    napi_create_double(env, stats.recentHostProcessingLatency, &hostLatency);  // 最近 1 秒主机处理延迟
     
     // 网络丢帧统计
     napi_value framesLost, totalFrames;
@@ -1758,7 +1758,7 @@ napi_value MoonBridge_GetVideoStats(napi_env env, napi_callback_info info) {
     napi_set_named_property(env, result, "fps", fps);             // 接收帧率 (Rx)
     napi_set_named_property(env, result, "renderedFps", renderedFps); // 渲染帧率 (Rd)
     napi_set_named_property(env, result, "bitrate", bitrate);
-    napi_set_named_property(env, result, "hostLatency", hostLatency);  // 主机处理延迟（编码时间）
+    napi_set_named_property(env, result, "hostLatency", hostLatency);  // 最近 1 秒主机处理延迟（编码时间）
     napi_set_named_property(env, result, "framesLost", framesLost);
     napi_set_named_property(env, result, "totalFrames", totalFrames);
     

--- a/nativelib/src/main/cpp/video_decoder.cpp
+++ b/nativelib/src/main/cpp/video_decoder.cpp
@@ -1352,6 +1352,27 @@ void VideoDecoder::UpdateReceivedStats(int size, int frameNumber, uint16_t hostP
     
     auto currentTimeMs = std::chrono::duration_cast<std::chrono::milliseconds>(
         std::chrono::steady_clock::now().time_since_epoch()).count();
+
+    // Keep the live overlay responsive to recovery instead of letting old
+    // high-latency frames affect the value for the rest of the session.
+    if (recentHostLatencyWindowStartTimeMs_ == 0) {
+        recentHostLatencyWindowStartTimeMs_ = currentTimeMs;
+    } else if (currentTimeMs - recentHostLatencyWindowStartTimeMs_ >= kStatsUpdateIntervalMs) {
+        stats_.recentHostProcessingLatency = 0.0;
+        recentHostLatencyWindowFrames_ = 0;
+        recentHostLatencyWindowTotalMs_ = 0.0;
+        recentHostLatencyWindowStartTimeMs_ = currentTimeMs;
+    }
+
+    if (hostProcessingLatency > 0) {
+        double hostLatencyMs = static_cast<double>(hostProcessingLatency) / 10.0;
+        stats_.framesWithHostLatency++;
+        stats_.totalHostProcessingLatency += hostLatencyMs;
+        recentHostLatencyWindowFrames_++;
+        recentHostLatencyWindowTotalMs_ += hostLatencyMs;
+        stats_.recentHostProcessingLatency = recentHostLatencyWindowTotalMs_ /
+            static_cast<double>(recentHostLatencyWindowFrames_);
+    }
     
     if (stats_.lastFpsCalculationTime == 0) {
         // 初始化统计基线 - 注意：这是在增加 totalFrames 之后
@@ -1401,10 +1422,6 @@ void VideoDecoder::UpdateReceivedStats(int size, int frameNumber, uint16_t hostP
         }
     }
     
-    if (hostProcessingLatency > 0) {
-        stats_.framesWithHostLatency++;
-        stats_.totalHostProcessingLatency += static_cast<double>(hostProcessingLatency) / 10.0;
-    }
 }
 
 VideoDecoderStats VideoDecoder::GetStats() const {

--- a/nativelib/src/main/cpp/video_decoder.h
+++ b/nativelib/src/main/cpp/video_decoder.h
@@ -167,6 +167,7 @@ struct VideoDecoderStats {
     uint64_t framesWithHostLatency;      // 有主机延迟数据的帧数
     double totalHostProcessingLatency;   // 累计主机处理延迟（ms）
     double avgHostProcessingLatency;     // 平均主机处理延迟（ms）
+    double recentHostProcessingLatency;  // 最近 1 秒主机处理延迟（ms）
     // 分类丢帧统计（按丢弃机制分类，用于诊断性能问题）
     uint64_t droppedByL1;                // L1: sync drain-to-latest 跳过的中间帧
     uint64_t droppedByL2;                // L2: async 模式延迟过高跳帧
@@ -359,6 +360,9 @@ private:
     // 统计信息
     mutable std::mutex statsMutex_;
     VideoDecoderStats stats_;
+    uint64_t recentHostLatencyWindowFrames_{0};
+    double recentHostLatencyWindowTotalMs_{0.0};
+    int64_t recentHostLatencyWindowStartTimeMs_{0};
     
     // 运行状态
     std::atomic<bool> running_{false};


### PR DESCRIPTION
## 改了啥喵

- 增加最近 1 秒主机处理延迟窗口统计。
- 性能浮层的 `hostLatency` 改为实时窗口平均值。
- 保留累计主机延迟总量和帧数，串流结束报告继续使用全局平均值。

## 为啥要改

之前客户端把整个会话的累计平均主机延迟直接显示在实时浮层里。一次网络或编码抖动留下的高延迟样本会一直拖住后续数值，看起来就像主机延迟持续上升，杂鱼统计把历史包袱背太久了。

## 验证

- `npm run test:sunshine-mock`
- `git diff --check`
- HarmonyOS `assembleHap` 未执行成功：本机缺少 DevEco/Hvigor，脚本尝试从 npm 获取不存在的 `hvigor` 包。

关联 issue：#57