### PR TITLE
fix(render): unify host PTS presentation

### DIFF
--- a/AppScope/app.json5
+++ b/AppScope/app.json5
@@ -2,8 +2,8 @@
   "app": {
     "bundleName": "com.alkaidlab.sdream",
     "vendor": "Moonlight",
-    "versionCode": 1000782,
-    "versionName": "1.0.0.782",
+    "versionCode": 1000784,
+    "versionName": "1.0.0.784",
     "icon": "$media:layered_icon",
     "label": "$string:app_name",
     "bundleType": "app",

--- a/entry/src/main/ets/model/StreamConfig.ets
+++ b/entry/src/main/ets/model/StreamConfig.ets
@@ -91,7 +91,7 @@ export interface StreamConfig {
   enableSyncDecode: boolean;  // 同步解码模式（API 20+，主动轮询 + 仅渲染最新输出帧，低延迟优先）
   enableVrr: boolean;         // VRR 可变刷新率模式（动态调整屏幕刷新率，可能丢帧）
   enableVsync: boolean;       // VSync 渲染模式（按时间戳精确呈现，更平滑但可能增加延迟）
-  enableTwoStepPreciseSync: boolean; // 二步精确同步（host 节奏去抖 + 本地 VSync 对齐）
+  enableHostPacedPresentation: boolean; // 主机 PTS 平滑呈现（独立于同步/异步解码）
   enablePostProcess: boolean; // 后处理滤镜（HDR 暗区抖动补偿，适用于 OLED 面板）
   upscaleMode: number;        // 超分辨率模式 (0=OFF, 1=XENGINE, 2=FSR1, 3=AUTO)
   upscaleSharpness: number;   // 超分锐度 (0.0 - 1.0)
@@ -278,7 +278,7 @@ export function getDefaultStreamConfig(): StreamConfig {
     enableSyncDecode: false, // 默认禁用同步解码（需要 API 20+；启用后低延迟优先）
     enableVrr: false,       // 默认禁用 VRR（可能丢帧）
     enableVsync: false,     // 默认关闭（低延迟优先；开启后更平滑但可能增加 1 帧左右延迟）
-    enableTwoStepPreciseSync: false, // 默认关闭，便于与原 VSync 路径做 A/B 对比
+    enableHostPacedPresentation: false, // 默认关闭，约增加一帧呈现余量
     enablePostProcess: false, // 默认禁用后处理滤镜
     upscaleMode: 0,           // 默认不超分
     upscaleSharpness: 0.5,    // 默认锐度 50%

--- a/entry/src/main/ets/pages/SettingsPageV2.ets
+++ b/entry/src/main/ets/pages/SettingsPageV2.ets
@@ -238,7 +238,7 @@ struct SettingsPageV2 {
   @State enableSyncDecode: boolean = false;  // 同步解码模式，默认禁用
   @State enableVrr: boolean = false;  // VRR 可变刷新率，默认禁用
   @State enableVsync: boolean = false;
-  @State enableTwoStepPreciseSync: boolean = false;
+  @State enableHostPacedPresentation: boolean = false;
   @State enablePostProcess: boolean = false;  // 后处理滤镜（暗区抖动补偿）
   @State upscaleMode: number = 0;             // 超分辨率模式
   @State upscaleSharpness: number = 50;       // 超分锐度 (0-100)
@@ -590,7 +590,8 @@ struct SettingsPageV2 {
       this.enableSyncDecode = await this.loadBoolean(SettingsKeys.ENABLE_SYNC_DECODE, false);  // 默认禁用
       this.enableVrr = await this.loadBoolean(SettingsKeys.ENABLE_VRR, false);  // VRR 默认禁用
       this.enableVsync = await this.loadBoolean(SettingsKeys.ENABLE_VSYNC, false);
-      this.enableTwoStepPreciseSync = await this.loadBoolean(SettingsKeys.ENABLE_TWO_STEP_PRECISE_SYNC, false);
+      this.enableHostPacedPresentation = await this.loadBoolean(
+        SettingsKeys.ENABLE_HOST_PACED_PRESENTATION, false);
       this.enablePostProcess = await this.loadBoolean(SettingsKeys.ENABLE_POST_PROCESS, false);
       this.upscaleMode = await PreferencesUtil.get<number>(SettingsKeys.UPSCALE_MODE, 0);
       this.upscaleSharpness = await PreferencesUtil.get<number>(SettingsKeys.UPSCALE_SHARPNESS, 50);
@@ -2113,13 +2114,14 @@ struct SettingsPageV2 {
                 }
               },
               {
-                title: '二步精确同步 (实验性)',
-                subtitle: '先跟随主机出帧节奏，再对齐本地屏幕刷新',
+                title: '主机 PTS 平滑呈现 (实验性)',
+                subtitle: '按主机时间线匀速送显，约增加一帧延迟',
                 type: 'toggle',
-                value: this.enableTwoStepPreciseSync,
+                value: this.enableHostPacedPresentation,
                 action: () => {
-                  this.enableTwoStepPreciseSync = !this.enableTwoStepPreciseSync;
-                  this.saveSetting(SettingsKeys.ENABLE_TWO_STEP_PRECISE_SYNC, this.enableTwoStepPreciseSync);
+                  this.enableHostPacedPresentation = !this.enableHostPacedPresentation;
+                  this.saveSetting(SettingsKeys.ENABLE_HOST_PACED_PRESENTATION,
+                    this.enableHostPacedPresentation);
                 }
               },
               {

--- a/entry/src/main/ets/service/SettingsService.ets
+++ b/entry/src/main/ets/service/SettingsService.ets
@@ -134,7 +134,8 @@ export class SettingsKeys {
   static readonly ENABLE_SYNC_DECODE: string = 'settings_enable_sync_decode';  // 同步解码模式
   static readonly ENABLE_VRR: string = 'settings_enable_vrr';  // VRR 可变刷新率模式
   static readonly ENABLE_VSYNC: string = 'settings_enable_vsync';
-  static readonly ENABLE_TWO_STEP_PRECISE_SYNC: string = 'settings_enable_two_step_precise_sync';
+  // Keep the PR #58 key value so existing experimental settings migrate without data loss.
+  static readonly ENABLE_HOST_PACED_PRESENTATION: string = 'settings_enable_two_step_precise_sync';
   static readonly ADAPTIVE_BITRATE: string = 'settings_adaptive_bitrate';  // 智能码率调节
   static readonly ABR_MODE: string = 'settings_abr_mode';  // ABR 模式: balanced | quality | lowLatency
   static readonly ENABLE_POST_PROCESS: string = 'settings_enable_post_process';  // 后处理滤镜
@@ -640,7 +641,8 @@ export class SettingsService {
     const enableSyncDecode = await this.getBoolean(SettingsKeys.ENABLE_SYNC_DECODE, false);  // 默认禁用
     const enableVrr = await this.getBoolean(SettingsKeys.ENABLE_VRR, false);  // VRR 默认禁用
     const enableVsync = await this.getBoolean(SettingsKeys.ENABLE_VSYNC, false);
-    const enableTwoStepPreciseSync = await this.getBoolean(SettingsKeys.ENABLE_TWO_STEP_PRECISE_SYNC, false);
+    const enableHostPacedPresentation = await this.getBoolean(
+      SettingsKeys.ENABLE_HOST_PACED_PRESENTATION, false);
     const enablePostProcess = await this.getBoolean(SettingsKeys.ENABLE_POST_PROCESS, false);
     const upscaleMode = await this.getNumber(SettingsKeys.UPSCALE_MODE, 0);
     const upscaleSharpness = await this.getNumber(SettingsKeys.UPSCALE_SHARPNESS, 50) / 100.0;
@@ -731,7 +733,7 @@ export class SettingsService {
       enableSyncDecode: enableSyncDecode,
       enableVrr: enableVrr,
       enableVsync: enableVsync,
-      enableTwoStepPreciseSync: enableTwoStepPreciseSync,
+      enableHostPacedPresentation: enableHostPacedPresentation,
       enablePostProcess: enablePostProcess,
       sdrToHdrMode: sdrToHdrMode,
       sdrToHdr: sdrToHdr,

--- a/entry/src/main/ets/service/streaming/StreamingSession.ets
+++ b/entry/src/main/ets/service/streaming/StreamingSession.ets
@@ -136,7 +136,7 @@ interface NativeModule {
   isDecoderSyncMode(): boolean;
   setVsyncEnabled(enabled: boolean): void;
   isVsyncEnabled(): boolean;
-  setTwoStepPreciseSyncEnabled(enabled: boolean): void;
+  setHostPacedPresentationEnabled(enabled: boolean): void;
   setVrrEnabled(enabled: boolean): void;
   setPostProcessEnabled(enabled: boolean): void;
   setUpscaleMode(mode: number, sharpness: number): void;
@@ -1284,7 +1284,8 @@ export class StreamingSession {
     this.nativeModule.setDecoderBufferCount(this.config.decoderBufferCount);
     this.nativeModule.setDecoderSyncMode(this.config.enableSyncDecode);
     this.nativeModule.setVsyncEnabled(this.config.enableVsync);
-    this.nativeModule.setTwoStepPreciseSyncEnabled(this.config.enableTwoStepPreciseSync ?? false);
+    this.nativeModule.setHostPacedPresentationEnabled(
+      this.config.enableHostPacedPresentation ?? false);
     this.nativeModule.setVrrEnabled(this.config.enableVrr);
     this.nativeModule.setPostProcessEnabled(this.config.enablePostProcess ?? false);
     this.nativeModule.setUpscaleMode(this.config.upscaleMode ?? 0, this.config.upscaleSharpness ?? 0.5);
@@ -1295,7 +1296,7 @@ export class StreamingSession {
     }
 
     console.info(`解码器: buffers=${this.config.decoderBufferCount}, sync=${this.config.enableSyncDecode}, ` +
-      `vsync=${this.config.enableVsync}, twoStep=${this.config.enableTwoStepPreciseSync ?? false}, ` +
+      `vsync=${this.config.enableVsync}, hostPaced=${this.config.enableHostPacedPresentation ?? false}, ` +
       `vrr=${this.config.enableVrr}`);
 
     const callStart = async (): Promise<number> => {

--- a/nativelib/src/main/cpp/CMakeLists.txt
+++ b/nativelib/src/main/cpp/CMakeLists.txt
@@ -85,6 +85,7 @@ set(SOURCE_FILES
     usb_helper.cpp
     usb_ddk_poller.cpp
     native_render.cpp
+    presentation_scheduler.cpp
     gl_post_processor.cpp
     sdl_gamecontrollerdb.cpp
 )

--- a/nativelib/src/main/cpp/gl_post_processor.cpp
+++ b/nativelib/src/main/cpp/gl_post_processor.cpp
@@ -22,6 +22,7 @@
 
 #include "gl_post_processor.h"
 #include <native_buffer/native_buffer.h>
+#include <native_image/native_image.h>
 #include <cstring>
 #include <cmath>
 #include <dlfcn.h>
@@ -172,10 +173,12 @@ typedef void (*PFN_HMS_XEG_RenderSpatialUpscale)(GLuint);
 typedef OH_NativeImage* (*PFN_OH_NativeImage_Create)(GLuint, unsigned int);
 typedef OHNativeWindow* (*PFN_OH_NativeImage_AcquireNativeWindow)(OH_NativeImage*);
 typedef int32_t (*PFN_OH_NativeImage_UpdateSurfaceImage)(OH_NativeImage*);
-typedef int32_t (*PFN_OH_NativeImage_GetTimestamp)(OH_NativeImage*, int64_t*);
+typedef int64_t (*PFN_OH_NativeImage_GetTimestamp)(OH_NativeImage*);
 typedef void (*PFN_OH_NativeImage_Destroy)(OH_NativeImage**);
 typedef int32_t (*PFN_OH_NativeImage_AttachContext)(OH_NativeImage*, GLuint);
-typedef int32_t (*PFN_OH_NativeImage_SetOnFrameAvailableListener)(OH_NativeImage*, void*);
+typedef int32_t (*PFN_OH_NativeImage_SetOnFrameAvailableListener)(
+    OH_NativeImage*, OH_OnFrameAvailableListener);
+typedef int32_t (*PFN_OH_NativeImage_UnsetOnFrameAvailableListener)(OH_NativeImage*);
 
 // Function pointer storage
 static struct {
@@ -246,6 +249,8 @@ static struct {
     PFN_OH_NativeImage_GetTimestamp nativeImageGetTimestamp;
     PFN_OH_NativeImage_Destroy nativeImageDestroy;
     PFN_OH_NativeImage_AttachContext nativeImageAttachContext;
+    PFN_OH_NativeImage_SetOnFrameAvailableListener nativeImageSetFrameListener;
+    PFN_OH_NativeImage_UnsetOnFrameAvailableListener nativeImageUnsetFrameListener;
     // XEngine (optional)
     PFN_HMS_XEG_GetString xegGetString;
     PFN_HMS_XEG_SpatialUpscaleParameter xegSpatialUpscaleParam;
@@ -337,13 +342,18 @@ static bool LoadAPIs() {
     g_api.nativeImageGetTimestamp = (PFN_OH_NativeImage_GetTimestamp)dlsym(niLib, "OH_NativeImage_GetTimestamp");
     g_api.nativeImageDestroy = (PFN_OH_NativeImage_Destroy)dlsym(niLib, "OH_NativeImage_Destroy");
     g_api.nativeImageAttachContext = (PFN_OH_NativeImage_AttachContext)dlsym(niLib, "OH_NativeImage_AttachContext");
+    g_api.nativeImageSetFrameListener = (PFN_OH_NativeImage_SetOnFrameAvailableListener)
+        dlsym(niLib, "OH_NativeImage_SetOnFrameAvailableListener");
+    g_api.nativeImageUnsetFrameListener = (PFN_OH_NativeImage_UnsetOnFrameAvailableListener)
+        dlsym(niLib, "OH_NativeImage_UnsetOnFrameAvailableListener");
 
     // Validate critical functions
     if (!g_api.eglGetDisplay || !g_api.eglInitialize || !g_api.eglChooseConfig ||
         !g_api.eglCreateContext || !g_api.eglCreateWindowSurface || !g_api.eglMakeCurrent ||
         !g_api.eglSwapBuffers || !g_api.glCreateShader || !g_api.glCreateProgram ||
         !g_api.nativeImageCreate || !g_api.nativeImageAcquireWindow ||
-        !g_api.nativeImageUpdateSurface) {
+        !g_api.nativeImageUpdateSurface || !g_api.nativeImageSetFrameListener ||
+        !g_api.nativeImageUnsetFrameListener) {
         OH_LOG_ERROR(LOG_APP, "Missing critical GL/EGL/NativeImage APIs");
         return false;
     }
@@ -532,8 +542,9 @@ int GLPostProcessor::Init(OHNativeWindow* displayWindow,
 
     initialized_ = true;
 
-    // Release EGL context from init thread so decode thread can claim it
+    // Release the context before the frame worker becomes eligible to claim it.
     g_api.eglMakeCurrent(eglDisplay_, MY_EGL_NO_SURFACE, MY_EGL_NO_SURFACE, MY_EGL_NO_CONTEXT);
+    StartFrameWorker();
 
     OH_LOG_INFO(LOG_APP, "GLPostProcessor initialized: input=%{public}ux%{public}u output=%{public}ux%{public}u upscale=%{public}d",
                 inputWidth_, inputHeight_, outputWidth_, outputHeight_, static_cast<int>(activeUpscale_));
@@ -712,9 +723,77 @@ bool GLPostProcessor::InitNativeImage() {
         return false;
     }
 
+    OH_OnFrameAvailableListener listener = {};
+    listener.context = this;
+    listener.onFrameAvailable = &GLPostProcessor::OnFrameAvailable;
+    if (g_api.nativeImageSetFrameListener(nativeImage_, listener) != 0) {
+        OH_LOG_ERROR(LOG_APP, "OH_NativeImage_SetOnFrameAvailableListener failed");
+        return false;
+    }
+    frameListenerRegistered_ = true;
+
     OH_LOG_INFO(LOG_APP, "NativeImage created: texture=%{public}u, proxyWindow=%{public}p",
                 oesTexture_, static_cast<void*>(proxyWindow_));
     return true;
+}
+
+void GLPostProcessor::StartFrameWorker() {
+    if (frameWorkerRunning_.exchange(true)) {
+        return;
+    }
+    frameWorkerThread_ = std::thread(&GLPostProcessor::FrameWorkerLoop, this);
+}
+
+void GLPostProcessor::StopFrameWorker() {
+    // Stop new callbacks before joining the worker. This also handles init
+    // failures where the listener exists but the worker was never started.
+    if (nativeImage_ && frameListenerRegistered_) {
+        if (g_api.nativeImageUnsetFrameListener) {
+            g_api.nativeImageUnsetFrameListener(nativeImage_);
+        }
+        frameListenerRegistered_ = false;
+    }
+
+    frameWorkerRunning_.store(false);
+    frameWorkerCond_.notify_all();
+    if (frameWorkerThread_.joinable()) {
+        frameWorkerThread_.join();
+    }
+    std::lock_guard<std::mutex> lock(frameWorkerMutex_);
+    framePending_ = false;
+}
+
+void GLPostProcessor::OnFrameAvailable(void* context) {
+    auto* self = static_cast<GLPostProcessor*>(context);
+    if (self == nullptr || !self->frameWorkerRunning_.load()) {
+        return;
+    }
+    {
+        std::lock_guard<std::mutex> lock(self->frameWorkerMutex_);
+        self->framePending_ = true;
+    }
+    self->frameWorkerCond_.notify_one();
+}
+
+void GLPostProcessor::FrameWorkerLoop() {
+    while (frameWorkerRunning_.load()) {
+        {
+            std::unique_lock<std::mutex> lock(frameWorkerMutex_);
+            frameWorkerCond_.wait(lock, [this] {
+                return framePending_ || !frameWorkerRunning_.load();
+            });
+            if (!frameWorkerRunning_.load()) {
+                break;
+            }
+            framePending_ = false;
+        }
+        ProcessFrame();
+    }
+
+    if (eglDisplay_) {
+        g_api.eglMakeCurrent(
+            eglDisplay_, MY_EGL_NO_SURFACE, MY_EGL_NO_SURFACE, MY_EGL_NO_CONTEXT);
+    }
 }
 
 static GLuint CompileShader(unsigned int type, const char* source) {
@@ -1265,11 +1344,13 @@ void GLPostProcessor::DrawFullscreenQuad() {
 // =============================================================================
 
 void GLPostProcessor::Release() {
+    StopFrameWorker();
     std::lock_guard<std::mutex> lock(processMutex_);
     ReleaseInternal();
 }
 
 void GLPostProcessor::ReleaseInternal() {
+    StopFrameWorker();
     if (eglDisplay_ && eglSurface_ && eglContext_) {
         g_api.eglMakeCurrent(eglDisplay_, eglSurface_, eglSurface_, eglContext_);
     }
@@ -1293,6 +1374,10 @@ void GLPostProcessor::ReleaseShaders() {
 
 void GLPostProcessor::ReleaseNativeImage() {
     if (nativeImage_) {
+        if (frameListenerRegistered_ && g_api.nativeImageUnsetFrameListener) {
+            g_api.nativeImageUnsetFrameListener(nativeImage_);
+        }
+        frameListenerRegistered_ = false;
         g_api.nativeImageDestroy(&nativeImage_);
         nativeImage_ = nullptr;
         proxyWindow_ = nullptr;  // owned by NativeImage

--- a/nativelib/src/main/cpp/gl_post_processor.cpp
+++ b/nativelib/src/main/cpp/gl_post_processor.cpp
@@ -415,8 +415,11 @@ GLPostProcessor* GLPostProcessor::GetInstance() {
 void GLPostProcessor::ReleaseInstance() {
     std::lock_guard<std::mutex> lock(instanceMutex_);
     if (instance_) {
-        delete instance_;
-        instance_ = nullptr;
+        // The NativeImage API does not promise that unregistering a listener
+        // drains callbacks already dispatched by the system. Keep the process
+        // singleton alive and release only session resources so callback
+        // context and synchronization primitives always remain valid.
+        instance_->Release();
     }
 }
 
@@ -723,16 +726,23 @@ bool GLPostProcessor::InitNativeImage() {
         return false;
     }
 
+    auto callbackContext = std::make_unique<FrameCallbackContext>();
+    callbackContext->owner = this;
+    FrameCallbackContext* callbackContextPtr = callbackContext.get();
+    frameCallbackContexts_.push_back(std::move(callbackContext));
+
     OH_OnFrameAvailableListener listener = {};
-    listener.context = this;
+    listener.context = callbackContextPtr;
     listener.onFrameAvailable = &GLPostProcessor::OnFrameAvailable;
     {
         std::lock_guard<std::mutex> lock(frameCallbackMutex_);
+        activeFrameCallbackContext_ = callbackContextPtr;
         frameCallbacksEnabled_ = true;
     }
     if (g_api.nativeImageSetFrameListener(nativeImage_, listener) != 0) {
         std::lock_guard<std::mutex> lock(frameCallbackMutex_);
         frameCallbacksEnabled_ = false;
+        activeFrameCallbackContext_ = nullptr;
         OH_LOG_ERROR(LOG_APP, "OH_NativeImage_SetOnFrameAvailableListener failed");
         return false;
     }
@@ -744,19 +754,25 @@ bool GLPostProcessor::InitNativeImage() {
 }
 
 void GLPostProcessor::StartFrameWorker() {
-    if (frameWorkerRunning_.exchange(true)) {
-        return;
+    {
+        std::lock_guard<std::mutex> lock(frameWorkerMutex_);
+        if (frameWorkerRunning_.load()) {
+            return;
+        }
+        framePending_ = false;
+        frameWorkerRunning_.store(true);
     }
     frameWorkerThread_ = std::thread(&GLPostProcessor::FrameWorkerLoop, this);
 }
 
 void GLPostProcessor::StopFrameWorker() {
-    // Stop callbacks before joining the worker. Unregistering the listener
-    // prevents new callbacks, while the in-flight counter is the lifetime
-    // barrier for callbacks that were already executing.
+    // Disable the current registration before joining the worker. A callback
+    // dispatched before unregister may still enter later; its retained context
+    // keeps that entry safe and prevents it from targeting a newer session.
     {
         std::lock_guard<std::mutex> lock(frameCallbackMutex_);
         frameCallbacksEnabled_ = false;
+        activeFrameCallbackContext_ = nullptr;
     }
     if (nativeImage_ && frameListenerRegistered_) {
         if (g_api.nativeImageUnsetFrameListener) {
@@ -772,7 +788,13 @@ void GLPostProcessor::StopFrameWorker() {
         });
     }
 
-    frameWorkerRunning_.store(false);
+    {
+        // Update the wait predicate while holding the same mutex used by
+        // FrameWorkerLoop. This prevents a notify between predicate evaluation
+        // and wait() from being lost during shutdown.
+        std::lock_guard<std::mutex> lock(frameWorkerMutex_);
+        frameWorkerRunning_.store(false);
+    }
     frameWorkerCond_.notify_all();
     if (frameWorkerThread_.joinable()) {
         frameWorkerThread_.join();
@@ -782,16 +804,18 @@ void GLPostProcessor::StopFrameWorker() {
 }
 
 void GLPostProcessor::OnFrameAvailable(void* context) {
-    auto* self = static_cast<GLPostProcessor*>(context);
-    if (self == nullptr) {
+    auto* callbackContext = static_cast<FrameCallbackContext*>(context);
+    if (callbackContext == nullptr || callbackContext->owner == nullptr) {
         return;
     }
+    GLPostProcessor* self = callbackContext->owner;
 
     bool shouldNotifyWorker = false;
     {
         std::lock_guard<std::mutex> lock(self->frameCallbackMutex_);
         self->activeFrameCallbacks_++;
-        shouldNotifyWorker = self->frameCallbacksEnabled_;
+        shouldNotifyWorker = self->frameCallbacksEnabled_ &&
+            self->activeFrameCallbackContext_ == callbackContext;
     }
 
     if (shouldNotifyWorker && self->frameWorkerRunning_.load()) {
@@ -1399,6 +1423,8 @@ void GLPostProcessor::ReleaseInternal() {
 
     initialized_ = false;
     frameCount_ = 0;
+    xengineConsecutiveErrors_ = 0;
+    swapConsecutiveFailures_ = 0;
     OH_LOG_INFO(LOG_APP, "GLPostProcessor released");
 }
 

--- a/nativelib/src/main/cpp/gl_post_processor.cpp
+++ b/nativelib/src/main/cpp/gl_post_processor.cpp
@@ -726,7 +726,13 @@ bool GLPostProcessor::InitNativeImage() {
     OH_OnFrameAvailableListener listener = {};
     listener.context = this;
     listener.onFrameAvailable = &GLPostProcessor::OnFrameAvailable;
+    {
+        std::lock_guard<std::mutex> lock(frameCallbackMutex_);
+        frameCallbacksEnabled_ = true;
+    }
     if (g_api.nativeImageSetFrameListener(nativeImage_, listener) != 0) {
+        std::lock_guard<std::mutex> lock(frameCallbackMutex_);
+        frameCallbacksEnabled_ = false;
         OH_LOG_ERROR(LOG_APP, "OH_NativeImage_SetOnFrameAvailableListener failed");
         return false;
     }
@@ -745,13 +751,25 @@ void GLPostProcessor::StartFrameWorker() {
 }
 
 void GLPostProcessor::StopFrameWorker() {
-    // Stop new callbacks before joining the worker. This also handles init
-    // failures where the listener exists but the worker was never started.
+    // Stop callbacks before joining the worker. Unregistering the listener
+    // prevents new callbacks, while the in-flight counter is the lifetime
+    // barrier for callbacks that were already executing.
+    {
+        std::lock_guard<std::mutex> lock(frameCallbackMutex_);
+        frameCallbacksEnabled_ = false;
+    }
     if (nativeImage_ && frameListenerRegistered_) {
         if (g_api.nativeImageUnsetFrameListener) {
             g_api.nativeImageUnsetFrameListener(nativeImage_);
         }
         frameListenerRegistered_ = false;
+    }
+
+    {
+        std::unique_lock<std::mutex> lock(frameCallbackMutex_);
+        frameCallbackCond_.wait(lock, [this] {
+            return activeFrameCallbacks_ == 0;
+        });
     }
 
     frameWorkerRunning_.store(false);
@@ -765,14 +783,32 @@ void GLPostProcessor::StopFrameWorker() {
 
 void GLPostProcessor::OnFrameAvailable(void* context) {
     auto* self = static_cast<GLPostProcessor*>(context);
-    if (self == nullptr || !self->frameWorkerRunning_.load()) {
+    if (self == nullptr) {
         return;
     }
+
+    bool shouldNotifyWorker = false;
     {
-        std::lock_guard<std::mutex> lock(self->frameWorkerMutex_);
-        self->framePending_ = true;
+        std::lock_guard<std::mutex> lock(self->frameCallbackMutex_);
+        self->activeFrameCallbacks_++;
+        shouldNotifyWorker = self->frameCallbacksEnabled_;
     }
-    self->frameWorkerCond_.notify_one();
+
+    if (shouldNotifyWorker && self->frameWorkerRunning_.load()) {
+        {
+            std::lock_guard<std::mutex> lock(self->frameWorkerMutex_);
+            self->framePending_ = true;
+        }
+        self->frameWorkerCond_.notify_one();
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(self->frameCallbackMutex_);
+        self->activeFrameCallbacks_--;
+        if (self->activeFrameCallbacks_ == 0) {
+            self->frameCallbackCond_.notify_all();
+        }
+    }
 }
 
 void GLPostProcessor::FrameWorkerLoop() {

--- a/nativelib/src/main/cpp/gl_post_processor.h
+++ b/nativelib/src/main/cpp/gl_post_processor.h
@@ -199,6 +199,10 @@ private:
     std::condition_variable frameWorkerCond_;
     std::thread frameWorkerThread_;
     std::atomic<bool> frameWorkerRunning_{false};
+    std::mutex frameCallbackMutex_;
+    std::condition_variable frameCallbackCond_;
+    uint32_t activeFrameCallbacks_ = 0;
+    bool frameCallbacksEnabled_ = false;
     bool frameListenerRegistered_ = false;
     bool framePending_ = false;
 

--- a/nativelib/src/main/cpp/gl_post_processor.h
+++ b/nativelib/src/main/cpp/gl_post_processor.h
@@ -37,6 +37,8 @@
 #include <atomic>
 #include <thread>
 #include <condition_variable>
+#include <memory>
+#include <vector>
 
 // 前向声明 — 避免在头文件中引入 EGL/GL/NativeImage 依赖
 // 实际类型在 cpp 中通过 dlsym 加载
@@ -190,6 +192,10 @@ private:
     void FallbackFromXEngine();
 
 private:
+    struct FrameCallbackContext {
+        GLPostProcessor* owner = nullptr;
+    };
+
     static GLPostProcessor* instance_;
     static std::mutex instanceMutex_;
 
@@ -204,6 +210,11 @@ private:
     uint32_t activeFrameCallbacks_ = 0;
     bool frameCallbacksEnabled_ = false;
     bool frameListenerRegistered_ = false;
+    FrameCallbackContext* activeFrameCallbackContext_ = nullptr;
+    // Listener callbacks may already be dispatched when the listener is
+    // removed. Retain their immutable contexts for the process lifetime so a
+    // late callback never dereferences a freed context or a newer session.
+    std::vector<std::unique_ptr<FrameCallbackContext>> frameCallbackContexts_;
     bool framePending_ = false;
 
     // 显示目标

--- a/nativelib/src/main/cpp/gl_post_processor.h
+++ b/nativelib/src/main/cpp/gl_post_processor.h
@@ -36,6 +36,7 @@
 #include <mutex>
 #include <atomic>
 #include <thread>
+#include <condition_variable>
 
 // 前向声明 — 避免在头文件中引入 EGL/GL/NativeImage 依赖
 // 实际类型在 cpp 中通过 dlsym 加载
@@ -142,11 +143,6 @@ public:
     bool IsActive() const { return ditherEnabled_ || sdrToHdr_ || upscaleMode_ != UpscaleMode::OFF; }
 
     /**
-     * 手动触发处理当前帧（供解码器回调调用）
-     */
-    void ProcessFrame();
-
-    /**
      * 释放所有资源
      */
     void Release();
@@ -171,6 +167,11 @@ private:
     // OH_NativeImage 代理 surface
     bool InitNativeImage();
     void ReleaseNativeImage();
+    void StartFrameWorker();
+    void StopFrameWorker();
+    static void OnFrameAvailable(void* context);
+    void FrameWorkerLoop();
+    void ProcessFrame();
 
     // FBO (用于 OES → TEXTURE_2D 转换)
     bool InitFBO();
@@ -194,6 +195,12 @@ private:
 
     std::atomic<bool> ditherEnabled_{false};  // 暗区增强（HDR 暗部抖动补偿）
     std::mutex processMutex_;
+    std::mutex frameWorkerMutex_;
+    std::condition_variable frameWorkerCond_;
+    std::thread frameWorkerThread_;
+    std::atomic<bool> frameWorkerRunning_{false};
+    bool frameListenerRegistered_ = false;
+    bool framePending_ = false;
 
     // 显示目标
     OHNativeWindow* displayWindow_ = nullptr;

--- a/nativelib/src/main/cpp/moonlight_bridge.cpp
+++ b/nativelib/src/main/cpp/moonlight_bridge.cpp
@@ -1998,7 +1998,7 @@ napi_value MoonBridge_IsVsyncEnabled(napi_env env, napi_callback_info info) {
     return result;
 }
 
-napi_value MoonBridge_SetTwoStepPreciseSyncEnabled(napi_env env, napi_callback_info info) {
+napi_value MoonBridge_SetHostPacedPresentationEnabled(napi_env env, napi_callback_info info) {
     size_t argc = 1;
     napi_value args[1];
     napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
@@ -2008,8 +2008,8 @@ napi_value MoonBridge_SetTwoStepPreciseSyncEnabled(napi_env env, napi_callback_i
         napi_get_value_bool(env, args[0], &enabled);
     }
 
-    NativeRender::GetInstance()->SetTwoStepPreciseSyncEnabled(enabled);
-    OH_LOG_INFO(LOG_APP, "MoonBridge_SetTwoStepPreciseSyncEnabled: %{public}s",
+    NativeRender::GetInstance()->SetHostPacedPresentationEnabled(enabled);
+    OH_LOG_INFO(LOG_APP, "MoonBridge_SetHostPacedPresentationEnabled: %{public}s",
                 enabled ? "true" : "false");
 
     napi_value result;

--- a/nativelib/src/main/cpp/moonlight_bridge.h
+++ b/nativelib/src/main/cpp/moonlight_bridge.h
@@ -273,10 +273,10 @@ napi_value MoonBridge_SetVsyncEnabled(napi_env env, napi_callback_info info);
 napi_value MoonBridge_IsVsyncEnabled(napi_env env, napi_callback_info info);
 
 /**
- * 设置是否启用二步精确同步（内部自行使用 VSync）。
+ * 设置是否启用主机 PTS 平滑呈现。
  * @param enabled boolean
  */
-napi_value MoonBridge_SetTwoStepPreciseSyncEnabled(napi_env env, napi_callback_info info);
+napi_value MoonBridge_SetHostPacedPresentationEnabled(napi_env env, napi_callback_info info);
 
 // =============================================================================
 // 音频设置

--- a/nativelib/src/main/cpp/napi_init.cpp
+++ b/nativelib/src/main/cpp/napi_init.cpp
@@ -130,7 +130,9 @@ static napi_value Init(napi_env env, napi_value exports) {
         { "isDecoderSyncMode", nullptr, MoonBridge_IsDecoderSyncMode, nullptr, nullptr, nullptr, napi_default, nullptr },
         { "setVsyncEnabled", nullptr, MoonBridge_SetVsyncEnabled, nullptr, nullptr, nullptr, napi_default, nullptr },
         { "isVsyncEnabled", nullptr, MoonBridge_IsVsyncEnabled, nullptr, nullptr, nullptr, napi_default, nullptr },
-        { "setTwoStepPreciseSyncEnabled", nullptr, MoonBridge_SetTwoStepPreciseSyncEnabled, nullptr, nullptr, nullptr, napi_default, nullptr },
+        { "setHostPacedPresentationEnabled", nullptr, MoonBridge_SetHostPacedPresentationEnabled, nullptr, nullptr, nullptr, napi_default, nullptr },
+        // Compatibility alias for builds that persisted PR #58's experimental setting.
+        { "setTwoStepPreciseSyncEnabled", nullptr, MoonBridge_SetHostPacedPresentationEnabled, nullptr, nullptr, nullptr, napi_default, nullptr },
         { "setVrrEnabled", nullptr, MoonBridge_SetVrrEnabled, nullptr, nullptr, nullptr, napi_default, nullptr },
         { "setPostProcessEnabled", nullptr, MoonBridge_SetPostProcessEnabled, nullptr, nullptr, nullptr, napi_default, nullptr },
         { "setUpscaleMode", nullptr, MoonBridge_SetUpscaleMode, nullptr, nullptr, nullptr, napi_default, nullptr },

--- a/nativelib/src/main/cpp/napi_init.cpp
+++ b/nativelib/src/main/cpp/napi_init.cpp
@@ -131,8 +131,6 @@ static napi_value Init(napi_env env, napi_value exports) {
         { "setVsyncEnabled", nullptr, MoonBridge_SetVsyncEnabled, nullptr, nullptr, nullptr, napi_default, nullptr },
         { "isVsyncEnabled", nullptr, MoonBridge_IsVsyncEnabled, nullptr, nullptr, nullptr, napi_default, nullptr },
         { "setHostPacedPresentationEnabled", nullptr, MoonBridge_SetHostPacedPresentationEnabled, nullptr, nullptr, nullptr, napi_default, nullptr },
-        // Compatibility alias for builds that persisted PR #58's experimental setting.
-        { "setTwoStepPreciseSyncEnabled", nullptr, MoonBridge_SetHostPacedPresentationEnabled, nullptr, nullptr, nullptr, napi_default, nullptr },
         { "setVrrEnabled", nullptr, MoonBridge_SetVrrEnabled, nullptr, nullptr, nullptr, napi_default, nullptr },
         { "setPostProcessEnabled", nullptr, MoonBridge_SetPostProcessEnabled, nullptr, nullptr, nullptr, napi_default, nullptr },
         { "setUpscaleMode", nullptr, MoonBridge_SetUpscaleMode, nullptr, nullptr, nullptr, napi_default, nullptr },

--- a/nativelib/src/main/cpp/native_render.cpp
+++ b/nativelib/src/main/cpp/native_render.cpp
@@ -127,7 +127,6 @@ void NativeRender::ReleaseInstance() {
 
 NativeRender::NativeRender() {
     OH_LOG_INFO(LOG_APP, "NativeRender created");
-    lastFrameTime_ = std::chrono::steady_clock::now();
 }
 
 NativeRender::~NativeRender() {
@@ -527,6 +526,5 @@ OH_AVErrCode NativeRender::SubmitFrame(const DecodedFrame& frame) {
         OH_LOG_WARN(LOG_APP, "RenderOutputBuffer failed: %{public}d; freeing output", renderResult);
         freeFrame();
     }
-    lastFrameTime_ = std::chrono::steady_clock::now();
     return renderResult;
 }

--- a/nativelib/src/main/cpp/native_render.cpp
+++ b/nativelib/src/main/cpp/native_render.cpp
@@ -399,12 +399,12 @@ void NativeRender::ApplyFrameRateRange() {
 // =============================================================================
 
 void NativeRender::ResetPresentationClockLocked() {
-    pendingPresentTargets_.clear();
     timeBaseInitialized_ = false;
     estimatedOffsetNs_ = 0;
     skewNs_ = 0;
     jitterEstNs_ = 0.0;
     lastPtsUs_ = 0;
+    lastScheduledPresentNs_ = 0;
 }
 
 void NativeRender::ResetPresentationClock() {
@@ -421,7 +421,6 @@ int64_t NativeRender::CalculatePresentTargetLocked(int64_t pts, int64_t nowNs, b
 
     if (!timeBaseInitialized_ || discontinuity) {
         if (discontinuity) {
-            pendingPresentTargets_.clear();
             vsyncResyncCount_++;
         }
         estimatedOffsetNs_ = instOffset;
@@ -454,35 +453,20 @@ int64_t NativeRender::CalculatePresentTargetLocked(int64_t pts, int64_t nowNs, b
         vsyncLateFrameCount_++;
     }
 
-    if (++vsyncFrameCount_ % 6000 == 0) {
+    const int64_t statsPeriod = twoStep ? 600 : 6000;
+    if (++vsyncFrameCount_ % statsPeriod == 0) {
+        const int64_t vsyncPeriodUs =
+            g_vsyncPeriodNs.load(std::memory_order_acquire) / 1000;
         OH_LOG_INFO(LOG_APP,
-            "VSync clock stats: mode=%{public}s, frames=%{public}lld, late=%{public}lld, resync=%{public}lld, hit=%{public}lld, fallback=%{public}lld, pending=%{public}zu, cushion=%{public}lldus",
+            "VSync clock stats: mode=%{public}s, frames=%{public}lld, late=%{public}lld, resync=%{public}lld, hit=%{public}lld, fallback=%{public}lld, sameSlot=%{public}lld, period=%{public}lldus, cushion=%{public}lldus",
             twoStep ? "two-step" : "baseline",
             static_cast<long long>(vsyncFrameCount_), static_cast<long long>(vsyncLateFrameCount_),
             static_cast<long long>(vsyncResyncCount_), static_cast<long long>(twoStepHitCount_),
-            static_cast<long long>(twoStepFallbackCount_), pendingPresentTargets_.size(),
+            static_cast<long long>(twoStepFallbackCount_), static_cast<long long>(twoStepSameSlotCount_),
+            static_cast<long long>(vsyncPeriodUs),
             static_cast<long long>(cushionNs / 1000));
     }
     return targetNs;
-}
-
-void NativeRender::PrepareFrame(int64_t pts) {
-    if (!twoStepPreciseSyncEnabled_.load()) {
-        return;
-    }
-
-    RequestVsyncSample();
-    const int64_t nowNs = GetMonotonicTimeNs();
-    std::lock_guard<std::mutex> lock(presentationMutex_);
-    pendingPresentTargets_[pts] = CalculatePresentTargetLocked(pts, nowNs, true);
-    while (pendingPresentTargets_.size() > kMaxPendingPresentTargets) {
-        pendingPresentTargets_.erase(pendingPresentTargets_.begin());
-    }
-}
-
-void NativeRender::DiscardFrame(int64_t pts) {
-    std::lock_guard<std::mutex> lock(presentationMutex_);
-    pendingPresentTargets_.erase(pts);
 }
 
 int64_t NativeRender::SnapTargetToVsync(int64_t targetNs, int64_t nowNs) const {
@@ -525,7 +509,6 @@ OH_AVErrCode NativeRender::SubmitFrame(OH_AVCodec* codec, uint32_t bufferIndex, 
         PFN_RenderOutputBufferAtTime renderAtTime = GetRenderAtTimeFunc();
         if (renderAtTime == nullptr) {
             if (twoStepPreciseSyncEnabled_.load()) {
-                DiscardFrame(pts);
                 noteFallback();
             }
             renderResult = renderImmediately();
@@ -542,44 +525,42 @@ OH_AVErrCode NativeRender::SubmitFrame(OH_AVCodec* codec, uint32_t bufferIndex, 
                 renderResult = renderImmediately();
             }
         } else {
-            int64_t targetNs = 0;
-            bool foundTarget = false;
+            RequestVsyncSample();
+            const int64_t nowNs = GetMonotonicTimeNs();
+            int64_t targetNs;
             {
                 std::lock_guard<std::mutex> lock(presentationMutex_);
-                auto it = pendingPresentTargets_.find(pts);
-                if (it != pendingPresentTargets_.end()) {
-                    targetNs = it->second;
-                    pendingPresentTargets_.erase(it);
-                    foundTarget = true;
-                }
+                // step1 必须在解码输出到达时采样，目标才包含解码和排队耗时。
+                targetNs = CalculatePresentTargetLocked(pts, nowNs, true);
             }
 
-            if (!foundTarget) {
+            // step2 只负责把已恢复的 host 节奏落到本地显示槽。
+            const int64_t presentTimeNs = SnapTargetToVsync(targetNs, nowNs);
+            const int64_t frameIntervalNs = configuredFps_ > 0 ?
+                1000000000LL / configuredFps_ : 16666667LL;
+            const int64_t timeUntilPresentNs = presentTimeNs - nowNs;
+
+            if (timeUntilPresentNs < 0 || timeUntilPresentNs > frameIntervalNs * 3) {
                 noteFallback();
+                ResetPresentationClock();
                 renderResult = renderImmediately();
             } else {
-                const int64_t nowNs = GetMonotonicTimeNs();
-                const int64_t presentTimeNs = SnapTargetToVsync(targetNs, nowNs);
-                const int64_t frameIntervalNs = configuredFps_ > 0 ?
-                    1000000000LL / configuredFps_ : 16666667LL;
-                const int64_t timeUntilPresentNs = presentTimeNs - nowNs;
-
-                if (timeUntilPresentNs < 0 || timeUntilPresentNs > frameIntervalNs * 3) {
-                    noteFallback();
-                    ResetPresentationClock();
-                    renderResult = renderImmediately();
-                } else {
-                    renderResult = renderAtTime(codec, bufferIndex, presentTimeNs);
-                    if (renderResult == AV_ERR_OK) {
-                        std::lock_guard<std::mutex> lock(presentationMutex_);
-                        twoStepHitCount_++;
-                    } else {
-                        OH_LOG_WARN(LOG_APP,
-                            "RenderOutputBufferAtTime failed: %{public}d, pts=%{public}lld, presentNs=%{public}lld; falling back",
-                            renderResult, static_cast<long long>(pts), static_cast<long long>(presentTimeNs));
-                        noteFallback();
-                        renderResult = renderImmediately();
+                renderResult = renderAtTime(codec, bufferIndex, presentTimeNs);
+                if (renderResult == AV_ERR_OK) {
+                    std::lock_guard<std::mutex> lock(presentationMutex_);
+                    if (lastScheduledPresentNs_ >= nowNs && presentTimeNs <= lastScheduledPresentNs_) {
+                        twoStepSameSlotCount_++;
                     }
+                    if (presentTimeNs > lastScheduledPresentNs_) {
+                        lastScheduledPresentNs_ = presentTimeNs;
+                    }
+                    twoStepHitCount_++;
+                } else {
+                    OH_LOG_WARN(LOG_APP,
+                        "RenderOutputBufferAtTime failed: %{public}d, pts=%{public}lld, presentNs=%{public}lld; falling back",
+                        renderResult, static_cast<long long>(pts), static_cast<long long>(presentTimeNs));
+                    noteFallback();
+                    renderResult = renderImmediately();
                 }
             }
         }

--- a/nativelib/src/main/cpp/native_render.cpp
+++ b/nativelib/src/main/cpp/native_render.cpp
@@ -453,8 +453,7 @@ int64_t NativeRender::CalculatePresentTargetLocked(int64_t pts, int64_t nowNs, b
         vsyncLateFrameCount_++;
     }
 
-    const int64_t statsPeriod = twoStep ? 600 : 6000;
-    if (++vsyncFrameCount_ % statsPeriod == 0) {
+    if (++vsyncFrameCount_ % 6000 == 0) {
         const int64_t vsyncPeriodUs =
             g_vsyncPeriodNs.load(std::memory_order_acquire) / 1000;
         OH_LOG_INFO(LOG_APP,

--- a/nativelib/src/main/cpp/native_render.cpp
+++ b/nativelib/src/main/cpp/native_render.cpp
@@ -30,11 +30,11 @@
 #undef LOG_TAG
 #define LOG_TAG "NativeRender"
 
-// RenderOutputBufferAtTime 是 API 14+ 的函数，低版本设备不存在
+// RenderOutputBufferAtTime 是 API 12+ 的函数，旧设备或不完整运行时可能不存在
 // 通过 dlsym 动态加载，避免硬依赖
 typedef OH_AVErrCode (*PFN_RenderOutputBufferAtTime)(OH_AVCodec*, uint32_t, int64_t);
 static PFN_RenderOutputBufferAtTime g_pfnRenderAtTime = nullptr;
-static bool g_renderAtTimeChecked = false;
+static std::once_flag g_renderAtTimeOnce;
 
 static int64_t GetMonotonicTimeNs() {
     struct timespec ts;
@@ -43,8 +43,7 @@ static int64_t GetMonotonicTimeNs() {
 }
 
 static PFN_RenderOutputBufferAtTime GetRenderAtTimeFunc() {
-    if (!g_renderAtTimeChecked) {
-        g_renderAtTimeChecked = true;
+    std::call_once(g_renderAtTimeOnce, [] {
         g_pfnRenderAtTime = (PFN_RenderOutputBufferAtTime)
             dlsym(RTLD_DEFAULT, "OH_VideoDecoder_RenderOutputBufferAtTime");
         // RTLD_DEFAULT 可能在某些设备上找不到（如 API 22），回退到显式 dlopen
@@ -55,7 +54,7 @@ static PFN_RenderOutputBufferAtTime GetRenderAtTimeFunc() {
                     dlsym(handle, "OH_VideoDecoder_RenderOutputBufferAtTime");
             }
         }
-    }
+    });
     return g_pfnRenderAtTime;
 }
 
@@ -185,7 +184,7 @@ void NativeRender::SetNativeWindow(OHNativeWindow* window, uint64_t width, uint6
         
         // 如果帧率已配置，立即应用帧率范围
         // 这处理 SetConfiguredFps 在 SetNativeWindow 之前调用的情况
-        if (configuredFps_ > 0) {
+        if (configuredFps_.load() > 0) {
             ApplyFrameRateRange();
         }
         
@@ -200,14 +199,13 @@ void NativeRender::SetNativeWindow(OHNativeWindow* window, uint64_t width, uint6
 }
 
 void NativeRender::SetConfiguredFps(double fps) {
-    configuredFps_ = fps;
-    OH_LOG_INFO(LOG_APP, "Configured FPS set to: %.3f", fps);
-
     {
         std::lock_guard<std::mutex> lock(presentationMutex_);
+        configuredFps_.store(fps);
         ptsScheduler_.Configure(fps);
         ResetPresentationClockLocked();
     }
+    OH_LOG_INFO(LOG_APP, "Configured FPS set to: %.3f", fps);
     
     // 应用帧率范围（NativeVSync 层）
     ApplyFrameRateRange();
@@ -238,6 +236,14 @@ void NativeRender::SetHostPacedPresentationEnabled(bool enable) {
         }
         OH_LOG_INFO(LOG_APP, "Host-paced presentation %{public}s", enable ? "enabled" : "disabled");
     }
+    if (enable && GetRenderAtTimeFunc() == nullptr) {
+        OH_LOG_WARN(LOG_APP,
+            "Host-paced presentation unavailable; keeping decoder low-latency policies active");
+    }
+}
+
+bool NativeRender::IsHostPacedPresentationActive() const {
+    return hostPacedPresentationEnabled_.load() && GetRenderAtTimeFunc() != nullptr;
 }
 
 void NativeRender::ConfigureNativeWindow() {
@@ -252,7 +258,7 @@ void NativeRender::ConfigureNativeWindow() {
     }
     
     // 如果帧率已配置，立即在 NativeWindow 层设置帧率偏好
-    if (configuredFps_ > 60) {
+    if (configuredFps_.load() > 60) {
         ApplyNativeWindowFrameRate();
     }
 }
@@ -298,7 +304,8 @@ static bool CheckAndLoadNWFrameRateApi() {
 }
 
 void NativeRender::ApplyNativeWindowFrameRate() {
-    if (window_ == nullptr || configuredFps_ <= 60) {
+    const double configuredFps = configuredFps_.load();
+    if (window_ == nullptr || configuredFps <= 60) {
         return;
     }
     
@@ -307,7 +314,7 @@ void NativeRender::ApplyNativeWindowFrameRate() {
     }
     
     // strategy = 0 (DEFAULT): 让系统根据能力选择最佳刷新率
-    const int fps = static_cast<int>(configuredFps_ + 0.5);
+    const int fps = static_cast<int>(configuredFps + 0.5);
     int32_t ret = g_pfnNWSetFrameRateRange(window_, fps, fps, fps, 0);
     if (ret == 0) {
         OH_LOG_INFO(LOG_APP, "NativeWindow FrameRateRange set to %{public}d fps (Surface level)", fps);
@@ -328,7 +335,7 @@ void NativeRender::ApplyFrameRateRange() {
 
     if (CheckAndLoadApi20()) {
         OH_NativeVSync_ExpectedRateRange range;
-        const int fps = static_cast<int>(configuredFps_ + 0.5);
+        const int fps = static_cast<int>(configuredFps_.load() + 0.5);
         range.min = fps;
         range.max = fps;
         range.expected = fps;
@@ -378,8 +385,9 @@ void NativeRender::ResetPresentationClock() {
 int64_t NativeRender::CalculateLegacyPresentTargetLocked(int64_t pts, int64_t nowNs) {
     const int64_t hostNs = pts * 1000LL;
     const int64_t instOffset = nowNs - hostNs;
-    const int64_t frameIntervalNs = configuredFps_ > 0.0 ?
-        static_cast<int64_t>(1000000000.0 / configuredFps_) : 16666667LL;
+    const double configuredFps = configuredFps_.load();
+    const int64_t frameIntervalNs = configuredFps > 0.0 ?
+        static_cast<int64_t>(1000000000.0 / configuredFps) : 16666667LL;
     const bool discontinuity = timeBaseInitialized_ &&
         (pts < lastPtsUs_ || (pts - lastPtsUs_) > 2000000LL);
 
@@ -432,12 +440,16 @@ int64_t NativeRender::CalculateLegacyPresentTargetLocked(int64_t pts, int64_t no
 // 帧渲染
 // =============================================================================
 
-OH_AVErrCode NativeRender::SubmitFrame(const DecodedFrame& frame) {
+NativeRender::FrameSubmitResult NativeRender::SubmitFrame(const DecodedFrame& frame) {
     bool bufferConsumed = false;
-    auto renderImmediately = [&frame, &bufferConsumed]() {
+    bool framePresented = false;
+    auto renderImmediately = [&frame, &bufferConsumed, &framePresented]() {
         const OH_AVErrCode result =
             OH_VideoDecoder_RenderOutputBuffer(frame.codec, frame.bufferIndex);
-        if (result == AV_ERR_OK) bufferConsumed = true;
+        if (result == AV_ERR_OK) {
+            bufferConsumed = true;
+            framePresented = true;
+        }
         return result;
     };
     auto freeFrame = [&frame, &bufferConsumed]() {
@@ -457,19 +469,21 @@ OH_AVErrCode NativeRender::SubmitFrame(const DecodedFrame& frame) {
         if (renderAtTime == nullptr) {
             renderResult = renderImmediately();
         } else if (!hostPacedPresentationEnabled_.load()) {
-            const int64_t nowNs = frame.decodedAtNs > 0 ? frame.decodedAtNs : GetMonotonicTimeNs();
+            const int64_t nowNs = GetMonotonicTimeNs();
             int64_t presentTimeNs;
             {
                 std::lock_guard<std::mutex> lock(presentationMutex_);
                 presentTimeNs = CalculateLegacyPresentTargetLocked(frame.ptsUs, nowNs);
             }
             renderResult = renderAtTime(frame.codec, frame.bufferIndex, presentTimeNs);
-            if (renderResult != AV_ERR_OK) {
+            if (renderResult == AV_ERR_OK) {
+                bufferConsumed = true;
+                framePresented = true;
+            } else {
                 renderResult = renderImmediately();
             }
         } else {
-            const int64_t decodedAtNs = frame.decodedAtNs > 0 ?
-                frame.decodedAtNs : GetMonotonicTimeNs();
+            const int64_t decodedAtNs = GetMonotonicTimeNs();
             PresentationPlan plan;
             {
                 std::lock_guard<std::mutex> lock(presentationMutex_);
@@ -482,7 +496,10 @@ OH_AVErrCode NativeRender::SubmitFrame(const DecodedFrame& frame) {
                 if (plan.latenessNs > 0) preciseLateCount_++;
                 if (plan.event == PresentationEvent::PHASE_SHIFT) precisePhaseShiftCount_++;
                 if (plan.event == PresentationEvent::REBUFFER) preciseRebufferCount_++;
-                if (plan.event == PresentationEvent::DISCONTINUITY) preciseResyncCount_++;
+                if (plan.event == PresentationEvent::DISCONTINUITY ||
+                    plan.event == PresentationEvent::DUPLICATE_PTS) {
+                    preciseResyncCount_++;
+                }
 
                 const int64_t totalFrames = preciseScheduledCount_ + preciseDroppedCount_;
                 if (totalFrames % 6000 == 0) {
@@ -507,6 +524,7 @@ OH_AVErrCode NativeRender::SubmitFrame(const DecodedFrame& frame) {
                     frame.codec, frame.bufferIndex, plan.targetTimeNs);
                 if (renderResult == AV_ERR_OK) {
                     bufferConsumed = true;
+                    framePresented = true;
                 } else {
                     {
                         std::lock_guard<std::mutex> lock(presentationMutex_);
@@ -526,5 +544,5 @@ OH_AVErrCode NativeRender::SubmitFrame(const DecodedFrame& frame) {
         OH_LOG_WARN(LOG_APP, "RenderOutputBuffer failed: %{public}d; freeing output", renderResult);
         freeFrame();
     }
-    return renderResult;
+    return {renderResult, framePresented};
 }

--- a/nativelib/src/main/cpp/native_render.cpp
+++ b/nativelib/src/main/cpp/native_render.cpp
@@ -191,6 +191,7 @@ void NativeRender::ReleaseNativeVSync() {
 
     OH_NativeVSync_Destroy(nativeVSync_);
     nativeVSync_ = nullptr;
+    lastVsyncRequestFailureLogNs_ = 0;
     g_lastVsyncTimestampNs.store(0, std::memory_order_release);
     g_vsyncPeriodNs.store(0, std::memory_order_release);
     OH_LOG_INFO(LOG_APP, "NativeVSync destroyed");
@@ -213,7 +214,13 @@ void NativeRender::RequestVsyncSample() {
 
     int32_t ret = OH_NativeVSync_RequestFrame(nativeVSync_, OnNativeVsync, nullptr);
     if (ret != 0) {
-        OH_LOG_DEBUG(LOG_APP, "NativeVSync sample request failed: %{public}d", ret);
+        constexpr int64_t kFailureLogIntervalNs = 10000000000LL;
+        const int64_t nowNs = GetMonotonicTimeNs();
+        if (lastVsyncRequestFailureLogNs_ == 0 ||
+            nowNs - lastVsyncRequestFailureLogNs_ >= kFailureLogIntervalNs) {
+            lastVsyncRequestFailureLogNs_ = nowNs;
+            OH_LOG_DEBUG(LOG_APP, "NativeVSync sample request failed: %{public}d", ret);
+        }
     }
 }
 
@@ -266,7 +273,11 @@ void NativeRender::SetConfiguredFps(int fps) {
 void NativeRender::SetVsyncEnabled(bool enable) {
     bool wasEnabled = vsyncEnabled_.exchange(enable);
     if (wasEnabled != enable) {
-        ResetPresentationClock();
+        {
+            std::lock_guard<std::mutex> lock(presentationMutex_);
+            ResetPresentationClockLocked();
+            ResetPresentationStatsLocked();
+        }
         if (enable && twoStepPreciseSyncEnabled_.load()) {
             RequestVsyncSample();
         }
@@ -277,7 +288,11 @@ void NativeRender::SetVsyncEnabled(bool enable) {
 void NativeRender::SetTwoStepPreciseSyncEnabled(bool enable) {
     bool wasEnabled = twoStepPreciseSyncEnabled_.exchange(enable);
     if (wasEnabled != enable) {
-        ResetPresentationClock();
+        {
+            std::lock_guard<std::mutex> lock(presentationMutex_);
+            ResetPresentationClockLocked();
+            ResetPresentationStatsLocked();
+        }
         if (enable) {
             RequestVsyncSample();
         }
@@ -407,29 +422,44 @@ void NativeRender::ResetPresentationClockLocked() {
     lastScheduledPresentNs_ = 0;
 }
 
+void NativeRender::ResetPresentationStatsLocked() {
+    vsyncFrameCount_ = 0;
+    vsyncLateFrameCount_ = 0;
+    vsyncResyncCount_ = 0;
+    twoStepHitCount_ = 0;
+    twoStepFallbackCount_ = 0;
+    twoStepSameSlotCount_ = 0;
+    twoStepDrainReanchorCount_ = 0;
+}
+
 void NativeRender::ResetPresentationClock() {
     std::lock_guard<std::mutex> lock(presentationMutex_);
     ResetPresentationClockLocked();
 }
 
-int64_t NativeRender::CalculatePresentTargetLocked(int64_t pts, int64_t nowNs, bool twoStep) {
+int64_t NativeRender::CalculatePresentTargetLocked(int64_t pts, int64_t nowNs, bool twoStep,
+                                                   bool forceReanchor) {
     const int64_t hostNs = pts * 1000LL;
     const int64_t instOffset = nowNs - hostNs;
     const int64_t frameIntervalNs = configuredFps_ > 0 ? 1000000000LL / configuredFps_ : 16666667LL;
     const bool discontinuity = timeBaseInitialized_ &&
         (pts < lastPtsUs_ || (pts - lastPtsUs_) > 2000000LL);
 
-    if (!timeBaseInitialized_ || discontinuity) {
-        if (discontinuity) {
+    if (forceReanchor || !timeBaseInitialized_ || discontinuity) {
+        if (forceReanchor) {
+            twoStepDrainReanchorCount_++;
+        } else if (discontinuity) {
             vsyncResyncCount_++;
         }
         estimatedOffsetNs_ = instOffset;
         skewNs_ = 0;
         jitterEstNs_ = static_cast<double>(frameIntervalNs) / 16.0;
         timeBaseInitialized_ = true;
-        OH_LOG_INFO(LOG_APP, "VSync clock (re)anchored: offset=%{public}lldus, pts=%{public}lldus%{public}s",
-                    static_cast<long long>(estimatedOffsetNs_ / 1000),
-                    static_cast<long long>(pts), discontinuity ? " [discontinuity]" : "");
+        if (!forceReanchor) {
+            OH_LOG_INFO(LOG_APP, "VSync clock (re)anchored: offset=%{public}lldus, pts=%{public}lldus%{public}s",
+                        static_cast<long long>(estimatedOffsetNs_ / 1000),
+                        static_cast<long long>(pts), discontinuity ? " [discontinuity]" : "");
+        }
     } else {
         const int64_t pred = estimatedOffsetNs_ + skewNs_;
         const int64_t e = instOffset - pred;
@@ -457,11 +487,12 @@ int64_t NativeRender::CalculatePresentTargetLocked(int64_t pts, int64_t nowNs, b
         const int64_t vsyncPeriodUs =
             g_vsyncPeriodNs.load(std::memory_order_acquire) / 1000;
         OH_LOG_INFO(LOG_APP,
-            "VSync clock stats: mode=%{public}s, frames=%{public}lld, late=%{public}lld, resync=%{public}lld, hit=%{public}lld, fallback=%{public}lld, sameSlot=%{public}lld, period=%{public}lldus, cushion=%{public}lldus",
+            "VSync clock stats: mode=%{public}s, frames=%{public}lld, late=%{public}lld, resync=%{public}lld, hit=%{public}lld, fallback=%{public}lld, sameSlot=%{public}lld, drainReanchor=%{public}lld, period=%{public}lldus, cushion=%{public}lldus",
             twoStep ? "two-step" : "baseline",
             static_cast<long long>(vsyncFrameCount_), static_cast<long long>(vsyncLateFrameCount_),
             static_cast<long long>(vsyncResyncCount_), static_cast<long long>(twoStepHitCount_),
             static_cast<long long>(twoStepFallbackCount_), static_cast<long long>(twoStepSameSlotCount_),
+            static_cast<long long>(twoStepDrainReanchorCount_),
             static_cast<long long>(vsyncPeriodUs),
             static_cast<long long>(cushionNs / 1000));
     }
@@ -492,7 +523,8 @@ int64_t NativeRender::SnapTargetToVsync(int64_t targetNs, int64_t nowNs) const {
 // 帧渲染
 // =============================================================================
 
-OH_AVErrCode NativeRender::SubmitFrame(OH_AVCodec* codec, uint32_t bufferIndex, int64_t pts) {
+OH_AVErrCode NativeRender::SubmitFrame(OH_AVCodec* codec, uint32_t bufferIndex, int64_t pts,
+                                       bool drainToLatest) {
     auto renderImmediately = [codec, bufferIndex]() {
         return OH_VideoDecoder_RenderOutputBuffer(codec, bufferIndex);
     };
@@ -524,17 +556,24 @@ OH_AVErrCode NativeRender::SubmitFrame(OH_AVCodec* codec, uint32_t bufferIndex, 
                 renderResult = renderImmediately();
             }
         } else {
-            RequestVsyncSample();
             const int64_t nowNs = GetMonotonicTimeNs();
+            RequestVsyncSample();
             int64_t targetNs;
             {
                 std::lock_guard<std::mutex> lock(presentationMutex_);
                 // step1 必须在解码输出到达时采样，目标才包含解码和排队耗时。
-                targetNs = CalculatePresentTargetLocked(pts, nowNs, true);
+                targetNs = CalculatePresentTargetLocked(pts, nowNs, true, drainToLatest);
             }
 
             // step2 只负责把已恢复的 host 节奏落到本地显示槽。
-            const int64_t presentTimeNs = SnapTargetToVsync(targetNs, nowNs);
+            int64_t presentTimeNs = SnapTargetToVsync(targetNs, nowNs);
+            if (drainToLatest) {
+                std::lock_guard<std::mutex> lock(presentationMutex_);
+                // Surface 按提交顺序处理；已有未来帧时让最新帧进入同槽覆盖，避免倒序时间戳。
+                if (lastScheduledPresentNs_ >= nowNs && presentTimeNs < lastScheduledPresentNs_) {
+                    presentTimeNs = lastScheduledPresentNs_;
+                }
+            }
             const int64_t frameIntervalNs = configuredFps_ > 0 ?
                 1000000000LL / configuredFps_ : 16666667LL;
             const int64_t timeUntilPresentNs = presentTimeNs - nowNs;

--- a/nativelib/src/main/cpp/native_render.cpp
+++ b/nativelib/src/main/cpp/native_render.cpp
@@ -36,22 +36,6 @@ typedef OH_AVErrCode (*PFN_RenderOutputBufferAtTime)(OH_AVCodec*, uint32_t, int6
 static PFN_RenderOutputBufferAtTime g_pfnRenderAtTime = nullptr;
 static bool g_renderAtTimeChecked = false;
 
-// VSync 回调只写入进程级原子状态，避免 Surface 销毁时回调持有悬空对象。
-static std::atomic<int64_t> g_lastVsyncTimestampNs{0};
-static std::atomic<int64_t> g_vsyncPeriodNs{0};
-static std::atomic<bool> g_vsyncRequestPending{false};
-
-static constexpr int64_t kVsyncSampleRefreshPeriods = 2;
-static constexpr int64_t kVsyncPeriodRefreshIntervalNs = 250000000LL;
-
-static void OnNativeVsync(long long timestamp, void* data) {
-    (void)data;
-    if (timestamp > 0) {
-        g_lastVsyncTimestampNs.store(static_cast<int64_t>(timestamp), std::memory_order_release);
-    }
-    g_vsyncRequestPending.store(false, std::memory_order_release);
-}
-
 static int64_t GetMonotonicTimeNs() {
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);
@@ -158,37 +142,17 @@ NativeRender::~NativeRender() {
 // =============================================================================
 
 void NativeRender::InitNativeVSync() {
-    bool created = false;
-    {
-        std::lock_guard<std::mutex> lock(nativeVsyncMutex_);
-        if (nativeVSync_ != nullptr) {
-            return;
-        }
-
-        const char* name = "moonlight_render";
-        nativeVSync_ = OH_NativeVSync_Create(name, strlen(name));
-        if (nativeVSync_ != nullptr) {
-            long long periodNs = 0;
-            const bool periodAvailable =
-                OH_NativeVSync_GetPeriod(nativeVSync_, &periodNs) == 0 && periodNs > 0;
-            if (!periodAvailable) {
-                const int fps = configuredFps_ > 0 ? configuredFps_ : 60;
-                periodNs = 1000000000LL / fps;
-                OH_LOG_WARN(LOG_APP,
-                    "NativeVSync period unavailable; using %{public}d FPS fallback", fps);
-            }
-            g_vsyncPeriodNs.store(static_cast<int64_t>(periodNs), std::memory_order_release);
-            lastVsyncPeriodQueryNs_ = periodAvailable ? GetMonotonicTimeNs() : 0;
-            g_vsyncRequestPending.store(false, std::memory_order_release);
-            created = true;
-            OH_LOG_INFO(LOG_APP, "NativeVSync created successfully, period=%{public}lldns", periodNs);
-        } else {
-            OH_LOG_WARN(LOG_APP, "Failed to create NativeVSync");
-        }
+    std::lock_guard<std::mutex> lock(nativeVsyncMutex_);
+    if (nativeVSync_ != nullptr) {
+        return;
     }
 
-    if (created && twoStepPreciseSyncEnabled_.load()) {
-        RequestVsyncSample();
+    const char* name = "moonlight_render";
+    nativeVSync_ = OH_NativeVSync_Create(name, strlen(name));
+    if (nativeVSync_ != nullptr) {
+        OH_LOG_INFO(LOG_APP, "NativeVSync created successfully");
+    } else {
+        OH_LOG_WARN(LOG_APP, "Failed to create NativeVSync");
     }
 }
 
@@ -200,62 +164,7 @@ void NativeRender::ReleaseNativeVSync() {
 
     OH_NativeVSync_Destroy(nativeVSync_);
     nativeVSync_ = nullptr;
-    lastVsyncRequestFailureLogNs_ = 0;
-    g_lastVsyncTimestampNs.store(0, std::memory_order_release);
-    g_vsyncPeriodNs.store(0, std::memory_order_release);
-    g_vsyncRequestPending.store(false, std::memory_order_release);
-    lastVsyncPeriodQueryNs_ = 0;
     OH_LOG_INFO(LOG_APP, "NativeVSync destroyed");
-}
-
-void NativeRender::RequestVsyncSample() {
-    bool expected = false;
-    if (!g_vsyncRequestPending.compare_exchange_strong(
-            expected, true, std::memory_order_acq_rel, std::memory_order_acquire)) {
-        return;
-    }
-
-    std::lock_guard<std::mutex> lock(nativeVsyncMutex_);
-    if (nativeVSync_ == nullptr) {
-        g_vsyncRequestPending.store(false, std::memory_order_release);
-        return;
-    }
-
-    // GetPeriod takes the VSync receiver lock. Poll it at most once per second
-    // to retain refresh-rate switch handling without doing it for every frame.
-    const int64_t nowNs = GetMonotonicTimeNs();
-    const bool periodRefreshDue = lastVsyncPeriodQueryNs_ == 0 ||
-        nowNs - lastVsyncPeriodQueryNs_ >= kVsyncPeriodRefreshIntervalNs;
-    if (periodRefreshDue && g_lastVsyncTimestampNs.load(std::memory_order_acquire) > 0) {
-        long long periodNs = 0;
-        if (OH_NativeVSync_GetPeriod(nativeVSync_, &periodNs) == 0 && periodNs > 0) {
-            g_vsyncPeriodNs.store(static_cast<int64_t>(periodNs), std::memory_order_release);
-        }
-        lastVsyncPeriodQueryNs_ = nowNs;
-    }
-
-    int32_t ret = OH_NativeVSync_RequestFrame(nativeVSync_, OnNativeVsync, nullptr);
-    if (ret != 0) {
-        g_vsyncRequestPending.store(false, std::memory_order_release);
-        constexpr int64_t kFailureLogIntervalNs = 10000000000LL;
-        if (lastVsyncRequestFailureLogNs_ == 0 ||
-            nowNs - lastVsyncRequestFailureLogNs_ >= kFailureLogIntervalNs) {
-            lastVsyncRequestFailureLogNs_ = nowNs;
-            OH_LOG_DEBUG(LOG_APP, "NativeVSync sample request failed: %{public}d", ret);
-        }
-    }
-}
-
-void NativeRender::MaybeRequestVsyncSample(int64_t nowNs) {
-    const int64_t phaseNs = g_lastVsyncTimestampNs.load(std::memory_order_acquire);
-    const int64_t periodNs = g_vsyncPeriodNs.load(std::memory_order_acquire);
-    if (phaseNs > 0 && periodNs > 0) {
-        const int64_t phaseAgeNs = nowNs - phaseNs;
-        if (phaseAgeNs >= -periodNs && phaseAgeNs < periodNs * kVsyncSampleRefreshPeriods) {
-            return;
-        }
-    }
-    RequestVsyncSample();
 }
 
 // =============================================================================
@@ -291,11 +200,15 @@ void NativeRender::SetNativeWindow(OHNativeWindow* window, uint64_t width, uint6
     }
 }
 
-void NativeRender::SetConfiguredFps(int fps) {
+void NativeRender::SetConfiguredFps(double fps) {
     configuredFps_ = fps;
-    OH_LOG_INFO(LOG_APP, "Configured FPS set to: %{public}d", fps);
+    OH_LOG_INFO(LOG_APP, "Configured FPS set to: %.3f", fps);
 
-    ResetPresentationClock();
+    {
+        std::lock_guard<std::mutex> lock(presentationMutex_);
+        ptsScheduler_.Configure(fps);
+        ResetPresentationClockLocked();
+    }
     
     // 应用帧率范围（NativeVSync 层）
     ApplyFrameRateRange();
@@ -312,25 +225,19 @@ void NativeRender::SetVsyncEnabled(bool enable) {
             ResetPresentationClockLocked();
             ResetPresentationStatsLocked();
         }
-        if (enable && twoStepPreciseSyncEnabled_.load()) {
-            RequestVsyncSample();
-        }
         OH_LOG_INFO(LOG_APP, "VSync mode %{public}s", enable ? "enabled" : "disabled");
     }
 }
 
-void NativeRender::SetTwoStepPreciseSyncEnabled(bool enable) {
-    bool wasEnabled = twoStepPreciseSyncEnabled_.exchange(enable);
+void NativeRender::SetHostPacedPresentationEnabled(bool enable) {
+    bool wasEnabled = hostPacedPresentationEnabled_.exchange(enable);
     if (wasEnabled != enable) {
         {
             std::lock_guard<std::mutex> lock(presentationMutex_);
             ResetPresentationClockLocked();
             ResetPresentationStatsLocked();
         }
-        if (enable) {
-            RequestVsyncSample();
-        }
-        OH_LOG_INFO(LOG_APP, "Two-step precise sync %{public}s", enable ? "enabled" : "disabled");
+        OH_LOG_INFO(LOG_APP, "Host-paced presentation %{public}s", enable ? "enabled" : "disabled");
     }
 }
 
@@ -401,12 +308,13 @@ void NativeRender::ApplyNativeWindowFrameRate() {
     }
     
     // strategy = 0 (DEFAULT): 让系统根据能力选择最佳刷新率
-    int32_t ret = g_pfnNWSetFrameRateRange(window_, configuredFps_, configuredFps_, configuredFps_, 0);
+    const int fps = static_cast<int>(configuredFps_ + 0.5);
+    int32_t ret = g_pfnNWSetFrameRateRange(window_, fps, fps, fps, 0);
     if (ret == 0) {
-        OH_LOG_INFO(LOG_APP, "NativeWindow FrameRateRange set to %{public}d fps (Surface level)", configuredFps_);
+        OH_LOG_INFO(LOG_APP, "NativeWindow FrameRateRange set to %{public}d fps (Surface level)", fps);
     } else {
         OH_LOG_WARN(LOG_APP, "NativeWindow SetFrameRateRange failed: ret=%{public}d, fps=%{public}d", 
-                    ret, configuredFps_);
+                    ret, fps);
     }
 }
 
@@ -421,52 +329,46 @@ void NativeRender::ApplyFrameRateRange() {
 
     if (CheckAndLoadApi20()) {
         OH_NativeVSync_ExpectedRateRange range;
-        range.min = configuredFps_;
-        range.max = configuredFps_;
-        range.expected = configuredFps_;
+        const int fps = static_cast<int>(configuredFps_ + 0.5);
+        range.min = fps;
+        range.max = fps;
+        range.expected = fps;
         
         int32_t ret = g_pfnSetExpectedFrameRateRange(nativeVSync_, &range);
         if (ret == 0) {
             OH_LOG_INFO(LOG_APP, "NativeVSync FrameRateRange set to fixed %{public}d fps",
-                        configuredFps_);
+                        fps);
         } else {
             OH_LOG_WARN(LOG_APP, "Failed to set NativeVSync FrameRateRange to %{public}d: ret=%{public}d", 
-                        configuredFps_, ret);
+                        fps, ret);
         }
     }
-
-    long long periodNs = 0;
-    const bool periodAvailable =
-        OH_NativeVSync_GetPeriod(nativeVSync_, &periodNs) == 0 && periodNs > 0;
-    if (!periodAvailable) {
-        const int fps = configuredFps_ > 0 ? configuredFps_ : 60;
-        periodNs = 1000000000LL / fps;
-    }
-    g_vsyncPeriodNs.store(static_cast<int64_t>(periodNs), std::memory_order_release);
-    lastVsyncPeriodQueryNs_ = periodAvailable ? GetMonotonicTimeNs() : 0;
 }
 
 // =============================================================================
-// 两步呈现时钟
+// PTS presentation clocks
 // =============================================================================
 
 void NativeRender::ResetPresentationClockLocked() {
+    ptsScheduler_.Reset();
     timeBaseInitialized_ = false;
     estimatedOffsetNs_ = 0;
     skewNs_ = 0;
     jitterEstNs_ = 0.0;
     lastPtsUs_ = 0;
-    lastScheduledPresentNs_ = 0;
 }
 
 void NativeRender::ResetPresentationStatsLocked() {
     vsyncFrameCount_ = 0;
     vsyncLateFrameCount_ = 0;
     vsyncResyncCount_ = 0;
-    twoStepHitCount_ = 0;
-    twoStepFallbackCount_ = 0;
-    twoStepSameSlotCount_ = 0;
-    twoStepDrainReanchorCount_ = 0;
+    preciseScheduledCount_ = 0;
+    preciseDroppedCount_ = 0;
+    preciseLateCount_ = 0;
+    precisePhaseShiftCount_ = 0;
+    preciseRebufferCount_ = 0;
+    preciseResyncCount_ = 0;
+    preciseApiFailureCount_ = 0;
 }
 
 void NativeRender::ResetPresentationClock() {
@@ -474,29 +376,26 @@ void NativeRender::ResetPresentationClock() {
     ResetPresentationClockLocked();
 }
 
-int64_t NativeRender::CalculatePresentTargetLocked(int64_t pts, int64_t nowNs, bool twoStep,
-                                                   bool forceReanchor) {
+int64_t NativeRender::CalculateLegacyPresentTargetLocked(int64_t pts, int64_t nowNs) {
     const int64_t hostNs = pts * 1000LL;
     const int64_t instOffset = nowNs - hostNs;
-    const int64_t frameIntervalNs = configuredFps_ > 0 ? 1000000000LL / configuredFps_ : 16666667LL;
+    const int64_t frameIntervalNs = configuredFps_ > 0.0 ?
+        static_cast<int64_t>(1000000000.0 / configuredFps_) : 16666667LL;
     const bool discontinuity = timeBaseInitialized_ &&
         (pts < lastPtsUs_ || (pts - lastPtsUs_) > 2000000LL);
 
-    if (forceReanchor || !timeBaseInitialized_ || discontinuity) {
-        if (forceReanchor) {
-            twoStepDrainReanchorCount_++;
-        } else if (discontinuity) {
+    if (!timeBaseInitialized_ || discontinuity) {
+        if (discontinuity) {
             vsyncResyncCount_++;
         }
         estimatedOffsetNs_ = instOffset;
         skewNs_ = 0;
         jitterEstNs_ = static_cast<double>(frameIntervalNs) / 16.0;
         timeBaseInitialized_ = true;
-        if (!forceReanchor) {
-            OH_LOG_INFO(LOG_APP, "VSync clock (re)anchored: offset=%{public}lldus, pts=%{public}lldus%{public}s",
-                        static_cast<long long>(estimatedOffsetNs_ / 1000),
-                        static_cast<long long>(pts), discontinuity ? " [discontinuity]" : "");
-        }
+        OH_LOG_INFO(LOG_APP,
+            "Legacy VSync clock (re)anchored: offset=%{public}lldus, pts=%{public}lldus%{public}s",
+            static_cast<long long>(estimatedOffsetNs_ / 1000),
+            static_cast<long long>(pts), discontinuity ? " [discontinuity]" : "");
     } else {
         const int64_t pred = estimatedOffsetNs_ + skewNs_;
         const int64_t e = instOffset - pred;
@@ -510,9 +409,8 @@ int64_t NativeRender::CalculatePresentTargetLocked(int64_t pts, int64_t nowNs, b
     }
     lastPtsUs_ = pts;
 
-    // 二步模式的 VSync 向上取整自带约半帧余量；基线模式保留原 3×MAD + 1ms cushion。
-    int64_t cushionNs = static_cast<int64_t>((twoStep ? 0.5 : 3.0) * jitterEstNs_);
-    if (!twoStep && cushionNs < 1000000LL) cushionNs = 1000000LL;
+    int64_t cushionNs = static_cast<int64_t>(3.0 * jitterEstNs_);
+    if (cushionNs < 1000000LL) cushionNs = 1000000LL;
     if (cushionNs > frameIntervalNs) cushionNs = frameIntervalNs;
 
     const int64_t targetNs = hostNs + estimatedOffsetNs_ + cushionNs;
@@ -521,125 +419,113 @@ int64_t NativeRender::CalculatePresentTargetLocked(int64_t pts, int64_t nowNs, b
     }
 
     if (++vsyncFrameCount_ % 6000 == 0) {
-        const int64_t vsyncPeriodUs =
-            g_vsyncPeriodNs.load(std::memory_order_acquire) / 1000;
         OH_LOG_INFO(LOG_APP,
-            "VSync clock stats: mode=%{public}s, frames=%{public}lld, late=%{public}lld, resync=%{public}lld, hit=%{public}lld, fallback=%{public}lld, sameSlot=%{public}lld, drainReanchor=%{public}lld, period=%{public}lldus, cushion=%{public}lldus",
-            twoStep ? "two-step" : "baseline",
-            static_cast<long long>(vsyncFrameCount_), static_cast<long long>(vsyncLateFrameCount_),
-            static_cast<long long>(vsyncResyncCount_), static_cast<long long>(twoStepHitCount_),
-            static_cast<long long>(twoStepFallbackCount_), static_cast<long long>(twoStepSameSlotCount_),
-            static_cast<long long>(twoStepDrainReanchorCount_),
-            static_cast<long long>(vsyncPeriodUs),
+            "Legacy VSync stats: frames=%{public}lld, late=%{public}lld, resync=%{public}lld, cushion=%{public}lldus",
+            static_cast<long long>(vsyncFrameCount_),
+            static_cast<long long>(vsyncLateFrameCount_),
+            static_cast<long long>(vsyncResyncCount_),
             static_cast<long long>(cushionNs / 1000));
     }
     return targetNs;
-}
-
-int64_t NativeRender::SnapTargetToVsync(int64_t targetNs, int64_t nowNs) const {
-    const int64_t phaseNs = g_lastVsyncTimestampNs.load(std::memory_order_acquire);
-    const int64_t periodNs = g_vsyncPeriodNs.load(std::memory_order_acquire);
-    if (phaseNs <= 0 || periodNs <= 0) {
-        return targetNs;
-    }
-
-    const int64_t phaseAgeNs = nowNs - phaseNs;
-    if (phaseAgeNs < -periodNs || phaseAgeNs > periodNs * 4) {
-        return targetNs;
-    }
-
-    const int64_t rawNs = targetNs < nowNs ? nowNs : targetNs;
-    if (rawNs <= phaseNs) {
-        return phaseNs;
-    }
-    const int64_t deltaNs = rawNs - phaseNs;
-    return phaseNs + ((deltaNs + periodNs - 1) / periodNs) * periodNs;
 }
 
 // =============================================================================
 // 帧渲染
 // =============================================================================
 
-OH_AVErrCode NativeRender::SubmitFrame(OH_AVCodec* codec, uint32_t bufferIndex, int64_t pts,
-                                       bool drainToLatest) {
-    auto renderImmediately = [codec, bufferIndex]() {
-        return OH_VideoDecoder_RenderOutputBuffer(codec, bufferIndex);
+OH_AVErrCode NativeRender::SubmitFrame(const DecodedFrame& frame) {
+    bool bufferConsumed = false;
+    auto renderImmediately = [&frame, &bufferConsumed]() {
+        const OH_AVErrCode result =
+            OH_VideoDecoder_RenderOutputBuffer(frame.codec, frame.bufferIndex);
+        if (result == AV_ERR_OK) bufferConsumed = true;
+        return result;
     };
-    auto noteFallback = [this]() {
-        std::lock_guard<std::mutex> lock(presentationMutex_);
-        twoStepFallbackCount_++;
+    auto freeFrame = [&frame, &bufferConsumed]() {
+        if (bufferConsumed) return AV_ERR_OK;
+        const OH_AVErrCode result =
+            OH_VideoDecoder_FreeOutputBuffer(frame.codec, frame.bufferIndex);
+        // Do not retry a failed release with an index whose ownership is unclear.
+        bufferConsumed = true;
+        return result;
     };
 
     OH_AVErrCode renderResult = AV_ERR_OK;
-    if (!vsyncEnabled_.load() && !twoStepPreciseSyncEnabled_.load()) {
+    if (!vsyncEnabled_.load() && !hostPacedPresentationEnabled_.load()) {
         renderResult = renderImmediately();
     } else {
         PFN_RenderOutputBufferAtTime renderAtTime = GetRenderAtTimeFunc();
         if (renderAtTime == nullptr) {
-            if (twoStepPreciseSyncEnabled_.load()) {
-                noteFallback();
-            }
             renderResult = renderImmediately();
-        } else if (!twoStepPreciseSyncEnabled_.load()) {
-            // A/B 基线：保留原有的解码输出时采样 + 较大 cushion，不做 VSync 相位 snap。
-            const int64_t nowNs = GetMonotonicTimeNs();
+        } else if (!hostPacedPresentationEnabled_.load()) {
+            const int64_t nowNs = frame.decodedAtNs > 0 ? frame.decodedAtNs : GetMonotonicTimeNs();
             int64_t presentTimeNs;
             {
                 std::lock_guard<std::mutex> lock(presentationMutex_);
-                presentTimeNs = CalculatePresentTargetLocked(pts, nowNs, false);
+                presentTimeNs = CalculateLegacyPresentTargetLocked(frame.ptsUs, nowNs);
             }
-            renderResult = renderAtTime(codec, bufferIndex, presentTimeNs);
+            renderResult = renderAtTime(frame.codec, frame.bufferIndex, presentTimeNs);
             if (renderResult != AV_ERR_OK) {
                 renderResult = renderImmediately();
             }
         } else {
-            const int64_t nowNs = GetMonotonicTimeNs();
-            int64_t targetNs;
+            const int64_t decodedAtNs = frame.decodedAtNs > 0 ?
+                frame.decodedAtNs : GetMonotonicTimeNs();
+            PresentationPlan plan;
             {
                 std::lock_guard<std::mutex> lock(presentationMutex_);
-                // step1 必须在解码输出到达时采样，目标才包含解码和排队耗时。
-                targetNs = CalculatePresentTargetLocked(pts, nowNs, true, drainToLatest);
-            }
+                plan = ptsScheduler_.PlanFrame(frame.ptsUs, decodedAtNs);
+                if (plan.action == PresentationAction::SCHEDULE) {
+                    preciseScheduledCount_++;
+                } else {
+                    preciseDroppedCount_++;
+                }
+                if (plan.latenessNs > 0) preciseLateCount_++;
+                if (plan.event == PresentationEvent::PHASE_SHIFT) precisePhaseShiftCount_++;
+                if (plan.event == PresentationEvent::REBUFFER) preciseRebufferCount_++;
+                if (plan.event == PresentationEvent::DISCONTINUITY) preciseResyncCount_++;
 
-            // step2 只负责把已恢复的 host 节奏落到本地显示槽。
-            int64_t presentTimeNs = SnapTargetToVsync(targetNs, nowNs);
-            if (drainToLatest) {
-                std::lock_guard<std::mutex> lock(presentationMutex_);
-                // Surface 按提交顺序处理；已有未来帧时让最新帧进入同槽覆盖，避免倒序时间戳。
-                if (lastScheduledPresentNs_ >= nowNs && presentTimeNs < lastScheduledPresentNs_) {
-                    presentTimeNs = lastScheduledPresentNs_;
+                const int64_t totalFrames = preciseScheduledCount_ + preciseDroppedCount_;
+                if (totalFrames % 6000 == 0) {
+                    OH_LOG_INFO(LOG_APP,
+                        "Host-paced stats: frames=%{public}lld, scheduled=%{public}lld, dropped=%{public}lld, late=%{public}lld, phaseShift=%{public}lld, rebuffer=%{public}lld, resync=%{public}lld, apiFailure=%{public}lld, lead=%{public}lldus",
+                        static_cast<long long>(totalFrames),
+                        static_cast<long long>(preciseScheduledCount_),
+                        static_cast<long long>(preciseDroppedCount_),
+                        static_cast<long long>(preciseLateCount_),
+                        static_cast<long long>(precisePhaseShiftCount_),
+                        static_cast<long long>(preciseRebufferCount_),
+                        static_cast<long long>(preciseResyncCount_),
+                        static_cast<long long>(preciseApiFailureCount_),
+                        static_cast<long long>(ptsScheduler_.GetInitialLeadNs() / 1000));
                 }
             }
-            if (targetNs < nowNs) {
-                noteFallback();
-                renderResult = renderImmediately();
+
+            if (plan.action == PresentationAction::DROP) {
+                renderResult = freeFrame();
             } else {
-                renderResult = renderAtTime(codec, bufferIndex, presentTimeNs);
+                renderResult = renderAtTime(
+                    frame.codec, frame.bufferIndex, plan.targetTimeNs);
                 if (renderResult == AV_ERR_OK) {
-                    std::lock_guard<std::mutex> lock(presentationMutex_);
-                    if (lastScheduledPresentNs_ >= nowNs && presentTimeNs <= lastScheduledPresentNs_) {
-                        twoStepSameSlotCount_++;
-                    }
-                    if (presentTimeNs > lastScheduledPresentNs_) {
-                        lastScheduledPresentNs_ = presentTimeNs;
-                    }
-                    twoStepHitCount_++;
+                    bufferConsumed = true;
                 } else {
+                    {
+                        std::lock_guard<std::mutex> lock(presentationMutex_);
+                        preciseApiFailureCount_++;
+                    }
                     OH_LOG_WARN(LOG_APP,
-                        "RenderOutputBufferAtTime failed: %{public}d, pts=%{public}lld, presentNs=%{public}lld; falling back",
-                        renderResult, static_cast<long long>(pts), static_cast<long long>(presentTimeNs));
-                    noteFallback();
+                        "Host-paced render failed: %{public}d, pts=%{public}lld, targetNs=%{public}lld; falling back",
+                        renderResult, static_cast<long long>(frame.ptsUs),
+                        static_cast<long long>(plan.targetTimeNs));
                     renderResult = renderImmediately();
                 }
             }
-            // Sampling only refreshes future frames, so keep its Binder work
-            // after the current codec buffer has already been released.
-            MaybeRequestVsyncSample(nowNs);
         }
     }
 
-    if (renderResult != AV_ERR_OK) {
-        OH_LOG_WARN(LOG_APP, "RenderOutputBuffer failed: %{public}d", renderResult);
+    if (renderResult != AV_ERR_OK && !bufferConsumed) {
+        OH_LOG_WARN(LOG_APP, "RenderOutputBuffer failed: %{public}d; freeing output", renderResult);
+        freeFrame();
     }
     lastFrameTime_ = std::chrono::steady_clock::now();
     return renderResult;

--- a/nativelib/src/main/cpp/native_render.cpp
+++ b/nativelib/src/main/cpp/native_render.cpp
@@ -39,12 +39,17 @@ static bool g_renderAtTimeChecked = false;
 // VSync 回调只写入进程级原子状态，避免 Surface 销毁时回调持有悬空对象。
 static std::atomic<int64_t> g_lastVsyncTimestampNs{0};
 static std::atomic<int64_t> g_vsyncPeriodNs{0};
+static std::atomic<bool> g_vsyncRequestPending{false};
+
+static constexpr int64_t kVsyncSampleRefreshPeriods = 2;
+static constexpr int64_t kVsyncPeriodRefreshIntervalNs = 250000000LL;
 
 static void OnNativeVsync(long long timestamp, void* data) {
     (void)data;
     if (timestamp > 0) {
         g_lastVsyncTimestampNs.store(static_cast<int64_t>(timestamp), std::memory_order_release);
     }
+    g_vsyncRequestPending.store(false, std::memory_order_release);
 }
 
 static int64_t GetMonotonicTimeNs() {
@@ -164,13 +169,17 @@ void NativeRender::InitNativeVSync() {
         nativeVSync_ = OH_NativeVSync_Create(name, strlen(name));
         if (nativeVSync_ != nullptr) {
             long long periodNs = 0;
-            if (OH_NativeVSync_GetPeriod(nativeVSync_, &periodNs) != 0 || periodNs <= 0) {
+            const bool periodAvailable =
+                OH_NativeVSync_GetPeriod(nativeVSync_, &periodNs) == 0 && periodNs > 0;
+            if (!periodAvailable) {
                 const int fps = configuredFps_ > 0 ? configuredFps_ : 60;
                 periodNs = 1000000000LL / fps;
                 OH_LOG_WARN(LOG_APP,
                     "NativeVSync period unavailable; using %{public}d FPS fallback", fps);
             }
             g_vsyncPeriodNs.store(static_cast<int64_t>(periodNs), std::memory_order_release);
+            lastVsyncPeriodQueryNs_ = periodAvailable ? GetMonotonicTimeNs() : 0;
+            g_vsyncRequestPending.store(false, std::memory_order_release);
             created = true;
             OH_LOG_INFO(LOG_APP, "NativeVSync created successfully, period=%{public}lldns", periodNs);
         } else {
@@ -194,34 +203,59 @@ void NativeRender::ReleaseNativeVSync() {
     lastVsyncRequestFailureLogNs_ = 0;
     g_lastVsyncTimestampNs.store(0, std::memory_order_release);
     g_vsyncPeriodNs.store(0, std::memory_order_release);
+    g_vsyncRequestPending.store(false, std::memory_order_release);
+    lastVsyncPeriodQueryNs_ = 0;
     OH_LOG_INFO(LOG_APP, "NativeVSync destroyed");
 }
 
 void NativeRender::RequestVsyncSample() {
-    std::lock_guard<std::mutex> lock(nativeVsyncMutex_);
-    if (nativeVSync_ == nullptr) {
+    bool expected = false;
+    if (!g_vsyncRequestPending.compare_exchange_strong(
+            expected, true, std::memory_order_acq_rel, std::memory_order_acquire)) {
         return;
     }
 
-    // GetPeriod only becomes valid after the first VSync callback. Query it on
-    // the following frame while the instance is protected from destruction.
-    if (g_lastVsyncTimestampNs.load(std::memory_order_acquire) > 0) {
+    std::lock_guard<std::mutex> lock(nativeVsyncMutex_);
+    if (nativeVSync_ == nullptr) {
+        g_vsyncRequestPending.store(false, std::memory_order_release);
+        return;
+    }
+
+    // GetPeriod takes the VSync receiver lock. Poll it at most once per second
+    // to retain refresh-rate switch handling without doing it for every frame.
+    const int64_t nowNs = GetMonotonicTimeNs();
+    const bool periodRefreshDue = lastVsyncPeriodQueryNs_ == 0 ||
+        nowNs - lastVsyncPeriodQueryNs_ >= kVsyncPeriodRefreshIntervalNs;
+    if (periodRefreshDue && g_lastVsyncTimestampNs.load(std::memory_order_acquire) > 0) {
         long long periodNs = 0;
         if (OH_NativeVSync_GetPeriod(nativeVSync_, &periodNs) == 0 && periodNs > 0) {
             g_vsyncPeriodNs.store(static_cast<int64_t>(periodNs), std::memory_order_release);
         }
+        lastVsyncPeriodQueryNs_ = nowNs;
     }
 
     int32_t ret = OH_NativeVSync_RequestFrame(nativeVSync_, OnNativeVsync, nullptr);
     if (ret != 0) {
+        g_vsyncRequestPending.store(false, std::memory_order_release);
         constexpr int64_t kFailureLogIntervalNs = 10000000000LL;
-        const int64_t nowNs = GetMonotonicTimeNs();
         if (lastVsyncRequestFailureLogNs_ == 0 ||
             nowNs - lastVsyncRequestFailureLogNs_ >= kFailureLogIntervalNs) {
             lastVsyncRequestFailureLogNs_ = nowNs;
             OH_LOG_DEBUG(LOG_APP, "NativeVSync sample request failed: %{public}d", ret);
         }
     }
+}
+
+void NativeRender::MaybeRequestVsyncSample(int64_t nowNs) {
+    const int64_t phaseNs = g_lastVsyncTimestampNs.load(std::memory_order_acquire);
+    const int64_t periodNs = g_vsyncPeriodNs.load(std::memory_order_acquire);
+    if (phaseNs > 0 && periodNs > 0) {
+        const int64_t phaseAgeNs = nowNs - phaseNs;
+        if (phaseAgeNs >= -periodNs && phaseAgeNs < periodNs * kVsyncSampleRefreshPeriods) {
+            return;
+        }
+    }
+    RequestVsyncSample();
 }
 
 // =============================================================================
@@ -402,11 +436,14 @@ void NativeRender::ApplyFrameRateRange() {
     }
 
     long long periodNs = 0;
-    if (OH_NativeVSync_GetPeriod(nativeVSync_, &periodNs) != 0 || periodNs <= 0) {
+    const bool periodAvailable =
+        OH_NativeVSync_GetPeriod(nativeVSync_, &periodNs) == 0 && periodNs > 0;
+    if (!periodAvailable) {
         const int fps = configuredFps_ > 0 ? configuredFps_ : 60;
         periodNs = 1000000000LL / fps;
     }
     g_vsyncPeriodNs.store(static_cast<int64_t>(periodNs), std::memory_order_release);
+    lastVsyncPeriodQueryNs_ = periodAvailable ? GetMonotonicTimeNs() : 0;
 }
 
 // =============================================================================
@@ -557,7 +594,6 @@ OH_AVErrCode NativeRender::SubmitFrame(OH_AVCodec* codec, uint32_t bufferIndex, 
             }
         } else {
             const int64_t nowNs = GetMonotonicTimeNs();
-            RequestVsyncSample();
             int64_t targetNs;
             {
                 std::lock_guard<std::mutex> lock(presentationMutex_);
@@ -596,6 +632,9 @@ OH_AVErrCode NativeRender::SubmitFrame(OH_AVCodec* codec, uint32_t bufferIndex, 
                     renderResult = renderImmediately();
                 }
             }
+            // Sampling only refreshes future frames, so keep its Binder work
+            // after the current codec buffer has already been released.
+            MaybeRequestVsyncSample(nowNs);
         }
     }
 

--- a/nativelib/src/main/cpp/native_render.cpp
+++ b/nativelib/src/main/cpp/native_render.cpp
@@ -574,13 +574,8 @@ OH_AVErrCode NativeRender::SubmitFrame(OH_AVCodec* codec, uint32_t bufferIndex, 
                     presentTimeNs = lastScheduledPresentNs_;
                 }
             }
-            const int64_t frameIntervalNs = configuredFps_ > 0 ?
-                1000000000LL / configuredFps_ : 16666667LL;
-            const int64_t timeUntilPresentNs = presentTimeNs - nowNs;
-
-            if (timeUntilPresentNs < 0 || timeUntilPresentNs > frameIntervalNs * 3) {
+            if (targetNs < nowNs) {
                 noteFallback();
-                ResetPresentationClock();
                 renderResult = renderImmediately();
             } else {
                 renderResult = renderAtTime(codec, bufferIndex, presentTimeNs);

--- a/nativelib/src/main/cpp/native_render.h
+++ b/nativelib/src/main/cpp/native_render.h
@@ -34,7 +34,6 @@
 #include <mutex>
 #include <atomic>
 #include <chrono>
-#include <map>
 
 /**
  * NativeRender 类
@@ -91,23 +90,13 @@ public:
     bool IsTwoStepPreciseSyncEnabled() const { return twoStepPreciseSyncEnabled_; }
     
     /**
-     * step1：帧到达解码管线时，用 host PTS 生成去抖的本地呈现目标。
-     */
-    void PrepareFrame(int64_t pts);
-
-    /**
-     * 丢弃尚未呈现的帧目标。
-     */
-    void DiscardFrame(int64_t pts);
-
-    /**
-     * 清空帧目标并强制下一帧重新锚定（Flush/重连/Surface 切换）。
+     * 强制下一帧重新锚定（Flush/重连/Surface 切换）。
      */
     void ResetPresentationClock();
 
     /**
-     * step2：解码输出时将 step1 目标对齐到最近 VSync 并呈现。
-     * 无效目标、不支持定时呈现或 API 失败时立即回退直接呈现。
+     * 解码输出时先按 host PTS 恢复节奏，再对齐最近 VSync 并呈现。
+     * 不支持定时呈现或 API 失败时立即回退直接呈现。
      */
     OH_AVErrCode SubmitFrame(OH_AVCodec* codec, uint32_t bufferIndex, int64_t pts);
     
@@ -172,13 +161,12 @@ private:
     // 帧率范围已经应用过（NativeVSync）
     bool frameRateApplied_ = false;
     
-    // 两步呈现状态：step1 host-PI 去抖，step2 对齐本地 VSync
+    // 两步呈现状态：解码输出时 step1 host-PI 去抖，step2 对齐本地 VSync
     mutable std::mutex presentationMutex_;
-    std::map<int64_t, int64_t> pendingPresentTargets_;
-    static constexpr size_t kMaxPendingPresentTargets = 64;
+    int64_t lastScheduledPresentNs_ = 0;
 
-    // Host PTS 去抖时钟。旧 VSync 模式在解码输出时计算目标；二步模式在输入时预计算，
-    // 再于输出时向上对齐真实 VSync。两者共享 offset/skew 与在线抖动估计。
+    // Host PTS 去抖时钟。旧 VSync 与二步模式都在解码输出时建立本地目标；
+    // 二步模式随后再向上对齐真实 VSync。两者共享 offset/skew 与在线抖动估计。
     int64_t estimatedOffsetNs_ = 0;  // 平滑后的 (本地 - host) 偏移均值(纳秒)
     int64_t skewNs_ = 0;             // 每帧频差估计(纳秒/帧)，消除时钟 skew 斜坡滞后
     double  jitterEstNs_ = 0.0;      // 在线抖动估计(平均绝对偏差, 纳秒)，驱动自适应 cushion
@@ -189,8 +177,9 @@ private:
     int64_t vsyncFrameCount_ = 0;      // step1 生成目标的帧数
     int64_t vsyncLateFrameCount_ = 0;  // step1 目标在生成时已过期的帧数
     int64_t vsyncResyncCount_ = 0;     // 因 PTS 不连续而重锚定的次数
-    int64_t twoStepHitCount_ = 0;      // step2 命中预计算目标的帧数
-    int64_t twoStepFallbackCount_ = 0; // 缺失/无效目标或定时 API 失败的回退次数
+    int64_t twoStepHitCount_ = 0;      // 成功按两步目标提交的帧数
+    int64_t twoStepFallbackCount_ = 0; // 无效目标或定时 API 失败的回退次数
+    int64_t twoStepSameSlotCount_ = 0; // 多帧映射到同一未来 VSync 槽的次数
     
     // NativeVSync（用于设置期望帧率范围，API 20+）
     std::mutex nativeVsyncMutex_;

--- a/nativelib/src/main/cpp/native_render.h
+++ b/nativelib/src/main/cpp/native_render.h
@@ -96,9 +96,11 @@ public:
 
     /**
      * 解码输出时先按 host PTS 恢复节奏，再对齐最近 VSync 并呈现。
+     * drainToLatest 为 true 时按当前输出重新锚定，避免已丢弃帧的 PTS 跨度转化为额外等待。
      * 不支持定时呈现或 API 失败时立即回退直接呈现。
      */
-    OH_AVErrCode SubmitFrame(OH_AVCodec* codec, uint32_t bufferIndex, int64_t pts);
+    OH_AVErrCode SubmitFrame(OH_AVCodec* codec, uint32_t bufferIndex, int64_t pts,
+                             bool drainToLatest = false);
     
     // Surface 尺寸
     uint64_t GetSurfaceWidth() const { return surfaceWidth_; }
@@ -134,8 +136,10 @@ private:
     void RequestVsyncSample();
 
     // 已持有 presentationMutex_ 时使用
-    int64_t CalculatePresentTargetLocked(int64_t pts, int64_t nowNs, bool twoStep);
+    int64_t CalculatePresentTargetLocked(int64_t pts, int64_t nowNs, bool twoStep,
+                                         bool forceReanchor = false);
     void ResetPresentationClockLocked();
+    void ResetPresentationStatsLocked();
 
     // 将目标向上对齐到最近的真实 VSync；无有效相位时返回原目标
     int64_t SnapTargetToVsync(int64_t targetNs, int64_t nowNs) const;
@@ -180,10 +184,12 @@ private:
     int64_t twoStepHitCount_ = 0;      // 成功按两步目标提交的帧数
     int64_t twoStepFallbackCount_ = 0; // 无效目标或定时 API 失败的回退次数
     int64_t twoStepSameSlotCount_ = 0; // 多帧映射到同一未来 VSync 槽的次数
+    int64_t twoStepDrainReanchorCount_ = 0; // 同步模式丢旧帧后按最新输出重新锚定的次数
     
     // NativeVSync（用于设置期望帧率范围，API 20+）
     std::mutex nativeVsyncMutex_;
     OH_NativeVSync* nativeVSync_ = nullptr;
+    int64_t lastVsyncRequestFailureLogNs_ = 0;
     
     // 上一帧渲染时间（用于帧率控制）
     std::chrono::steady_clock::time_point lastFrameTime_;

--- a/nativelib/src/main/cpp/native_render.h
+++ b/nativelib/src/main/cpp/native_render.h
@@ -82,9 +82,9 @@ public:
     /**
      * Enable host-PTS paced presentation. The existing setting/API name is
      * retained for compatibility with persisted preferences.
-     */
+    */
     void SetHostPacedPresentationEnabled(bool enable);
-    bool IsHostPacedPresentationEnabled() const { return hostPacedPresentationEnabled_; }
+    bool IsHostPacedPresentationActive() const;
     
     /**
      * 强制下一帧重新锚定（Flush/重连/Surface 切换）。
@@ -95,11 +95,15 @@ public:
         OH_AVCodec* codec = nullptr;
         uint32_t bufferIndex = 0;
         int64_t ptsUs = 0;
-        int64_t decodedAtNs = 0;
+    };
+
+    struct FrameSubmitResult {
+        OH_AVErrCode status = AV_ERR_OK;
+        bool presented = false;
     };
 
     // Takes ownership of the decoder output buffer for every return value.
-    OH_AVErrCode SubmitFrame(const DecodedFrame& frame);
+    FrameSubmitResult SubmitFrame(const DecodedFrame& frame);
     
     // Surface 尺寸
     uint64_t GetSurfaceWidth() const { return surfaceWidth_; }
@@ -148,7 +152,7 @@ private:
     std::atomic<bool> surfaceReady_{false};
     
     // 帧率配置
-    double configuredFps_ = 60.0;
+    std::atomic<double> configuredFps_{60.0};
     
     // VSync 模式
     std::atomic<bool> vsyncEnabled_{false};

--- a/nativelib/src/main/cpp/native_render.h
+++ b/nativelib/src/main/cpp/native_render.h
@@ -35,7 +35,6 @@
 #include <cstdint>
 #include <mutex>
 #include <atomic>
-#include <chrono>
 
 /**
  * NativeRender 类
@@ -68,11 +67,6 @@ public:
      * @param fps 期望帧率
      */
     void SetConfiguredFps(double fps);
-    
-    /**
-     * 获取配置的帧率
-     */
-    double GetConfiguredFps() const { return configuredFps_; }
     
     /**
      * 启用/禁用 VSync 渲染模式
@@ -160,9 +154,6 @@ private:
     std::atomic<bool> vsyncEnabled_{false};
     std::atomic<bool> hostPacedPresentationEnabled_{false};
     
-    // 帧率范围已经应用过（NativeVSync）
-    bool frameRateApplied_ = false;
-    
     // Timed presentation state. Legacy VSync and host-paced presentation use
     // separate clocks so switching decoder modes cannot perturb PTS cadence.
     mutable std::mutex presentationMutex_;
@@ -190,8 +181,6 @@ private:
     std::mutex nativeVsyncMutex_;
     OH_NativeVSync* nativeVSync_ = nullptr;
     
-    // 上一帧渲染时间（用于帧率控制）
-    std::chrono::steady_clock::time_point lastFrameTime_;
 };
 
 #endif // NATIVE_RENDER_H

--- a/nativelib/src/main/cpp/native_render.h
+++ b/nativelib/src/main/cpp/native_render.h
@@ -30,6 +30,8 @@
 #include <multimedia/player_framework/native_avcodec_videodecoder.h>
 #include <hilog/log.h>
 
+#include "presentation_scheduler.h"
+
 #include <cstdint>
 #include <mutex>
 #include <atomic>
@@ -65,12 +67,12 @@ public:
      * 配置帧率（用于高帧率优化）
      * @param fps 期望帧率
      */
-    void SetConfiguredFps(int fps);
+    void SetConfiguredFps(double fps);
     
     /**
      * 获取配置的帧率
      */
-    int GetConfiguredFps() const { return configuredFps_; }
+    double GetConfiguredFps() const { return configuredFps_; }
     
     /**
      * 启用/禁用 VSync 渲染模式
@@ -84,23 +86,26 @@ public:
     bool IsVsyncEnabled() const { return vsyncEnabled_; }
 
     /**
-     * 启用/禁用二步精确同步；开启时内部自行使用 VSync，不依赖 VSync 设置开关。
+     * Enable host-PTS paced presentation. The existing setting/API name is
+     * retained for compatibility with persisted preferences.
      */
-    void SetTwoStepPreciseSyncEnabled(bool enable);
-    bool IsTwoStepPreciseSyncEnabled() const { return twoStepPreciseSyncEnabled_; }
+    void SetHostPacedPresentationEnabled(bool enable);
+    bool IsHostPacedPresentationEnabled() const { return hostPacedPresentationEnabled_; }
     
     /**
      * 强制下一帧重新锚定（Flush/重连/Surface 切换）。
      */
     void ResetPresentationClock();
 
-    /**
-     * 解码输出时先按 host PTS 恢复节奏，再对齐最近 VSync 并呈现。
-     * drainToLatest 为 true 时按当前输出重新锚定，避免已丢弃帧的 PTS 跨度转化为额外等待。
-     * 不支持定时呈现或 API 失败时立即回退直接呈现。
-     */
-    OH_AVErrCode SubmitFrame(OH_AVCodec* codec, uint32_t bufferIndex, int64_t pts,
-                             bool drainToLatest = false);
+    struct DecodedFrame {
+        OH_AVCodec* codec = nullptr;
+        uint32_t bufferIndex = 0;
+        int64_t ptsUs = 0;
+        int64_t decodedAtNs = 0;
+    };
+
+    // Takes ownership of the decoder output buffer for every return value.
+    OH_AVErrCode SubmitFrame(const DecodedFrame& frame);
     
     // Surface 尺寸
     uint64_t GetSurfaceWidth() const { return surfaceWidth_; }
@@ -132,20 +137,10 @@ private:
     // 释放 NativeVSync
     void ReleaseNativeVSync();
 
-    // 请求一次 VSync 样本，供 step2 做相位对齐
-    void RequestVsyncSample();
-
-    // Reuse a recent phase sample and refresh it only when it becomes stale.
-    void MaybeRequestVsyncSample(int64_t nowNs);
-
     // 已持有 presentationMutex_ 时使用
-    int64_t CalculatePresentTargetLocked(int64_t pts, int64_t nowNs, bool twoStep,
-                                         bool forceReanchor = false);
+    int64_t CalculateLegacyPresentTargetLocked(int64_t pts, int64_t nowNs);
     void ResetPresentationClockLocked();
     void ResetPresentationStatsLocked();
-
-    // 将目标向上对齐到最近的真实 VSync；无有效相位时返回原目标
-    int64_t SnapTargetToVsync(int64_t targetNs, int64_t nowNs) const;
 
 private:
     // 单例
@@ -159,41 +154,41 @@ private:
     std::atomic<bool> surfaceReady_{false};
     
     // 帧率配置
-    int configuredFps_ = 60;
+    double configuredFps_ = 60.0;
     
     // VSync 模式
     std::atomic<bool> vsyncEnabled_{false};
-    std::atomic<bool> twoStepPreciseSyncEnabled_{false};
+    std::atomic<bool> hostPacedPresentationEnabled_{false};
     
     // 帧率范围已经应用过（NativeVSync）
     bool frameRateApplied_ = false;
     
-    // 两步呈现状态：解码输出时 step1 host-PI 去抖，step2 对齐本地 VSync
+    // Timed presentation state. Legacy VSync and host-paced presentation use
+    // separate clocks so switching decoder modes cannot perturb PTS cadence.
     mutable std::mutex presentationMutex_;
-    int64_t lastScheduledPresentNs_ = 0;
+    PtsPresentationScheduler ptsScheduler_;
 
-    // Host PTS 去抖时钟。旧 VSync 与二步模式都在解码输出时建立本地目标；
-    // 二步模式随后再向上对齐真实 VSync。两者共享 offset/skew 与在线抖动估计。
+    // Legacy VSync clock, kept isolated from the host-paced scheduler.
     int64_t estimatedOffsetNs_ = 0;  // 平滑后的 (本地 - host) 偏移均值(纳秒)
     int64_t skewNs_ = 0;             // 每帧频差估计(纳秒/帧)，消除时钟 skew 斜坡滞后
     double  jitterEstNs_ = 0.0;      // 在线抖动估计(平均绝对偏差, 纳秒)，驱动自适应 cushion
     int64_t lastPtsUs_ = 0;          // 上一帧 host PTS(微秒)，用于检测不连续(重连/跳变)
     bool timeBaseInitialized_ = false;
 
-    // VSync 去抖时钟的运行统计(用于评估收益/风险)
-    int64_t vsyncFrameCount_ = 0;      // step1 生成目标的帧数
-    int64_t vsyncLateFrameCount_ = 0;  // step1 目标在生成时已过期的帧数
-    int64_t vsyncResyncCount_ = 0;     // 因 PTS 不连续而重锚定的次数
-    int64_t twoStepHitCount_ = 0;      // 成功按两步目标提交的帧数
-    int64_t twoStepFallbackCount_ = 0; // 无效目标或定时 API 失败的回退次数
-    int64_t twoStepSameSlotCount_ = 0; // 多帧映射到同一未来 VSync 槽的次数
-    int64_t twoStepDrainReanchorCount_ = 0; // 同步模式丢旧帧后按最新输出重新锚定的次数
+    int64_t vsyncFrameCount_ = 0;
+    int64_t vsyncLateFrameCount_ = 0;
+    int64_t vsyncResyncCount_ = 0;
+    int64_t preciseScheduledCount_ = 0;
+    int64_t preciseDroppedCount_ = 0;
+    int64_t preciseLateCount_ = 0;
+    int64_t precisePhaseShiftCount_ = 0;
+    int64_t preciseRebufferCount_ = 0;
+    int64_t preciseResyncCount_ = 0;
+    int64_t preciseApiFailureCount_ = 0;
     
     // NativeVSync（用于设置期望帧率范围，API 20+）
     std::mutex nativeVsyncMutex_;
     OH_NativeVSync* nativeVSync_ = nullptr;
-    int64_t lastVsyncRequestFailureLogNs_ = 0;
-    int64_t lastVsyncPeriodQueryNs_ = 0;
     
     // 上一帧渲染时间（用于帧率控制）
     std::chrono::steady_clock::time_point lastFrameTime_;

--- a/nativelib/src/main/cpp/native_render.h
+++ b/nativelib/src/main/cpp/native_render.h
@@ -135,6 +135,9 @@ private:
     // 请求一次 VSync 样本，供 step2 做相位对齐
     void RequestVsyncSample();
 
+    // Reuse a recent phase sample and refresh it only when it becomes stale.
+    void MaybeRequestVsyncSample(int64_t nowNs);
+
     // 已持有 presentationMutex_ 时使用
     int64_t CalculatePresentTargetLocked(int64_t pts, int64_t nowNs, bool twoStep,
                                          bool forceReanchor = false);
@@ -190,6 +193,7 @@ private:
     std::mutex nativeVsyncMutex_;
     OH_NativeVSync* nativeVSync_ = nullptr;
     int64_t lastVsyncRequestFailureLogNs_ = 0;
+    int64_t lastVsyncPeriodQueryNs_ = 0;
     
     // 上一帧渲染时间（用于帧率控制）
     std::chrono::steady_clock::time_point lastFrameTime_;

--- a/nativelib/src/main/cpp/presentation_scheduler.cpp
+++ b/nativelib/src/main/cpp/presentation_scheduler.cpp
@@ -1,0 +1,146 @@
+/*
+ * Moonlight for HarmonyOS
+ * Copyright (C) 2024-2025 Moonlight/AlkaidLab
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#include "presentation_scheduler.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace {
+constexpr int64_t kNanosecondsPerSecond = 1000000000LL;
+constexpr int64_t kNanosecondsPerMicrosecond = 1000LL;
+constexpr int64_t kExtraPresentationLeadNs = 2000000LL;
+constexpr int64_t kMinSubmitLeadNs = 1000000LL;
+constexpr int64_t kMaxSubmitLeadNs = 2000000LL;
+constexpr int64_t kDriftDeadbandNs = 2000000LL;
+constexpr int64_t kMaxDriftCorrectionPerFrameNs = 20000LL;
+constexpr int kSevereLateFramesBeforeRebuffer = 2;
+} // namespace
+
+void PtsPresentationScheduler::Configure(double fps) {
+    const double safeFps = fps > 0.0 ? fps : 60.0;
+    frameIntervalNs_ = static_cast<int64_t>(
+        std::llround(static_cast<double>(kNanosecondsPerSecond) / safeFps));
+    frameIntervalNs_ = std::max<int64_t>(frameIntervalNs_, 1000000LL);
+    initialLeadNs_ = frameIntervalNs_ + kExtraPresentationLeadNs;
+    submitLeadNs_ = std::clamp(frameIntervalNs_ / 8,
+                               kMinSubmitLeadNs, kMaxSubmitLeadNs);
+    discontinuityNs_ = std::max<int64_t>(250000000LL, frameIntervalNs_ * 12);
+    Reset();
+}
+
+void PtsPresentationScheduler::Reset() {
+    initialized_ = false;
+    anchorPtsUs_ = 0;
+    anchorTargetNs_ = 0;
+    lastPtsUs_ = 0;
+    driftErrorEmaNs_ = 0;
+    consecutiveSevereLateFrames_ = 0;
+}
+
+PresentationPlan PtsPresentationScheduler::AnchorFrame(
+        int64_t ptsUs, int64_t decodedAtNs, PresentationEvent event) {
+    initialized_ = true;
+    anchorPtsUs_ = ptsUs;
+    anchorTargetNs_ = decodedAtNs + initialLeadNs_;
+    lastPtsUs_ = ptsUs;
+    driftErrorEmaNs_ = 0;
+    consecutiveSevereLateFrames_ = 0;
+
+    PresentationPlan plan;
+    plan.action = PresentationAction::SCHEDULE;
+    plan.event = event;
+    plan.targetTimeNs = anchorTargetNs_;
+    plan.leadTimeNs = initialLeadNs_;
+    return plan;
+}
+
+void PtsPresentationScheduler::ApplySlowDriftCorrection(
+        int64_t decodedAtNs, int64_t& targetTimeNs) {
+    int64_t leadErrorNs = targetTimeNs - decodedAtNs - initialLeadNs_;
+    leadErrorNs = std::clamp(leadErrorNs, -frameIntervalNs_, frameIntervalNs_);
+    driftErrorEmaNs_ += (leadErrorNs - driftErrorEmaNs_) / 256;
+
+    if (driftErrorEmaNs_ > kDriftDeadbandNs ||
+        driftErrorEmaNs_ < -kDriftDeadbandNs) {
+        const int64_t correctionNs = std::clamp(
+            -driftErrorEmaNs_ / 1024,
+            -kMaxDriftCorrectionPerFrameNs,
+            kMaxDriftCorrectionPerFrameNs);
+        anchorTargetNs_ += correctionNs;
+        targetTimeNs += correctionNs;
+    }
+}
+
+PresentationPlan PtsPresentationScheduler::PlanFrame(
+        int64_t ptsUs, int64_t decodedAtNs) {
+    if (ptsUs < 0 || decodedAtNs <= 0) {
+        PresentationPlan plan;
+        plan.event = PresentationEvent::INVALID_PTS;
+        return plan;
+    }
+
+    if (!initialized_) {
+        return AnchorFrame(ptsUs, decodedAtNs, PresentationEvent::INITIAL_ANCHOR);
+    }
+
+    if (ptsUs == lastPtsUs_) {
+        PresentationPlan plan;
+        plan.event = PresentationEvent::DUPLICATE_PTS;
+        return plan;
+    }
+
+    const int64_t ptsDeltaUs = ptsUs - lastPtsUs_;
+    if (ptsDeltaUs < 0 || ptsDeltaUs > discontinuityNs_ / kNanosecondsPerMicrosecond) {
+        return AnchorFrame(ptsUs, decodedAtNs, PresentationEvent::DISCONTINUITY);
+    }
+    lastPtsUs_ = ptsUs;
+
+    int64_t targetTimeNs = anchorTargetNs_ +
+        (ptsUs - anchorPtsUs_) * kNanosecondsPerMicrosecond;
+    ApplySlowDriftCorrection(decodedAtNs, targetTimeNs);
+
+    const int64_t requiredTargetNs = decodedAtNs + submitLeadNs_;
+    if (targetTimeNs < requiredTargetNs) {
+        const int64_t latenessNs = requiredTargetNs - targetTimeNs;
+        if (latenessNs <= frameIntervalNs_ / 2) {
+            // Move the complete timeline forward. This keeps all following PTS
+            // intervals intact instead of switching this frame to immediate mode.
+            anchorTargetNs_ += latenessNs;
+            driftErrorEmaNs_ = 0;
+            consecutiveSevereLateFrames_ = 0;
+
+            PresentationPlan plan;
+            plan.action = PresentationAction::SCHEDULE;
+            plan.event = PresentationEvent::PHASE_SHIFT;
+            plan.targetTimeNs = requiredTargetNs;
+            plan.leadTimeNs = submitLeadNs_;
+            plan.latenessNs = latenessNs;
+            return plan;
+        }
+
+        consecutiveSevereLateFrames_++;
+        if (consecutiveSevereLateFrames_ >= kSevereLateFramesBeforeRebuffer) {
+            return AnchorFrame(ptsUs, decodedAtNs, PresentationEvent::REBUFFER);
+        }
+
+        PresentationPlan plan;
+        plan.event = PresentationEvent::LATE_DROP;
+        plan.latenessNs = latenessNs;
+        return plan;
+    }
+
+    consecutiveSevereLateFrames_ = 0;
+    PresentationPlan plan;
+    plan.action = PresentationAction::SCHEDULE;
+    plan.targetTimeNs = targetTimeNs;
+    plan.leadTimeNs = targetTimeNs - decodedAtNs;
+    return plan;
+}

--- a/nativelib/src/main/cpp/presentation_scheduler.cpp
+++ b/nativelib/src/main/cpp/presentation_scheduler.cpp
@@ -58,7 +58,6 @@ PresentationPlan PtsPresentationScheduler::AnchorFrame(
     plan.action = PresentationAction::SCHEDULE;
     plan.event = event;
     plan.targetTimeNs = anchorTargetNs_;
-    plan.leadTimeNs = initialLeadNs_;
     return plan;
 }
 
@@ -121,7 +120,6 @@ PresentationPlan PtsPresentationScheduler::PlanFrame(
             plan.action = PresentationAction::SCHEDULE;
             plan.event = PresentationEvent::PHASE_SHIFT;
             plan.targetTimeNs = requiredTargetNs;
-            plan.leadTimeNs = submitLeadNs_;
             plan.latenessNs = latenessNs;
             return plan;
         }
@@ -141,6 +139,5 @@ PresentationPlan PtsPresentationScheduler::PlanFrame(
     PresentationPlan plan;
     plan.action = PresentationAction::SCHEDULE;
     plan.targetTimeNs = targetTimeNs;
-    plan.leadTimeNs = targetTimeNs - decodedAtNs;
     return plan;
 }

--- a/nativelib/src/main/cpp/presentation_scheduler.cpp
+++ b/nativelib/src/main/cpp/presentation_scheduler.cpp
@@ -42,6 +42,7 @@ void PtsPresentationScheduler::Reset() {
     anchorTargetNs_ = 0;
     lastPtsUs_ = 0;
     driftErrorEmaNs_ = 0;
+    phaseShiftDebtNs_ = 0;
     consecutiveSevereLateFrames_ = 0;
 }
 
@@ -52,6 +53,7 @@ PresentationPlan PtsPresentationScheduler::AnchorFrame(
     anchorTargetNs_ = decodedAtNs + initialLeadNs_;
     lastPtsUs_ = ptsUs;
     driftErrorEmaNs_ = 0;
+    phaseShiftDebtNs_ = 0;
     consecutiveSevereLateFrames_ = 0;
 
     PresentationPlan plan;
@@ -75,6 +77,10 @@ void PtsPresentationScheduler::ApplySlowDriftCorrection(
             kMaxDriftCorrectionPerFrameNs);
         anchorTargetNs_ += correctionNs;
         targetTimeNs += correctionNs;
+        if (correctionNs < 0 && phaseShiftDebtNs_ > 0) {
+            phaseShiftDebtNs_ = std::max<int64_t>(
+                0, phaseShiftDebtNs_ + correctionNs);
+        }
     }
 }
 
@@ -91,9 +97,10 @@ PresentationPlan PtsPresentationScheduler::PlanFrame(
     }
 
     if (ptsUs == lastPtsUs_) {
-        PresentationPlan plan;
-        plan.event = PresentationEvent::DUPLICATE_PTS;
-        return plan;
+        // A permanently repeated timestamp must not become a permanent DROP
+        // state. Treat it as a broken host timeline and fall back to a fresh
+        // local anchor until valid PTS progression resumes.
+        return AnchorFrame(ptsUs, decodedAtNs, PresentationEvent::DUPLICATE_PTS);
     }
 
     const int64_t ptsDeltaUs = ptsUs - lastPtsUs_;
@@ -104,6 +111,29 @@ PresentationPlan PtsPresentationScheduler::PlanFrame(
 
     int64_t targetTimeNs = anchorTargetNs_ +
         (ptsUs - anchorPtsUs_) * kNanosecondsPerMicrosecond;
+
+    // Small late frames move the complete timeline forward and accumulate a
+    // known phase-shift debt. Once the decode/transport delay recovers, repay
+    // only that debt. This restores low latency quickly without mistaking a
+    // normal decoder output burst (which has no debt) for excessive queuing.
+    const int64_t surplusLeadNs =
+        targetTimeNs - decodedAtNs - initialLeadNs_;
+    if (phaseShiftDebtNs_ > 0 && surplusLeadNs > kDriftDeadbandNs) {
+        const int64_t repaymentNs = std::min(phaseShiftDebtNs_, surplusLeadNs);
+        anchorTargetNs_ -= repaymentNs;
+        targetTimeNs -= repaymentNs;
+        phaseShiftDebtNs_ -= repaymentNs;
+        driftErrorEmaNs_ = 0;
+        consecutiveSevereLateFrames_ = 0;
+
+        PresentationPlan plan;
+        plan.action = PresentationAction::SCHEDULE;
+        plan.event = PresentationEvent::PHASE_SHIFT;
+        plan.targetTimeNs = targetTimeNs;
+        plan.latenessNs = -repaymentNs;
+        return plan;
+    }
+
     ApplySlowDriftCorrection(decodedAtNs, targetTimeNs);
 
     const int64_t requiredTargetNs = decodedAtNs + submitLeadNs_;
@@ -113,6 +143,7 @@ PresentationPlan PtsPresentationScheduler::PlanFrame(
             // Move the complete timeline forward. This keeps all following PTS
             // intervals intact instead of switching this frame to immediate mode.
             anchorTargetNs_ += latenessNs;
+            phaseShiftDebtNs_ += latenessNs;
             driftErrorEmaNs_ = 0;
             consecutiveSevereLateFrames_ = 0;
 

--- a/nativelib/src/main/cpp/presentation_scheduler.h
+++ b/nativelib/src/main/cpp/presentation_scheduler.h
@@ -1,0 +1,70 @@
+/*
+ * Moonlight for HarmonyOS
+ * Copyright (C) 2024-2025 Moonlight/AlkaidLab
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#ifndef PRESENTATION_SCHEDULER_H
+#define PRESENTATION_SCHEDULER_H
+
+#include <cstdint>
+
+enum class PresentationAction {
+    SCHEDULE,
+    DROP,
+};
+
+enum class PresentationEvent {
+    NONE,
+    INITIAL_ANCHOR,
+    DISCONTINUITY,
+    PHASE_SHIFT,
+    REBUFFER,
+    DUPLICATE_PTS,
+    INVALID_PTS,
+    LATE_DROP,
+};
+
+struct PresentationPlan {
+    PresentationAction action = PresentationAction::DROP;
+    PresentationEvent event = PresentationEvent::NONE;
+    int64_t targetTimeNs = 0;
+    int64_t leadTimeNs = 0;
+    int64_t latenessNs = 0;
+};
+
+// Maps host PTS to a continuous local presentation timeline. Decoder output
+// arrival is used only for initial buffering and slow clock-drift correction;
+// it never replaces the PTS cadence on a normal frame.
+class PtsPresentationScheduler {
+public:
+    void Configure(double fps);
+    void Reset();
+    PresentationPlan PlanFrame(int64_t ptsUs, int64_t decodedAtNs);
+
+    int64_t GetFrameIntervalNs() const { return frameIntervalNs_; }
+    int64_t GetInitialLeadNs() const { return initialLeadNs_; }
+
+private:
+    PresentationPlan AnchorFrame(int64_t ptsUs, int64_t decodedAtNs,
+                                 PresentationEvent event);
+    void ApplySlowDriftCorrection(int64_t decodedAtNs, int64_t& targetTimeNs);
+
+    int64_t frameIntervalNs_ = 16666667LL;
+    int64_t initialLeadNs_ = 18666667LL;
+    int64_t submitLeadNs_ = 2000000LL;
+    int64_t discontinuityNs_ = 250000000LL;
+
+    bool initialized_ = false;
+    int64_t anchorPtsUs_ = 0;
+    int64_t anchorTargetNs_ = 0;
+    int64_t lastPtsUs_ = 0;
+    int64_t driftErrorEmaNs_ = 0;
+    int consecutiveSevereLateFrames_ = 0;
+};
+
+#endif // PRESENTATION_SCHEDULER_H

--- a/nativelib/src/main/cpp/presentation_scheduler.h
+++ b/nativelib/src/main/cpp/presentation_scheduler.h
@@ -33,7 +33,6 @@ struct PresentationPlan {
     PresentationAction action = PresentationAction::DROP;
     PresentationEvent event = PresentationEvent::NONE;
     int64_t targetTimeNs = 0;
-    int64_t leadTimeNs = 0;
     int64_t latenessNs = 0;
 };
 
@@ -46,7 +45,6 @@ public:
     void Reset();
     PresentationPlan PlanFrame(int64_t ptsUs, int64_t decodedAtNs);
 
-    int64_t GetFrameIntervalNs() const { return frameIntervalNs_; }
     int64_t GetInitialLeadNs() const { return initialLeadNs_; }
 
 private:

--- a/nativelib/src/main/cpp/presentation_scheduler.h
+++ b/nativelib/src/main/cpp/presentation_scheduler.h
@@ -62,6 +62,7 @@ private:
     int64_t anchorTargetNs_ = 0;
     int64_t lastPtsUs_ = 0;
     int64_t driftErrorEmaNs_ = 0;
+    int64_t phaseShiftDebtNs_ = 0;
     int consecutiveSevereLateFrames_ = 0;
 };
 

--- a/nativelib/src/main/cpp/video_decoder.cpp
+++ b/nativelib/src/main/cpp/video_decoder.cpp
@@ -1047,32 +1047,6 @@ static OH_AVCodecBufferAttr MakeInputBufferAttr(int32_t size, int64_t pts, Video
     return attr;
 }
 
-class PresentationTargetGuard {
-public:
-    PresentationTargetGuard(int64_t pts, bool prepare)
-        : render_(NativeRender::GetInstance()), pts_(pts) {
-        if (prepare) {
-            render_->PrepareFrame(pts_);
-        }
-    }
-
-    ~PresentationTargetGuard() {
-        if (!committed_) {
-            render_->DiscardFrame(pts_);
-        }
-    }
-
-    void Commit() { committed_ = true; }
-
-    PresentationTargetGuard(const PresentationTargetGuard&) = delete;
-    PresentationTargetGuard& operator=(const PresentationTargetGuard&) = delete;
-
-private:
-    NativeRender* render_;
-    int64_t pts_;
-    bool committed_ = false;
-};
-
 void VideoDecoder::RecordEnqueueTimestamp(int64_t timestamp) {
     auto enqueueTimeMs = std::chrono::duration_cast<std::chrono::milliseconds>(
         std::chrono::steady_clock::now().time_since_epoch()).count();
@@ -1155,9 +1129,6 @@ int VideoDecoder::SubmitDecodeUnitScatter(const BufferSegment* segments, int seg
         return recoveryResult;  // -1 = DR_NEED_IDR
     }
 
-    // step1 在网络帧进入解码管线的时刻完成；未能提交的帧由 guard 自动清理。
-    PresentationTargetGuard presentationTarget(timestamp, true);
-    
     // 同步模式：直接提交到解码器（scatter-gather 直写 AVBuffer）
     if (config_.decoderMode == DecoderMode::SYNC) {
         UpdateReceivedStats(totalSize, frameNumber, hostProcessingLatency);
@@ -1198,7 +1169,6 @@ int VideoDecoder::SubmitDecodeUnitScatter(const BufferSegment* segments, int seg
                         if (ret == AV_ERR_OK) {
                             // 唤醒解码线程立即轮询输出，避免 wait_for(halfFrame) 空等
                             pendingFrameCond_.notify_one();
-                            presentationTarget.Commit();
                             return 0;  // 直接提交成功
                         }
                     }
@@ -1215,7 +1185,6 @@ int VideoDecoder::SubmitDecodeUnitScatter(const BufferSegment* segments, int seg
             std::lock_guard<std::mutex> lock(pendingFrameMutex_);
             while (pendingFrameQueue_.size() >= maxPendingFrames_) {
                 hadOverflow = true;
-                NativeRender::GetInstance()->DiscardFrame(pendingFrameQueue_.front().timestamp);
                 pendingFrameQueue_.pop();
                 std::lock_guard<std::mutex> statsLock(statsMutex_);
                 stats_.droppedFrames++;
@@ -1241,7 +1210,6 @@ int VideoDecoder::SubmitDecodeUnitScatter(const BufferSegment* segments, int seg
             }
         }
 
-        presentationTarget.Commit();
         return 0;
     }
     
@@ -1309,8 +1277,6 @@ int VideoDecoder::SubmitDecodeUnitScatter(const BufferSegment* segments, int seg
         return -1;
     }
 
-    presentationTarget.Commit();
-    
     UpdateReceivedStats(totalSize, frameNumber, hostProcessingLatency);
     
     if (!firstFrameReceived_) {
@@ -1499,7 +1465,6 @@ void VideoDecoder::OnOutputBufferAvailable(OH_AVCodec* codec, uint32_t index,
         // 跳过条件：解码时间 > 3倍帧间隔 且 非关键帧 且 已过启动阶段
         if (instantDecodeTimeMs > expectedFrameTimeMs * kAsyncSkipThresholdMultiplier &&
             !isKeyframe && self->stats_.decodedFrames > kLatencyRecoveryMinFrames) {
-            NativeRender::GetInstance()->DiscardFrame(pts);
             OH_VideoDecoder_FreeOutputBuffer(codec, index);
             {
                 std::lock_guard<std::mutex> lock(self->statsMutex_);
@@ -1531,7 +1496,6 @@ void VideoDecoder::OnOutputBufferAvailable(OH_AVCodec* codec, uint32_t index,
             if (outputInterval < static_cast<int64_t>(expectedFrameTimeMs * intervalRatio) &&
                 instantDecodeTimeMs > static_cast<int64_t>(expectedFrameTimeMs * latencyRatio) &&
                 meetsAbsoluteFloor) {
-                NativeRender::GetInstance()->DiscardFrame(pts);
                 OH_VideoDecoder_FreeOutputBuffer(codec, index);
                 {
                     std::lock_guard<std::mutex> lock(self->statsMutex_);
@@ -1993,8 +1957,6 @@ int VideoDecoder::SyncProcessInput(int64_t timeoutUs) {
         frame = std::move(pendingFrameQueue_.front());
         pendingFrameQueue_.pop();
     }
-    PresentationTargetGuard presentationTarget(frame.timestamp, false);
-    
     // 成功获得输入 buffer，继续处理帧
     static bool firstInputLog = true;
     if (firstInputLog) {
@@ -2039,7 +2001,6 @@ int VideoDecoder::SyncProcessInput(int64_t timeoutUs) {
         return -1;  // API 错误
     }
 
-    presentationTarget.Commit();
     return 1;  // 成功处理了一帧
 }
 
@@ -2091,7 +2052,6 @@ int VideoDecoder::SyncProcessOutput(int64_t timeoutUs) {
     // 检查 EOS
     if (attr.flags & AVCODEC_BUFFER_FLAGS_EOS) {
         OH_LOG_INFO(LOG_APP, "Sync: received EOS");
-        NativeRender::GetInstance()->DiscardFrame(attr.pts);
         OH_VideoDecoder_FreeOutputBuffer(decoder_, outputIndex);
         return 0;  // EOS 不是错误
     }
@@ -2134,7 +2094,6 @@ int VideoDecoder::SyncProcessOutput(int64_t timeoutUs) {
         
         // EOS 帧不参与收集
         if (nextAttr.flags & AVCODEC_BUFFER_FLAGS_EOS) {
-            NativeRender::GetInstance()->DiscardFrame(nextAttr.pts);
             OH_VideoDecoder_FreeOutputBuffer(decoder_, nextOutputIndex);
             break;
         }
@@ -2153,7 +2112,6 @@ int VideoDecoder::SyncProcessOutput(int64_t timeoutUs) {
                 std::lock_guard<std::mutex> lock(timestampMutex_);
                 timestampToEnqueueTime_.erase(frame.attr.pts);
             }
-            NativeRender::GetInstance()->DiscardFrame(frame.attr.pts);
             OH_VideoDecoder_FreeOutputBuffer(decoder_, frame.index);
         }
         {

--- a/nativelib/src/main/cpp/video_decoder.cpp
+++ b/nativelib/src/main/cpp/video_decoder.cpp
@@ -1677,13 +1677,16 @@ void VideoDecoder::UpdateDecodedStats(int64_t pts, int64_t enqueueTimeMs, uint32
             constexpr int64_t kPipelineWarningIntervalMs = 5000;
             const int64_t lastWarningMs =
                 lastPipelineWarningTimeMs_.load(std::memory_order_relaxed);
-            if (!latencyRecoveryActive_.load() &&
-                (lastWarningMs == 0 ||
-                 currentTimeMs - lastWarningMs >= kPipelineWarningIntervalMs)) {
-                lastPipelineWarningTimeMs_.store(currentTimeMs, std::memory_order_relaxed);
-                OH_LOG_WARN(LOG_APP, "Pipeline latency %{public}lldms critical (decode=%{public}lldms), flagging recovery",
-                            static_cast<long long>(pipelineLatencyMs),
-                            static_cast<long long>(decodeTimeMs));
+            if (!latencyRecoveryActive_.load()) {
+                bool expected = false;
+                if (latencyRecoveryActive_.compare_exchange_strong(expected, true) &&
+                    (lastWarningMs == 0 ||
+                     currentTimeMs - lastWarningMs >= kPipelineWarningIntervalMs)) {
+                    lastPipelineWarningTimeMs_.store(currentTimeMs, std::memory_order_relaxed);
+                    OH_LOG_WARN(LOG_APP, "Pipeline latency %{public}lldms critical (decode=%{public}lldms), flagging recovery",
+                                static_cast<long long>(pipelineLatencyMs),
+                                static_cast<long long>(decodeTimeMs));
+                }
             }
         }
     } else {

--- a/nativelib/src/main/cpp/video_decoder.cpp
+++ b/nativelib/src/main/cpp/video_decoder.cpp
@@ -372,7 +372,12 @@ static constexpr int kMaxTimeoutMs = 100;       // 最大等待超时 (ms) - 增
 
 // 统计配置
 static constexpr int64_t kStatsUpdateIntervalMs = 1000;  // 统计更新间隔
-static constexpr size_t kMaxTimestampMapSize = 120;      // 时间戳映射最大大小
+static constexpr int64_t kSyncLogIntervalMs = 10000;
+
+static int64_t GetSteadyTimeMs() {
+    return std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now().time_since_epoch()).count();
+}
 static constexpr int64_t kMaxValidDecodeTimeMs = 1000;   // 有效解码时间上限
 
 // 颜色空间常量 (OH_ColorPrimary)
@@ -476,6 +481,8 @@ int VideoDecoder::Init(const VideoDecoderConfig& config, OHNativeWindow* window)
     
     config_ = config;
     window_ = window;
+    render_ = NativeRender::GetInstance();
+    postProcessor_ = GLPostProcessor::GetInstance();
     
     OH_LOG_INFO(LOG_APP, "{Init} Initializing video decoder: %{public}dx%{public}d@%.2f, codec=%{public}d, window=%{public}p",
                 config_.width, config_.height, config_.fps, static_cast<int>(config_.codec), static_cast<void*>(window));
@@ -889,7 +896,7 @@ int VideoDecoder::Start() {
         return -1;
     }
     
-    NativeRender::GetInstance()->ResetPresentationClock();
+    render_->ResetPresentationClock();
     int32_t ret = OH_VideoDecoder_Start(decoder_);
     if (ret != AV_ERR_OK) {
         OH_LOG_ERROR(LOG_APP, "Failed to start decoder: %{public}d", ret);
@@ -912,7 +919,9 @@ int VideoDecoder::Start() {
 
 int VideoDecoder::Stop() {
     running_ = false;
-    NativeRender::GetInstance()->ResetPresentationClock();
+    if (render_ != nullptr) {
+        render_->ResetPresentationClock();
+    }
     
     // 同步模式：停止解码线程
     // 必须先 join 线程（等待 shared_lock 释放），再获取 unique_lock
@@ -958,7 +967,9 @@ int VideoDecoder::Flush() {
         return -1;
     }
 
-    NativeRender::GetInstance()->ResetPresentationClock();
+    if (render_ != nullptr) {
+        render_->ResetPresentationClock();
+    }
     
     // 参考官方文档：使用 unique_lock 保护 Flush 操作，防止解码线程并发访问
     std::unique_lock<std::shared_mutex> codecLock(codecMutex_);
@@ -1007,10 +1018,11 @@ void VideoDecoder::Cleanup() {
         while (!pendingFrameQueue_.empty()) pendingFrameQueue_.pop();
     }
     
-    // 清空时间戳映射
+    // 清空时间戳环
     {
         std::lock_guard<std::mutex> lock(timestampMutex_);
-        timestampToEnqueueTime_.clear();
+        timestampEntries_.fill({});
+        timestampWriteIndex_ = 0;
     }
     
     window_ = nullptr;
@@ -1023,6 +1035,8 @@ void VideoDecoder::Cleanup() {
     burstFrameCount_ = 0;
     lastAsyncRenderTimeMs_ = 0;
     lastAsyncOutputTimeMs_ = 0;
+    render_ = nullptr;
+    postProcessor_ = nullptr;
     
     OH_LOG_INFO(LOG_APP, "Video decoder cleaned up");
 }
@@ -1048,13 +1062,30 @@ static OH_AVCodecBufferAttr MakeInputBufferAttr(int32_t size, int64_t pts, Video
 }
 
 void VideoDecoder::RecordEnqueueTimestamp(int64_t timestamp) {
-    auto enqueueTimeMs = std::chrono::duration_cast<std::chrono::milliseconds>(
-        std::chrono::steady_clock::now().time_since_epoch()).count();
+    const int64_t enqueueTimeMs = GetSteadyTimeMs();
     std::lock_guard<std::mutex> lock(timestampMutex_);
-    timestampToEnqueueTime_[timestamp] = enqueueTimeMs;
-    if (timestampToEnqueueTime_.size() > kMaxTimestampMapSize) {
-        timestampToEnqueueTime_.erase(timestampToEnqueueTime_.begin());
+
+    TimestampEntry& entry = timestampEntries_[timestampWriteIndex_];
+    entry.pts = timestamp;
+    entry.enqueueTimeMs = enqueueTimeMs;
+    entry.valid = true;
+    timestampWriteIndex_ = (timestampWriteIndex_ + 1) % timestampEntries_.size();
+}
+
+int64_t VideoDecoder::TakeEnqueueTimestamp(int64_t timestamp) {
+    std::lock_guard<std::mutex> lock(timestampMutex_);
+
+    // Search newest-first so a repeated PTS resolves to the latest submission.
+    for (size_t offset = 0; offset < timestampEntries_.size(); ++offset) {
+        const size_t index =
+            (timestampWriteIndex_ + timestampEntries_.size() - 1 - offset) % timestampEntries_.size();
+        TimestampEntry& entry = timestampEntries_[index];
+        if (entry.valid && entry.pts == timestamp) {
+            entry.valid = false;
+            return entry.enqueueTimeMs;
+        }
     }
+    return 0;
 }
 
 int VideoDecoder::SubmitDecodeUnitScatter(const BufferSegment* segments, int segmentCount,
@@ -1065,7 +1096,7 @@ int VideoDecoder::SubmitDecodeUnitScatter(const BufferSegment* segments, int seg
     if (!running_ || decoder_ == nullptr) {
         return -1;
     }
-    
+
     // 解码器健康检查（节流：每 500ms 一次）
     // 如果解码器已失效，尽早返回错误触发上层恢复
     if (!CheckDecoderValid()) {
@@ -1079,8 +1110,7 @@ int VideoDecoder::SubmitDecodeUnitScatter(const BufferSegment* segments, int seg
     // === L4 网络抖动突发检测（仅异步模式） ===
     // 同步模式下 L1 drain-to-latest 已足够处理突发到达，L4 的 IDR 请求反而会加重负担
     if (config_.decoderMode != DecoderMode::SYNC) {
-        auto nowMs = std::chrono::duration_cast<std::chrono::milliseconds>(
-            std::chrono::steady_clock::now().time_since_epoch()).count();
+        const int64_t nowMs = GetSteadyTimeMs();
         int64_t lastArrival = lastFrameArrivalMs_.exchange(nowMs);
         double expectedFrameMs = 1000.0 / config_.fps;
         
@@ -1089,7 +1119,8 @@ int VideoDecoder::SubmitDecodeUnitScatter(const BufferSegment* segments, int seg
         int burstThreshold = std::max(kBurstFlushThreshold,
             static_cast<int>(kBurstFlushThreshold * config_.fps / kBurstBaselineFps + 0.5));
         
-        if (lastArrival > 0 && (nowMs - lastArrival) < static_cast<int64_t>(expectedFrameMs * kBurstIntervalRatio)) {
+        if (lastArrival > 0 &&
+            (nowMs - lastArrival) < static_cast<int64_t>(expectedFrameMs * kBurstIntervalRatio)) {
             int burst = burstFrameCount_.fetch_add(1) + 1;
             if (burst >= burstThreshold && frameType != VideoFrameType::I_FRAME) {
                 burstFrameCount_.store(0);
@@ -1105,14 +1136,10 @@ int VideoDecoder::SubmitDecodeUnitScatter(const BufferSegment* segments, int seg
                         OH_LOG_WARN(LOG_APP, "L4 burst flush: cleared %{public}d queued frames", cleared);
                     }
                 }
-                NativeRender::GetInstance()->ResetPresentationClock();
+                render_->ResetPresentationClock();
                 latencyRecoveryActive_.store(true);
                 UpdateReceivedStats(totalSize, frameNumber, hostProcessingLatency);
-                {
-                    std::lock_guard<std::mutex> lock(statsMutex_);
-                    stats_.droppedFrames++;
-                    stats_.droppedByL4++;
-                }
+                RecordDroppedFrames(DropReason::L4);
                 OH_LOG_WARN(LOG_APP, "L4 burst detected (%{public}d/%{public}d frames in <%.1fms interval @%.0ffps), requesting IDR",
                             burst, burstThreshold, expectedFrameMs * kBurstIntervalRatio, config_.fps);
                 return -1;  // DR_NEED_IDR
@@ -1124,7 +1151,8 @@ int VideoDecoder::SubmitDecodeUnitScatter(const BufferSegment* segments, int seg
     
     // === L3 延迟恢复：临界延迟检查 ===
     // 当解码延迟过高时，丢弃 P 帧并触发 IDR 请求
-    int recoveryResult = CheckLatencyRecovery(frameType, totalSize, frameNumber, hostProcessingLatency);
+    int recoveryResult = CheckLatencyRecovery(
+        frameType, totalSize, frameNumber, hostProcessingLatency);
     if (recoveryResult < 0) {
         return recoveryResult;  // -1 = DR_NEED_IDR
     }
@@ -1181,14 +1209,14 @@ int VideoDecoder::SubmitDecodeUnitScatter(const BufferSegment* segments, int seg
         
         // 直接提交失败，回退到队列（需要合并数据）
         {
-            bool hadOverflow = false;
+            uint64_t overflowCount = 0;
             std::lock_guard<std::mutex> lock(pendingFrameMutex_);
             while (pendingFrameQueue_.size() >= maxPendingFrames_) {
-                hadOverflow = true;
                 pendingFrameQueue_.pop();
-                std::lock_guard<std::mutex> statsLock(statsMutex_);
-                stats_.droppedFrames++;
-                stats_.droppedByQueueOverflow++;
+                overflowCount++;
+            }
+            if (overflowCount > 0) {
+                RecordDroppedFrames(DropReason::QUEUE_OVERFLOW, overflowCount);
             }
             
             PendingFrame frame;
@@ -1204,7 +1232,7 @@ int VideoDecoder::SubmitDecodeUnitScatter(const BufferSegment* segments, int seg
             
             // 队列溢出 = 丢弃了中间 P 帧 → 后续 P 帧缺少参考帧会损坏
             // 激活恢复模式：丢弃后续 P 帧，等待 IDR 重建参考链
-            if (hadOverflow && !latencyRecoveryActive_.exchange(true)) {
+            if (overflowCount > 0 && !latencyRecoveryActive_.exchange(true)) {
                 LiRequestIdrFrame();
                 OH_LOG_WARN(LOG_APP, "Scatter sync: queue overflow, requesting IDR recovery");
             }
@@ -1224,9 +1252,7 @@ int VideoDecoder::SubmitDecodeUnitScatter(const BufferSegment* segments, int seg
         if (inputIndexQueue_.empty()) {
             if (!inputCond_.wait_for(lock, std::chrono::milliseconds(timeoutMs), 
                 [this] { return !inputIndexQueue_.empty() || !running_; })) {
-                std::lock_guard<std::mutex> statsLock(statsMutex_);
-                stats_.droppedFrames++;
-                stats_.droppedByTimeout++;
+                RecordDroppedFrames(DropReason::TIMEOUT);
                 return -1;
             }
         }
@@ -1300,6 +1326,7 @@ int VideoDecoder::SubmitDecodeUnit(const uint8_t* data, int size,
 
 // 更新接收帧统计（提取公共逻辑）
 void VideoDecoder::UpdateReceivedStats(int size, int frameNumber, uint16_t hostProcessingLatency) {
+    const int64_t currentTimeMs = GetSteadyTimeMs();
     std::lock_guard<std::mutex> lock(statsMutex_);
     stats_.totalFrames++;
     stats_.totalBytesReceived += size;
@@ -1316,9 +1343,6 @@ void VideoDecoder::UpdateReceivedStats(int size, int frameNumber, uint16_t hostP
     }
     stats_.lastFrameNumber = frameNumber;
     
-    auto currentTimeMs = std::chrono::duration_cast<std::chrono::milliseconds>(
-        std::chrono::steady_clock::now().time_since_epoch()).count();
-
     // Keep the live overlay responsive to recovery instead of letting old
     // high-latency frames affect the value for the rest of the session.
     if (recentHostLatencyWindowStartTimeMs_ == 0) {
@@ -1345,7 +1369,7 @@ void VideoDecoder::UpdateReceivedStats(int size, int frameNumber, uint16_t hostP
         // 两个 lastCount 都设为当前值，这样后续计算的 delta 是正确的增量
         stats_.lastFpsCalculationTime = currentTimeMs;
         stats_.lastFrameCount = stats_.totalFrames;  // 基线 = 当前总帧数 (已包含第一帧)
-        stats_.lastDecodedFrameCount = stats_.decodedFrames;  // 基线 = 当前解码帧数 (可能为 0)
+        stats_.lastDecodedFrameCount = decodedFrames_.load(std::memory_order_relaxed);
         stats_.lastRenderedFpsCalculationTime = currentTimeMs;
         stats_.lastBytesCount = stats_.totalBytesReceived;
         stats_.lastBitrateCalculationTime = currentTimeMs;
@@ -1361,9 +1385,10 @@ void VideoDecoder::UpdateReceivedStats(int size, int frameNumber, uint16_t hostP
         
         // 计算渲染帧率 (RD) - 使用相同的时间窗口
         // decodedDelta = 当前解码帧数 - 上个窗口结束时的解码帧数
-        uint64_t decodedDelta = stats_.decodedFrames - stats_.lastDecodedFrameCount;
+        const uint64_t decodedFrames = decodedFrames_.load(std::memory_order_relaxed);
+        uint64_t decodedDelta = decodedFrames - stats_.lastDecodedFrameCount;
         stats_.renderedFps = static_cast<double>(decodedDelta) * 1000.0 / static_cast<double>(elapsedMs);
-        stats_.lastDecodedFrameCount = stats_.decodedFrames;
+        stats_.lastDecodedFrameCount = decodedFrames;
         
         // 更新公共时间基线
         stats_.lastFpsCalculationTime = currentTimeMs;
@@ -1373,7 +1398,8 @@ void VideoDecoder::UpdateReceivedStats(int size, int frameNumber, uint16_t hostP
         if (stats_.sessionStartTime > 0) {
             int64_t sessionMs = currentTimeMs - stats_.sessionStartTime;
             if (sessionMs > 0) {
-                stats_.globalAvgFps = static_cast<double>(stats_.decodedFrames) * 1000.0 / static_cast<double>(sessionMs);
+                stats_.globalAvgFps = static_cast<double>(decodedFrames) * 1000.0 /
+                    static_cast<double>(sessionMs);
             }
         }
         
@@ -1391,8 +1417,56 @@ void VideoDecoder::UpdateReceivedStats(int size, int frameNumber, uint16_t hostP
 }
 
 VideoDecoderStats VideoDecoder::GetStats() const {
-    std::lock_guard<std::mutex> lock(statsMutex_);
-    return stats_;
+    VideoDecoderStats snapshot;
+    {
+        std::lock_guard<std::mutex> lock(statsMutex_);
+        snapshot = stats_;
+    }
+
+    snapshot.decodedFrames = decodedFrames_.load(std::memory_order_relaxed);
+    snapshot.droppedFrames = droppedFrames_.load(std::memory_order_relaxed);
+    snapshot.droppedByL1 = droppedByL1_.load(std::memory_order_relaxed);
+    snapshot.droppedByL2 = droppedByL2_.load(std::memory_order_relaxed);
+    snapshot.droppedByL3 = droppedByL3_.load(std::memory_order_relaxed);
+    snapshot.droppedByL4 = droppedByL4_.load(std::memory_order_relaxed);
+    snapshot.droppedByL5 = droppedByL5_.load(std::memory_order_relaxed);
+    snapshot.droppedByQueueOverflow = droppedByQueueOverflow_.load(std::memory_order_relaxed);
+    snapshot.droppedByTimeout = droppedByTimeout_.load(std::memory_order_relaxed);
+    {
+        std::lock_guard<std::mutex> lock(decodeStatsMutex_);
+        snapshot.totalDecodeTimeMs = static_cast<double>(decodeTotalTimeMs_);
+        snapshot.validDecodeFrames = decodeValidFrames_;
+        snapshot.averageDecodeTimeMs = decodeAverageTimeMs_;
+        snapshot.maxDecodeTimeMs = static_cast<double>(decodeMaxTimeMs_);
+    }
+    return snapshot;
+}
+
+void VideoDecoder::RecordDroppedFrames(DropReason reason, uint64_t count) {
+    droppedFrames_.fetch_add(count, std::memory_order_relaxed);
+    switch (reason) {
+        case DropReason::L1:
+            droppedByL1_.fetch_add(count, std::memory_order_relaxed);
+            break;
+        case DropReason::L2:
+            droppedByL2_.fetch_add(count, std::memory_order_relaxed);
+            break;
+        case DropReason::L3:
+            droppedByL3_.fetch_add(count, std::memory_order_relaxed);
+            break;
+        case DropReason::L4:
+            droppedByL4_.fetch_add(count, std::memory_order_relaxed);
+            break;
+        case DropReason::L5:
+            droppedByL5_.fetch_add(count, std::memory_order_relaxed);
+            break;
+        case DropReason::QUEUE_OVERFLOW:
+            droppedByQueueOverflow_.fetch_add(count, std::memory_order_relaxed);
+            break;
+        case DropReason::TIMEOUT:
+            droppedByTimeout_.fetch_add(count, std::memory_order_relaxed);
+            break;
+    }
 }
 
 // =============================================================================
@@ -1439,38 +1513,27 @@ void VideoDecoder::OnOutputBufferAvailable(OH_AVCodec* codec, uint32_t index,
     if (OH_AVBuffer_GetBufferAttr(buffer, &attr) == AV_ERR_OK) {
         pts = attr.pts;
     }
+
+    const int64_t outputTimeMs = GetSteadyTimeMs();
     
     // 获取入队时间
-    int64_t enqueueTimeMs = 0;
-    {
-        std::lock_guard<std::mutex> lock(self->timestampMutex_);
-        auto it = self->timestampToEnqueueTime_.find(pts);
-        if (it != self->timestampToEnqueueTime_.end()) {
-            enqueueTimeMs = it->second;
-            self->timestampToEnqueueTime_.erase(it);
-        }
-    }
+    const int64_t enqueueTimeMs = self->TakeEnqueueTimestamp(pts);
     
     // === L2 延迟恢复：异步模式基于延迟的帧跳过 ===
     // 当解码耗时过高时，跳过非关键帧以快速追赶
     if (enqueueTimeMs > 0) {
-        auto currentTimeMs = std::chrono::duration_cast<std::chrono::milliseconds>(
-            std::chrono::steady_clock::now().time_since_epoch()).count();
         // 记录回调到达时间（用于 L5 输出间隔检测，排除渲染处理开销的抖动）
-        int64_t prevOutputTimeMs = self->lastAsyncOutputTimeMs_.exchange(currentTimeMs);
-        int64_t instantDecodeTimeMs = currentTimeMs - enqueueTimeMs;
+        int64_t prevOutputTimeMs = self->lastAsyncOutputTimeMs_.exchange(outputTimeMs);
+        int64_t instantDecodeTimeMs = outputTimeMs - enqueueTimeMs;
         double expectedFrameTimeMs = 1000.0 / self->config_.fps;
         bool isKeyframe = (attr.flags & AVCODEC_BUFFER_FLAGS_SYNC_FRAME) != 0;
         
         // 跳过条件：解码时间 > 3倍帧间隔 且 非关键帧 且 已过启动阶段
         if (instantDecodeTimeMs > expectedFrameTimeMs * kAsyncSkipThresholdMultiplier &&
-            !isKeyframe && self->stats_.decodedFrames > kLatencyRecoveryMinFrames) {
+            !isKeyframe &&
+            self->decodedFrames_.load(std::memory_order_relaxed) > kLatencyRecoveryMinFrames) {
             OH_VideoDecoder_FreeOutputBuffer(codec, index);
-            {
-                std::lock_guard<std::mutex> lock(self->statsMutex_);
-                self->stats_.droppedFrames++;
-                self->stats_.droppedByL2++;
-            }
+            self->RecordDroppedFrames(DropReason::L2);
             // 注意：不要把含排队等待的管线延迟 instantDecodeTimeMs 写入 lastInstantDecodeTimeMs_。
             // 该字段是 L3 临界延迟判据的输入，应只反映"真实解码耗时"（剔除队列等待）。
             // 若在此写入管线延迟，会让 L3 把网络抖动/积压误判为解码卡顿而触发 IDR（L2→L3 串扰）。
@@ -1483,8 +1546,8 @@ void VideoDecoder::OnOutputBufferAvailable(OH_AVCodec* codec, uint32_t index,
         // 高帧率（>90fps）使用更宽松的阈值，避免 VPU 正常管线延迟被误判
         // 使用回调到达间隔（而非渲染完成间隔），排除 GL 后处理/锁竞争等开销的抖动
         if (prevOutputTimeMs > 0 && !isKeyframe &&
-            self->stats_.decodedFrames > kLatencyRecoveryMinFrames) {
-            int64_t outputInterval = currentTimeMs - prevOutputTimeMs;
+            self->decodedFrames_.load(std::memory_order_relaxed) > kLatencyRecoveryMinFrames) {
+            int64_t outputInterval = outputTimeMs - prevOutputTimeMs;
             // 根据帧率选择阈值
             double latencyRatio = (self->config_.fps > kL5HighFpsThreshold)
                 ? kL5LatencyRatio_HighFps : kL5LatencyRatio_Base;
@@ -1497,11 +1560,7 @@ void VideoDecoder::OnOutputBufferAvailable(OH_AVCodec* codec, uint32_t index,
                 instantDecodeTimeMs > static_cast<int64_t>(expectedFrameTimeMs * latencyRatio) &&
                 meetsAbsoluteFloor) {
                 OH_VideoDecoder_FreeOutputBuffer(codec, index);
-                {
-                    std::lock_guard<std::mutex> lock(self->statsMutex_);
-                    self->stats_.droppedFrames++;
-                    self->stats_.droppedByL5++;
-                }
+                self->RecordDroppedFrames(DropReason::L5);
                 // 低帧率：回退 outputTime（级联丢帧确保 burst 中只保留最新帧）
                 // 高帧率：保持当前值不回退（避免级联丢帧过度）
                 if (self->config_.fps <= kL5HighFpsThreshold) {
@@ -1513,14 +1572,10 @@ void VideoDecoder::OnOutputBufferAvailable(OH_AVCodec* codec, uint32_t index,
     }
     
     // 更新异步渲染时间戳
-    {
-        auto renderNow = std::chrono::duration_cast<std::chrono::milliseconds>(
-            std::chrono::steady_clock::now().time_since_epoch()).count();
-        self->lastAsyncRenderTimeMs_.store(renderNow);
-    }
+    self->lastAsyncRenderTimeMs_.store(outputTimeMs);
     
     // 更新解码统计（复用统一函数）
-    self->UpdateDecodedStats(pts, enqueueTimeMs, attr.flags);
+    self->UpdateDecodedStats(pts, enqueueTimeMs, attr.flags, outputTimeMs);
     
     // 注意：异步模式不在此处做帧率限制
     // 原因：
@@ -1532,13 +1587,13 @@ void VideoDecoder::OnOutputBufferAvailable(OH_AVCodec* codec, uint32_t index,
     // 渲染到 Surface
     // 检查是否使用异步渲染（通过 NativeRender）
     if (g_useAsyncRender) {
-        NativeRender* render = NativeRender::GetInstance();
+        NativeRender* render = self->render_;
         if (render != nullptr && render->IsSurfaceReady()) {
             if (render->SubmitFrame(codec, index, pts) != AV_ERR_OK) {
                 OH_VideoDecoder_FreeOutputBuffer(codec, index);
             }
             // 后处理：如果启用，从代理 surface 读取并处理到显示 surface
-            GLPostProcessor* postProc = GLPostProcessor::GetInstance();
+            GLPostProcessor* postProc = self->postProcessor_;
             if (postProc->IsActive()) {
                 postProc->ProcessFrame();
             }
@@ -1547,14 +1602,14 @@ void VideoDecoder::OnOutputBufferAvailable(OH_AVCodec* codec, uint32_t index,
     }
     
     // 非 NativeRender surface 路径也使用同一呈现控制器，保持两步语义一致。
-    NativeRender* render = NativeRender::GetInstance();
+    NativeRender* render = self->render_;
     if (render->SubmitFrame(codec, index, pts) != AV_ERR_OK) {
         OH_VideoDecoder_FreeOutputBuffer(codec, index);
     }
     
     // 后处理：非异步路径也需要处理
     {
-        GLPostProcessor* postProc = GLPostProcessor::GetInstance();
+        GLPostProcessor* postProc = self->postProcessor_;
         if (postProc->IsActive()) {
             postProc->ProcessFrame();
         }
@@ -1565,12 +1620,10 @@ void VideoDecoder::OnOutputBufferAvailable(OH_AVCodec* codec, uint32_t index,
 // 同步模式解码实现
 // =============================================================================
 
-void VideoDecoder::UpdateDecodedStats(int64_t pts, int64_t enqueueTimeMs, uint32_t flags) {
-    auto currentTimeMs = std::chrono::duration_cast<std::chrono::milliseconds>(
-        std::chrono::steady_clock::now().time_since_epoch()).count();
-    
-    std::lock_guard<std::mutex> lock(statsMutex_);
-    stats_.decodedFrames++;
+void VideoDecoder::UpdateDecodedStats(int64_t pts, int64_t enqueueTimeMs, uint32_t flags,
+                                      int64_t currentTimeMs) {
+    const uint64_t decodedFrames =
+        decodedFrames_.fetch_add(1, std::memory_order_relaxed) + 1;
     
     if (enqueueTimeMs > 0) {
         // === 精确解码时间：排除队列等待 ===
@@ -1593,20 +1646,22 @@ void VideoDecoder::UpdateDecodedStats(int64_t pts, int64_t enqueueTimeMs, uint32
             // 瞬时解码时间使用精确值（用户可见统计）
             lastInstantDecodeTimeMs_.store(decodeTimeMs);
             
-            // 累积解码时间（用于串流结束后计算全局平均值）
-            stats_.totalDecodeTimeMs += static_cast<double>(decodeTimeMs);
-            stats_.validDecodeFrames++;
-            
-            if (stats_.decodedFrames == 1) {
-                stats_.averageDecodeTimeMs = static_cast<double>(decodeTimeMs);
+            // Output callbacks share this small accumulator but no longer
+            // contend with receive statistics or UI snapshot reads per frame.
+            std::lock_guard<std::mutex> lock(decodeStatsMutex_);
+            decodeTotalTimeMs_ += static_cast<uint64_t>(decodeTimeMs);
+            decodeValidFrames_++;
+
+            if (decodedFrames == 1) {
+                decodeAverageTimeMs_ = static_cast<double>(decodeTimeMs);
             } else {
-                double alpha = isKeyframe ? kEmaAlphaKeyframe : kEmaAlphaNormal;
-                stats_.averageDecodeTimeMs = alpha * decodeTimeMs + 
-                    (1.0 - alpha) * stats_.averageDecodeTimeMs;
+                const double alpha = isKeyframe ? kEmaAlphaKeyframe : kEmaAlphaNormal;
+                decodeAverageTimeMs_ = alpha * decodeTimeMs +
+                    (1.0 - alpha) * decodeAverageTimeMs_;
             }
-            
-            if (static_cast<double>(decodeTimeMs) > stats_.maxDecodeTimeMs) {
-                stats_.maxDecodeTimeMs = static_cast<double>(decodeTimeMs);
+
+            if (decodeTimeMs > decodeMaxTimeMs_) {
+                decodeMaxTimeMs_ = decodeTimeMs;
             }
         }
         
@@ -1617,9 +1672,15 @@ void VideoDecoder::UpdateDecodedStats(int64_t pts, int64_t enqueueTimeMs, uint32
         // 为保持 L3 敏感度，额外检查管线延迟是否超过临界值
         if (pipelineLatencyMs > static_cast<int64_t>(
                 std::max(1000.0 / config_.fps * kCriticalLatencyMultiplier, kCriticalLatencyMinMs)) &&
-            stats_.decodedFrames > kLatencyRecoveryMinFrames) {
+            decodedFrames > kLatencyRecoveryMinFrames) {
             // 管线延迟已超临界，但精确解码时间可能正常——标记为需要恢复
-            if (!latencyRecoveryActive_.load()) {
+            constexpr int64_t kPipelineWarningIntervalMs = 5000;
+            const int64_t lastWarningMs =
+                lastPipelineWarningTimeMs_.load(std::memory_order_relaxed);
+            if (!latencyRecoveryActive_.load() &&
+                (lastWarningMs == 0 ||
+                 currentTimeMs - lastWarningMs >= kPipelineWarningIntervalMs)) {
+                lastPipelineWarningTimeMs_.store(currentTimeMs, std::memory_order_relaxed);
                 OH_LOG_WARN(LOG_APP, "Pipeline latency %{public}lldms critical (decode=%{public}lldms), flagging recovery",
                             static_cast<long long>(pipelineLatencyMs),
                             static_cast<long long>(decodeTimeMs));
@@ -1642,16 +1703,15 @@ bool VideoDecoder::CheckDecoderValid() {
         return false;
     }
     
-    auto nowMs = std::chrono::duration_cast<std::chrono::milliseconds>(
-        std::chrono::steady_clock::now().time_since_epoch()).count();
+    const int64_t currentTimeMs = GetSteadyTimeMs();
     
     // 节流：每 500ms 检查一次
     constexpr int64_t kHealthCheckIntervalMs = 500;
     int64_t lastCheck = lastHealthCheckTimeMs_.load();
-    if (nowMs - lastCheck < kHealthCheckIntervalMs) {
+    if (currentTimeMs - lastCheck < kHealthCheckIntervalMs) {
         return true;  // 在冷却期内，假定有效
     }
-    lastHealthCheckTimeMs_.store(nowMs);
+    lastHealthCheckTimeMs_.store(currentTimeMs);
     
     bool isValid = false;
     OH_AVErrCode ret = OH_VideoDecoder_IsValid(decoder_, &isValid);
@@ -1675,7 +1735,8 @@ bool VideoDecoder::CheckDecoderValid() {
 // 配合输出端 drain-to-latest，可在最短时间内恢复到正常延迟
 // =============================================================================
 
-int VideoDecoder::CheckLatencyRecovery(VideoFrameType frameType, int size, int frameNumber, uint16_t hostProcessingLatency) {
+int VideoDecoder::CheckLatencyRecovery(VideoFrameType frameType, int size, int frameNumber,
+                                       uint16_t hostProcessingLatency) {
     bool isIFrame = (frameType == VideoFrameType::I_FRAME);
     
     // 收到 IDR 帧时重置恢复状态
@@ -1695,17 +1756,16 @@ int VideoDecoder::CheckLatencyRecovery(VideoFrameType frameType, int size, int f
     // 恢复模式已激活（由 L3 临界延迟或队列溢出触发），持续丢弃 P 帧直到 IDR 到达
     // 避免向解码器提交缺少参考帧的 P 帧，那样会导致输出损坏或卡顿
     if (latencyRecoveryActive_.load()) {
-        int64_t nowMs = std::chrono::duration_cast<std::chrono::milliseconds>(
-            std::chrono::steady_clock::now().time_since_epoch()).count();
+        const int64_t currentTimeMs = GetSteadyTimeMs();
         int64_t startMs = latencyRecoveryStartMs_.load();
         if (startMs == 0) {
-            latencyRecoveryStartMs_.store(nowMs);
-            startMs = nowMs;
+            latencyRecoveryStartMs_.store(currentTimeMs);
+            startMs = currentTimeMs;
         }
         // 超时兜底：IDR 久未到达（可能请求或 IDR 本身在弱网下丢失），
         // 若继续盲丢所有 P 帧会造成长时间冻结。超时后恢复正常提交并补发一次 IDR 请求，
         // 宁可短暂出现参考链断裂的瑕疵，也不要长冻结。
-        if (nowMs - startMs > kLatencyRecoveryTimeoutMs) {
+        if (currentTimeMs - startMs > kLatencyRecoveryTimeoutMs) {
             latencyRecoveryActive_.store(false);
             latencyRecoveryStartMs_.store(0);
             // 重置陈旧的解码耗时读数：恢复期间无新解码，lastInstantDecodeTimeMs_ 仍是触发时的高值，
@@ -1713,15 +1773,11 @@ int VideoDecoder::CheckLatencyRecovery(VideoFrameType frameType, int size, int f
             lastInstantDecodeTimeMs_.store(0);
             LiRequestIdrFrame();
             OH_LOG_WARN(LOG_APP, "Latency recovery timeout (%{public}lldms), resuming submit and re-requesting IDR",
-                        static_cast<long long>(nowMs - startMs));
+                        static_cast<long long>(currentTimeMs - startMs));
             // 不丢弃当前帧，落到下方正常处理逻辑
         } else {
             UpdateReceivedStats(size, frameNumber, hostProcessingLatency);
-            {
-                std::lock_guard<std::mutex> lock(statsMutex_);
-                stats_.droppedFrames++;
-                stats_.droppedByL3++;
-            }
+            RecordDroppedFrames(DropReason::L3);
             return -1;  // DR_NEED_IDR
         }
     }
@@ -1731,11 +1787,7 @@ int VideoDecoder::CheckLatencyRecovery(VideoFrameType frameType, int size, int f
     double criticalThresholdMs = std::max(expectedFrameTimeMs * kCriticalLatencyMultiplier, kCriticalLatencyMinMs);
     
     // 检查是否已过启动阶段（避免初始化时的误触发）
-    uint64_t decodedFrames;
-    {
-        std::lock_guard<std::mutex> lock(statsMutex_);
-        decodedFrames = stats_.decodedFrames;
-    }
+    const uint64_t decodedFrames = decodedFrames_.load(std::memory_order_relaxed);
     if (decodedFrames < static_cast<uint64_t>(kLatencyRecoveryMinFrames)) {
         return 0;
     }
@@ -1749,11 +1801,7 @@ int VideoDecoder::CheckLatencyRecovery(VideoFrameType frameType, int size, int f
         
         // 更新接收统计（帧被接收但被丢弃）
         UpdateReceivedStats(size, frameNumber, hostProcessingLatency);
-        {
-            std::lock_guard<std::mutex> lock(statsMutex_);
-            stats_.droppedFrames++;
-            stats_.droppedByL3++;
-        }
+        RecordDroppedFrames(DropReason::L3);
         return -1;  // DR_NEED_IDR
     }
     
@@ -1773,6 +1821,9 @@ void VideoDecoder::SyncDecodeLoop() {
     bool firstFrameRendered = false;
     int totalQueueInputSuccess = 0;  // 从后备队列提交的帧数
     int totalOutputSuccess = 0;
+    syncDrainEventsSinceLog_ = 0;
+    syncDrainFramesSinceLog_ = 0;
+    auto lastLogTime = std::chrono::steady_clock::now();
     
     // 冻结检测：基于墙钟时间而非循环次数
     // 原因：当队列非空且 timeout=0 时循环极快（<0.1ms/次），
@@ -1836,7 +1887,7 @@ void VideoDecoder::SyncDecodeLoop() {
             if (firstFrameRendered && timeSinceLastOutput >= kFreezeDetectionMs) {
                 OH_LOG_WARN(LOG_APP, "Sync decode: no output for %{public}lldms, flushing decoder + requesting IDR",
                             static_cast<long long>(timeSinceLastOutput));
-                NativeRender::GetInstance()->ResetPresentationClock();
+                render_->ResetPresentationClock();
                 
                 // Flush 清空解码器内部缓冲 + 请求 IDR 关键帧
                 // 使用 unique_lock 独占解码器操作
@@ -1884,13 +1935,22 @@ void VideoDecoder::SyncDecodeLoop() {
             }
         }
         
-        // 统计日志（每秒一次）
-        static thread_local auto lastLogTime = std::chrono::steady_clock::now();
+        // Aggregate diagnostics off the congested path.
         auto now = std::chrono::steady_clock::now();
-        if (std::chrono::duration_cast<std::chrono::milliseconds>(now - lastLogTime).count() >= 1000) {
-            std::lock_guard<std::mutex> lock(pendingFrameMutex_);
-            OH_LOG_INFO(LOG_APP, "Sync stats: queueIn=%{public}d, output=%{public}d, pending=%{public}zu", 
-                        totalQueueInputSuccess, totalOutputSuccess, pendingFrameQueue_.size());
+        if (std::chrono::duration_cast<std::chrono::milliseconds>(now - lastLogTime).count() >=
+            kSyncLogIntervalMs) {
+            size_t pendingFrames = 0;
+            {
+                std::lock_guard<std::mutex> lock(pendingFrameMutex_);
+                pendingFrames = pendingFrameQueue_.size();
+            }
+            OH_LOG_INFO(LOG_APP,
+                "Sync stats: queueIn=%{public}d, output=%{public}d, pending=%{public}zu, drainEvents=%{public}lld, drainFrames=%{public}lld",
+                totalQueueInputSuccess, totalOutputSuccess, pendingFrames,
+                static_cast<long long>(syncDrainEventsSinceLog_),
+                static_cast<long long>(syncDrainFramesSinceLog_));
+            syncDrainEventsSinceLog_ = 0;
+            syncDrainFramesSinceLog_ = 0;
             lastLogTime = now;
         }
         
@@ -2066,16 +2126,19 @@ int VideoDecoder::SyncProcessOutput(int64_t timeoutUs) {
     // 代价：IDR 慢解码时 Rd FPS 瞬时下降，但端到端延迟始终最低
     // ================================================================
     
-    // 收集所有可用的输出帧
     struct QueuedFrame {
         uint32_t index;
-        OH_AVBuffer* buffer;
         OH_AVCodecBufferAttr attr;
     };
-    std::vector<QueuedFrame> outputFrames;
-    outputFrames.push_back({outputIndex, outputBuffer, attr});
-    
-    while (running_ && syncDecodeRunning_) {
+    // Collect a bounded snapshot without releasing slots while querying. If a
+    // released slot were reused immediately, an unbounded drain could chase the
+    // decoder indefinitely and postpone presentation.
+    static constexpr size_t kMaxDrainBatch = 32;
+    std::array<QueuedFrame, kMaxDrainBatch> outputFrames;
+    size_t totalFrames = 1;
+    outputFrames[0] = {outputIndex, attr};
+
+    while (running_ && syncDecodeRunning_ && totalFrames < outputFrames.size()) {
         uint32_t nextOutputIndex = 0;
         OH_AVErrCode nextRet = pfn_QueryOutputBuffer(decoder_, &nextOutputIndex, 0);
         if (nextRet != AV_ERR_OK) {
@@ -2084,11 +2147,13 @@ int VideoDecoder::SyncProcessOutput(int64_t timeoutUs) {
         
         OH_AVBuffer* nextBuffer = pfn_GetOutputBuffer(decoder_, nextOutputIndex);
         if (nextBuffer == nullptr) {
+            OH_VideoDecoder_FreeOutputBuffer(decoder_, nextOutputIndex);
             break;
         }
         
         OH_AVCodecBufferAttr nextAttr;
         if (OH_AVBuffer_GetBufferAttr(nextBuffer, &nextAttr) != AV_ERR_OK) {
+            OH_VideoDecoder_FreeOutputBuffer(decoder_, nextOutputIndex);
             break;
         }
         
@@ -2098,66 +2163,44 @@ int VideoDecoder::SyncProcessOutput(int64_t timeoutUs) {
             break;
         }
         
-        outputFrames.push_back({nextOutputIndex, nextBuffer, nextAttr});
+        outputFrames[totalFrames++] = {nextOutputIndex, nextAttr};
     }
-    
-    int totalFrames = static_cast<int>(outputFrames.size());
-    
-    // 丢弃所有旧帧，仅保留最新帧
+
     if (totalFrames > 1) {
-        int drainedCount = totalFrames - 1;
-        for (int i = 0; i < drainedCount; i++) {
-            auto& frame = outputFrames[i];
-            {
-                std::lock_guard<std::mutex> lock(timestampMutex_);
-                timestampToEnqueueTime_.erase(frame.attr.pts);
-            }
-            OH_VideoDecoder_FreeOutputBuffer(decoder_, frame.index);
+        const uint64_t drainedCount = totalFrames - 1;
+        for (size_t i = 0; i < drainedCount; ++i) {
+            TakeEnqueueTimestamp(outputFrames[i].attr.pts);
+            OH_VideoDecoder_FreeOutputBuffer(decoder_, outputFrames[i].index);
         }
-        {
-            std::lock_guard<std::mutex> lock(statsMutex_);
-            stats_.droppedFrames += drainedCount;
-            stats_.droppedByL1 += drainedCount;
-        }
-        OH_LOG_INFO(LOG_APP, "L1 drain-to-latest: skipped %{public}d frames (total=%{public}d)",
-                    drainedCount, totalFrames);
+        RecordDroppedFrames(DropReason::L1, drainedCount);
+        syncDrainEventsSinceLog_++;
+        syncDrainFramesSinceLog_ += drainedCount;
     }
-    
-    // 渲染最新帧
-    auto& latestFrame = outputFrames.back();
-    int64_t pts = latestFrame.attr.pts;
-    
-    // 获取入队时间以计算解码延迟
-    int64_t enqueueTimeMs = 0;
-    {
-        std::lock_guard<std::mutex> lock(timestampMutex_);
-        auto it = timestampToEnqueueTime_.find(pts);
-        if (it != timestampToEnqueueTime_.end()) {
-            enqueueTimeMs = it->second;
-            timestampToEnqueueTime_.erase(it);
-        }
-    }
+
+    const QueuedFrame& latestFrame = outputFrames[totalFrames - 1];
+    const uint32_t latestIndex = latestFrame.index;
+    const OH_AVCodecBufferAttr& latestAttr = latestFrame.attr;
+    const int64_t pts = latestAttr.pts;
+    const int64_t enqueueTimeMs = TakeEnqueueTimestamp(pts);
+    const int64_t outputTimeMs = GetSteadyTimeMs();
     
     // 更新解码统计
-    UpdateDecodedStats(pts, enqueueTimeMs, latestFrame.attr.flags);
+    UpdateDecodedStats(pts, enqueueTimeMs, latestAttr.flags, outputTimeMs);
     
     // 开关关闭时保留同步模式原有的立即呈现基线；开启后仅对最新帧执行 step2。
-    NativeRender* render = NativeRender::GetInstance();
+    NativeRender* render = render_;
     ret = render->IsTwoStepPreciseSyncEnabled()
-        ? render->SubmitFrame(decoder_, latestFrame.index, pts, totalFrames > 1)
-        : OH_VideoDecoder_RenderOutputBuffer(decoder_, latestFrame.index);
+        ? render->SubmitFrame(decoder_, latestIndex, pts, totalFrames > 1)
+        : OH_VideoDecoder_RenderOutputBuffer(decoder_, latestIndex);
     if (ret != AV_ERR_OK) {
         OH_LOG_WARN(LOG_APP, "Sync: render failed (%{public}d), freeing buffer", ret);
-        OH_VideoDecoder_FreeOutputBuffer(decoder_, latestFrame.index);
+        OH_VideoDecoder_FreeOutputBuffer(decoder_, latestIndex);
         return 0;
     }
 
     // Post-processing: apply GL shader pipeline if enabled
-    {
-        GLPostProcessor* postProc = GLPostProcessor::GetInstance();
-        if (postProc->IsActive()) {
-            postProc->ProcessFrame();
-        }
+    if (postProcessor_->IsActive()) {
+        postProcessor_->ProcessFrame();
     }
 
     return 1;  // 成功渲染一帧
@@ -2170,6 +2213,7 @@ int VideoDecoder::SyncProcessOutput(int64_t timeoutUs) {
 namespace {
     VideoDecoder* g_videoDecoder = nullptr;
     std::mutex g_videoDecoderMutex;
+    NativeRender* g_renderInstance = nullptr;
     OHNativeWindow* g_savedWindow = nullptr;
     int g_savedVideoFormat = 0;
     int g_savedWidth = 0;
@@ -2317,7 +2361,8 @@ int SetupInternal(int videoFormat, int width, int height, double fps) {
     g_savedFps = fps;
     
     // 设置 NativeRender 的帧率配置（用于 SetExpectedFrameRateRange 优化高帧率显示）
-    NativeRender* render = NativeRender::GetInstance();
+    g_renderInstance = NativeRender::GetInstance();
+    NativeRender* render = g_renderInstance;
     if (render != nullptr) {
         render->SetConfiguredFps(static_cast<int>(std::round(fps)));  // 四舍五入到最近整数
         OH_LOG_INFO(LOG_APP, "VideoDecoder: NativeRender configured fps set to %.2f (rounded to %d)", 
@@ -2345,7 +2390,12 @@ static void PrepareFrameSubmitParams(int frameType, int frameNumber, int64_t pre
                                       VideoFrameType& outType, int64_t& outTimestamp) {
     // FRAME_TYPE_IDR = 1, FRAME_TYPE_I = 2
     outType = (frameType == 1 || frameType == 2) ? VideoFrameType::I_FRAME : VideoFrameType::P_FRAME;
-    if (presentationTimeUs >= 0 && NativeRender::GetInstance()->IsTwoStepPreciseSyncEnabled()) {
+    NativeRender* render = g_renderInstance;
+    if (render == nullptr) {
+        render = NativeRender::GetInstance();
+        g_renderInstance = render;
+    }
+    if (presentationTimeUs >= 0 && render->IsTwoStepPreciseSyncEnabled()) {
         outTimestamp = presentationTimeUs;
     } else {
         double fps = (g_savedFps > 0) ? g_savedFps : 60.0;

--- a/nativelib/src/main/cpp/video_decoder.cpp
+++ b/nativelib/src/main/cpp/video_decoder.cpp
@@ -375,10 +375,6 @@ static int64_t GetSteadyTimeMs() {
         std::chrono::steady_clock::now().time_since_epoch()).count();
 }
 
-static int64_t GetSteadyTimeNs() {
-    return std::chrono::duration_cast<std::chrono::nanoseconds>(
-        std::chrono::steady_clock::now().time_since_epoch()).count();
-}
 static constexpr int64_t kMaxValidDecodeTimeMs = 1000;   // 有效解码时间上限
 
 // 颜色空间常量 (OH_ColorPrimary)
@@ -416,6 +412,7 @@ static constexpr double kCriticalLatencyMultiplier = 8.0;
 static constexpr double kCriticalLatencyMinMs = 100.0;  // IDR 恢复最小阈值
 static constexpr int kLatencyRecoveryMinFrames = 60;     // 启动阶段不触发
 static constexpr int64_t kLatencyRecoveryTimeoutMs = 1000; // drop-until-IDR 超时兜底：IDR 久未到达则恢复提交，避免长时间冻结
+static constexpr int kCriticalPipelineFramesBeforeRecovery = 3;
 // L4: 网络抖动突发检测 - 连续 N 帧在极短间隔内到达时主动 Flush + IDR
 static constexpr int kBurstFlushThreshold = 4;           // 连续突发帧数阈值（@基准帧率）
 static constexpr double kBurstBaselineFps = 60.0;        // 突发计数阈值的基准帧率
@@ -1035,7 +1032,7 @@ void VideoDecoder::Cleanup() {
     burstFrameCount_ = 0;
     lastAsyncRenderTimeMs_ = 0;
     lastAsyncOutputTimeMs_ = 0;
-    render_ = nullptr;
+    consecutiveCriticalPipelineFrames_ = 0;
     
     OH_LOG_INFO(LOG_APP, "Video decoder cleaned up");
 }
@@ -1109,7 +1106,7 @@ int VideoDecoder::SubmitDecodeUnitScatter(const BufferSegment* segments, int seg
     // === L4 网络抖动突发检测（仅异步模式） ===
     // 同步模式下 L1 drain-to-latest 已足够处理突发到达，L4 的 IDR 请求反而会加重负担
     if (config_.decoderMode != DecoderMode::SYNC &&
-        !render_->IsHostPacedPresentationEnabled()) {
+        !render_->IsHostPacedPresentationActive()) {
         const int64_t nowMs = GetSteadyTimeMs();
         int64_t lastArrival = lastFrameArrivalMs_.exchange(nowMs);
         double expectedFrameMs = 1000.0 / config_.fps;
@@ -1466,6 +1463,8 @@ void VideoDecoder::RecordDroppedFrames(DropReason reason, uint64_t count) {
         case DropReason::TIMEOUT:
             droppedByTimeout_.fetch_add(count, std::memory_order_relaxed);
             break;
+        case DropReason::PRESENTATION:
+            break;
     }
 }
 
@@ -1528,7 +1527,7 @@ void VideoDecoder::OnOutputBufferAvailable(OH_AVCodec* codec, uint32_t index,
     
     // === L2 延迟恢复：异步模式基于延迟的帧跳过 ===
     // 当解码耗时过高时，跳过非关键帧以快速追赶
-    const bool hostPaced = self->render_->IsHostPacedPresentationEnabled();
+    const bool hostPaced = self->render_->IsHostPacedPresentationActive();
     if (enqueueTimeMs > 0 && !hostPaced) {
         // 记录回调到达时间（用于 L5 输出间隔检测，排除渲染处理开销的抖动）
         int64_t prevOutputTimeMs = self->lastAsyncOutputTimeMs_.exchange(outputTimeMs);
@@ -1539,7 +1538,7 @@ void VideoDecoder::OnOutputBufferAvailable(OH_AVCodec* codec, uint32_t index,
         // 跳过条件：解码时间 > 3倍帧间隔 且 非关键帧 且 已过启动阶段
         if (instantDecodeTimeMs > expectedFrameTimeMs * kAsyncSkipThresholdMultiplier &&
             !isKeyframe &&
-            self->decodedFrames_.load(std::memory_order_relaxed) > kLatencyRecoveryMinFrames) {
+            self->codecOutputFrames_.load(std::memory_order_relaxed) > kLatencyRecoveryMinFrames) {
             OH_VideoDecoder_FreeOutputBuffer(codec, index);
             self->RecordDroppedFrames(DropReason::L2);
             // 注意：不要把含排队等待的管线延迟 instantDecodeTimeMs 写入 lastInstantDecodeTimeMs_。
@@ -1554,7 +1553,7 @@ void VideoDecoder::OnOutputBufferAvailable(OH_AVCodec* codec, uint32_t index,
         // 高帧率（>90fps）使用更宽松的阈值，避免 VPU 正常管线延迟被误判
         // 使用回调到达间隔（而非渲染完成间隔），排除 GL 后处理/锁竞争等开销的抖动
         if (prevOutputTimeMs > 0 && !isKeyframe &&
-            self->decodedFrames_.load(std::memory_order_relaxed) > kLatencyRecoveryMinFrames) {
+            self->codecOutputFrames_.load(std::memory_order_relaxed) > kLatencyRecoveryMinFrames) {
             int64_t outputInterval = outputTimeMs - prevOutputTimeMs;
             // 根据帧率选择阈值
             double latencyRatio = (self->config_.fps > kL5HighFpsThreshold)
@@ -1582,9 +1581,6 @@ void VideoDecoder::OnOutputBufferAvailable(OH_AVCodec* codec, uint32_t index,
     // 更新异步渲染时间戳
     self->lastAsyncRenderTimeMs_.store(outputTimeMs);
     
-    // 更新解码统计（复用统一函数）
-    self->UpdateDecodedStats(pts, enqueueTimeMs, attr.flags, outputTimeMs);
-    
     // 注意：异步模式不在此处做帧率限制
     // 原因：
     // 1. 阻塞解码器回调线程会导致内部 buffer 堆积
@@ -1592,24 +1588,41 @@ void VideoDecoder::OnOutputBufferAvailable(OH_AVCodec* codec, uint32_t index,
     // 3. 低延迟模式应尽快渲染，由显示器 VSync 自然限制
     // 帧率限制通过 SetExpectedFrameRateRange 在系统层面实现
     
-    NativeRender::DecodedFrame decodedFrame;
-    decodedFrame.codec = codec;
-    decodedFrame.bufferIndex = index;
-    decodedFrame.ptsUs = pts;
-    decodedFrame.decodedAtNs = GetSteadyTimeNs();
-
-    // Async output follows the same PTS-aware ownership contract as sync output.
-    self->render_->SubmitFrame(decodedFrame);
+    self->SubmitDecodedFrame(codec, index, attr, enqueueTimeMs, outputTimeMs);
 }
 
 // =============================================================================
 // 同步模式解码实现
 // =============================================================================
 
-void VideoDecoder::UpdateDecodedStats(int64_t pts, int64_t enqueueTimeMs, uint32_t flags,
-                                      int64_t currentTimeMs) {
-    const uint64_t decodedFrames =
-        decodedFrames_.fetch_add(1, std::memory_order_relaxed) + 1;
+void VideoDecoder::SubmitDecodedFrame(OH_AVCodec* codec, uint32_t index,
+                                      const OH_AVCodecBufferAttr& attr,
+                                      int64_t enqueueTimeMs, int64_t outputTimeMs) {
+    NativeRender::DecodedFrame decodedFrame;
+    decodedFrame.codec = codec;
+    decodedFrame.bufferIndex = index;
+    decodedFrame.ptsUs = attr.pts;
+
+    // SubmitFrame owns the output buffer for every result. Keep presentation
+    // accounting and the ownership contract identical for all decoder modes.
+    const NativeRender::FrameSubmitResult result = render_->SubmitFrame(decodedFrame);
+    UpdateDecodedStats(enqueueTimeMs, attr.flags, outputTimeMs, result.presented);
+    if (!result.presented) {
+        RecordDroppedFrames(DropReason::PRESENTATION);
+    }
+    if (result.status != AV_ERR_OK) {
+        OH_LOG_WARN(LOG_APP, "Submit decoded frame failed: %{public}d, pts=%{public}lld",
+                    result.status, static_cast<long long>(attr.pts));
+    }
+}
+
+void VideoDecoder::UpdateDecodedStats(int64_t enqueueTimeMs, uint32_t flags,
+                                      int64_t currentTimeMs, bool presented) {
+    const uint64_t outputFrames =
+        codecOutputFrames_.fetch_add(1, std::memory_order_relaxed) + 1;
+    if (presented) {
+        decodedFrames_.fetch_add(1, std::memory_order_relaxed);
+    }
     
     if (enqueueTimeMs > 0) {
         // === 精确解码时间：排除队列等待 ===
@@ -1638,7 +1651,7 @@ void VideoDecoder::UpdateDecodedStats(int64_t pts, int64_t enqueueTimeMs, uint32
             decodeTotalTimeMs_ += static_cast<uint64_t>(decodeTimeMs);
             decodeValidFrames_++;
 
-            if (decodedFrames == 1) {
+            if (decodeValidFrames_ == 1) {
                 decodeAverageTimeMs_ = static_cast<double>(decodeTimeMs);
             } else {
                 const double alpha = isKeyframe ? kEmaAlphaKeyframe : kEmaAlphaNormal;
@@ -1658,26 +1671,36 @@ void VideoDecoder::UpdateDecodedStats(int64_t pts, int64_t enqueueTimeMs, uint32
         // 为保持 L3 敏感度，额外检查管线延迟是否超过临界值
         if (pipelineLatencyMs > static_cast<int64_t>(
                 std::max(1000.0 / config_.fps * kCriticalLatencyMultiplier, kCriticalLatencyMinMs)) &&
-            decodedFrames > kLatencyRecoveryMinFrames) {
-            // 管线延迟已超临界，但精确解码时间可能正常——标记为需要恢复
+            outputFrames > kLatencyRecoveryMinFrames) {
+            // Require a short run of critical samples. A single queue spike is
+            // common during transport jitter and must not turn into an IDR
+            // recovery freeze by itself.
+            const int criticalFrames =
+                consecutiveCriticalPipelineFrames_.fetch_add(
+                    1, std::memory_order_relaxed) + 1;
             constexpr int64_t kPipelineWarningIntervalMs = 5000;
             const int64_t lastWarningMs =
                 lastPipelineWarningTimeMs_.load(std::memory_order_relaxed);
-            if (!latencyRecoveryActive_.load()) {
+            if (criticalFrames >= kCriticalPipelineFramesBeforeRecovery &&
+                !latencyRecoveryActive_.load()) {
                 bool expected = false;
                 if (latencyRecoveryActive_.compare_exchange_strong(expected, true) &&
                     (lastWarningMs == 0 ||
                      currentTimeMs - lastWarningMs >= kPipelineWarningIntervalMs)) {
                     lastPipelineWarningTimeMs_.store(currentTimeMs, std::memory_order_relaxed);
-                    OH_LOG_WARN(LOG_APP, "Pipeline latency %{public}lldms critical (decode=%{public}lldms), flagging recovery",
+                    OH_LOG_WARN(LOG_APP, "Pipeline latency %{public}lldms critical for %{public}d frames (decode=%{public}lldms), flagging recovery",
                                 static_cast<long long>(pipelineLatencyMs),
+                                criticalFrames,
                                 static_cast<long long>(decodeTimeMs));
                 }
             }
+        } else {
+            consecutiveCriticalPipelineFrames_.store(0, std::memory_order_relaxed);
         }
     } else {
         // 无 enqueueTimeMs 时也更新 lastOutputTimeMs_
         lastOutputTimeMs_.store(currentTimeMs);
+        consecutiveCriticalPipelineFrames_.store(0, std::memory_order_relaxed);
     }
 }
 
@@ -1727,6 +1750,9 @@ bool VideoDecoder::CheckDecoderValid() {
 int VideoDecoder::CheckLatencyRecovery(VideoFrameType frameType, int size, int frameNumber,
                                        uint16_t hostProcessingLatency) {
     bool isIFrame = (frameType == VideoFrameType::I_FRAME);
+    if (isIFrame) {
+        consecutiveCriticalPipelineFrames_.store(0, std::memory_order_relaxed);
+    }
     
     // 收到 IDR 帧时重置恢复状态
     if (isIFrame && latencyRecoveryActive_.load()) {
@@ -1776,8 +1802,8 @@ int VideoDecoder::CheckLatencyRecovery(VideoFrameType frameType, int size, int f
     double criticalThresholdMs = std::max(expectedFrameTimeMs * kCriticalLatencyMultiplier, kCriticalLatencyMinMs);
     
     // 检查是否已过启动阶段（避免初始化时的误触发）
-    const uint64_t decodedFrames = decodedFrames_.load(std::memory_order_relaxed);
-    if (decodedFrames < static_cast<uint64_t>(kLatencyRecoveryMinFrames)) {
+    const uint64_t outputFrames = codecOutputFrames_.load(std::memory_order_relaxed);
+    if (outputFrames < static_cast<uint64_t>(kLatencyRecoveryMinFrames)) {
         return 0;
     }
     
@@ -2109,21 +2135,11 @@ int VideoDecoder::SyncProcessOutput(int64_t timeoutUs) {
 
     // Host-paced presentation must see every PTS. Do not apply the low-latency
     // drain-to-latest policy before the shared presentation scheduler.
-    if (render_->IsHostPacedPresentationEnabled()) {
+    if (render_->IsHostPacedPresentationActive()) {
         const int64_t pts = attr.pts;
         const int64_t enqueueTimeMs = TakeEnqueueTimestamp(pts);
         const int64_t outputTimeMs = GetSteadyTimeMs();
-        UpdateDecodedStats(pts, enqueueTimeMs, attr.flags, outputTimeMs);
-
-        NativeRender::DecodedFrame decodedFrame;
-        decodedFrame.codec = decoder_;
-        decodedFrame.bufferIndex = outputIndex;
-        decodedFrame.ptsUs = pts;
-        decodedFrame.decodedAtNs = GetSteadyTimeNs();
-        ret = render_->SubmitFrame(decodedFrame);
-        if (ret != AV_ERR_OK) {
-            OH_LOG_WARN(LOG_APP, "Sync host-paced render failed: %{public}d", ret);
-        }
+        SubmitDecodedFrame(decoder_, outputIndex, attr, enqueueTimeMs, outputTimeMs);
         return 1;
     }
     
@@ -2195,23 +2211,11 @@ int VideoDecoder::SyncProcessOutput(int64_t timeoutUs) {
     const int64_t enqueueTimeMs = TakeEnqueueTimestamp(pts);
     const int64_t outputTimeMs = GetSteadyTimeMs();
     
-    // 更新解码统计
-    UpdateDecodedStats(pts, enqueueTimeMs, latestAttr.flags, outputTimeMs);
-    
     // Decoder output selection and presentation are separate policies: sync
     // mode still drains to the latest frame, while the shared presenter uses
     // that frame's PTS when legacy VSync is enabled.
-    NativeRender::DecodedFrame decodedFrame;
-    decodedFrame.codec = decoder_;
-    decodedFrame.bufferIndex = latestIndex;
-    decodedFrame.ptsUs = pts;
-    decodedFrame.decodedAtNs = GetSteadyTimeNs();
-    ret = render_->SubmitFrame(decodedFrame);
-    if (ret != AV_ERR_OK) {
-        // SubmitFrame owns the output buffer even when presentation fails.
-        OH_LOG_WARN(LOG_APP, "Sync: render failed (%{public}d)", ret);
-        return 0;
-    }
+    SubmitDecodedFrame(decoder_, latestIndex, latestAttr,
+                       enqueueTimeMs, outputTimeMs);
 
     return 1;  // 成功渲染一帧
 }
@@ -2223,7 +2227,6 @@ int VideoDecoder::SyncProcessOutput(int64_t timeoutUs) {
 namespace {
     VideoDecoder* g_videoDecoder = nullptr;
     std::mutex g_videoDecoderMutex;
-    NativeRender* g_renderInstance = nullptr;
     OHNativeWindow* g_savedWindow = nullptr;
     int g_savedVideoFormat = 0;
     int g_savedWidth = 0;
@@ -2371,8 +2374,7 @@ int SetupInternal(int videoFormat, int width, int height, double fps) {
     g_savedFps = fps;
     
     // 设置 NativeRender 的帧率配置（用于 SetExpectedFrameRateRange 优化高帧率显示）
-    g_renderInstance = NativeRender::GetInstance();
-    NativeRender* render = g_renderInstance;
+    NativeRender* render = NativeRender::GetInstance();
     if (render != nullptr) {
         render->SetConfiguredFps(fps);
         OH_LOG_INFO(LOG_APP, "VideoDecoder: NativeRender configured fps set to %.3f", fps);

--- a/nativelib/src/main/cpp/video_decoder.cpp
+++ b/nativelib/src/main/cpp/video_decoder.cpp
@@ -36,10 +36,6 @@ extern "C" {
 
 #define LOG_TAG "VideoDecoder"
 
-// 是否启用异步渲染（通过 NativeRender）
-// 启用后可利用 SetExpectedFrameRateRange 优化高帧率显示
-static bool g_useAsyncRender = true;
-
 // =============================================================================
 // 大核绑定 + QoS 线程优化
 // 检测 ARM big.LITTLE 架构中的高频核心（大核），将解码线程绑定以获取最大性能
@@ -487,7 +483,6 @@ int VideoDecoder::Init(const VideoDecoderConfig& config, OHNativeWindow* window)
     config_ = config;
     window_ = window;
     render_ = NativeRender::GetInstance();
-    postProcessor_ = GLPostProcessor::GetInstance();
     
     OH_LOG_INFO(LOG_APP, "{Init} Initializing video decoder: %{public}dx%{public}d@%.2f, codec=%{public}d, window=%{public}p",
                 config_.width, config_.height, config_.fps, static_cast<int>(config_.codec), static_cast<void*>(window));
@@ -1041,7 +1036,6 @@ void VideoDecoder::Cleanup() {
     lastAsyncRenderTimeMs_ = 0;
     lastAsyncOutputTimeMs_ = 0;
     render_ = nullptr;
-    postProcessor_ = nullptr;
     
     OH_LOG_INFO(LOG_APP, "Video decoder cleaned up");
 }
@@ -1604,15 +1598,7 @@ void VideoDecoder::OnOutputBufferAvailable(OH_AVCodec* codec, uint32_t index,
     decodedFrame.ptsUs = pts;
     decodedFrame.decodedAtNs = GetSteadyTimeNs();
 
-    // Both async surface paths use the same PTS-aware presentation contract.
-    if (g_useAsyncRender) {
-        NativeRender* render = self->render_;
-        if (render != nullptr && render->IsSurfaceReady()) {
-            render->SubmitFrame(decodedFrame);
-            return;
-        }
-    }
-    
+    // Async output follows the same PTS-aware ownership contract as sync output.
     self->render_->SubmitFrame(decodedFrame);
 }
 

--- a/nativelib/src/main/cpp/video_decoder.cpp
+++ b/nativelib/src/main/cpp/video_decoder.cpp
@@ -378,6 +378,11 @@ static int64_t GetSteadyTimeMs() {
     return std::chrono::duration_cast<std::chrono::milliseconds>(
         std::chrono::steady_clock::now().time_since_epoch()).count();
 }
+
+static int64_t GetSteadyTimeNs() {
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(
+        std::chrono::steady_clock::now().time_since_epoch()).count();
+}
 static constexpr int64_t kMaxValidDecodeTimeMs = 1000;   // 有效解码时间上限
 
 // 颜色空间常量 (OH_ColorPrimary)
@@ -1109,7 +1114,8 @@ int VideoDecoder::SubmitDecodeUnitScatter(const BufferSegment* segments, int seg
     
     // === L4 网络抖动突发检测（仅异步模式） ===
     // 同步模式下 L1 drain-to-latest 已足够处理突发到达，L4 的 IDR 请求反而会加重负担
-    if (config_.decoderMode != DecoderMode::SYNC) {
+    if (config_.decoderMode != DecoderMode::SYNC &&
+        !render_->IsHostPacedPresentationEnabled()) {
         const int64_t nowMs = GetSteadyTimeMs();
         int64_t lastArrival = lastFrameArrivalMs_.exchange(nowMs);
         double expectedFrameMs = 1000.0 / config_.fps;
@@ -1508,10 +1514,17 @@ void VideoDecoder::OnOutputBufferAvailable(OH_AVCodec* codec, uint32_t index,
     if (self == nullptr) return;
     
     // 获取输出数据信息
-    OH_AVCodecBufferAttr attr;
-    int64_t pts = 0;
-    if (OH_AVBuffer_GetBufferAttr(buffer, &attr) == AV_ERR_OK) {
-        pts = attr.pts;
+    OH_AVCodecBufferAttr attr = {};
+    if (OH_AVBuffer_GetBufferAttr(buffer, &attr) != AV_ERR_OK) {
+        OH_LOG_WARN(LOG_APP, "Async: failed to get output buffer attr");
+        OH_VideoDecoder_FreeOutputBuffer(codec, index);
+        return;
+    }
+    const int64_t pts = attr.pts;
+
+    if (attr.flags & AVCODEC_BUFFER_FLAGS_EOS) {
+        OH_VideoDecoder_FreeOutputBuffer(codec, index);
+        return;
     }
 
     const int64_t outputTimeMs = GetSteadyTimeMs();
@@ -1521,7 +1534,8 @@ void VideoDecoder::OnOutputBufferAvailable(OH_AVCodec* codec, uint32_t index,
     
     // === L2 延迟恢复：异步模式基于延迟的帧跳过 ===
     // 当解码耗时过高时，跳过非关键帧以快速追赶
-    if (enqueueTimeMs > 0) {
+    const bool hostPaced = self->render_->IsHostPacedPresentationEnabled();
+    if (enqueueTimeMs > 0 && !hostPaced) {
         // 记录回调到达时间（用于 L5 输出间隔检测，排除渲染处理开销的抖动）
         int64_t prevOutputTimeMs = self->lastAsyncOutputTimeMs_.exchange(outputTimeMs);
         int64_t instantDecodeTimeMs = outputTimeMs - enqueueTimeMs;
@@ -1584,36 +1598,22 @@ void VideoDecoder::OnOutputBufferAvailable(OH_AVCodec* codec, uint32_t index,
     // 3. 低延迟模式应尽快渲染，由显示器 VSync 自然限制
     // 帧率限制通过 SetExpectedFrameRateRange 在系统层面实现
     
-    // 渲染到 Surface
-    // 检查是否使用异步渲染（通过 NativeRender）
+    NativeRender::DecodedFrame decodedFrame;
+    decodedFrame.codec = codec;
+    decodedFrame.bufferIndex = index;
+    decodedFrame.ptsUs = pts;
+    decodedFrame.decodedAtNs = GetSteadyTimeNs();
+
+    // Both async surface paths use the same PTS-aware presentation contract.
     if (g_useAsyncRender) {
         NativeRender* render = self->render_;
         if (render != nullptr && render->IsSurfaceReady()) {
-            if (render->SubmitFrame(codec, index, pts) != AV_ERR_OK) {
-                OH_VideoDecoder_FreeOutputBuffer(codec, index);
-            }
-            // 后处理：如果启用，从代理 surface 读取并处理到显示 surface
-            GLPostProcessor* postProc = self->postProcessor_;
-            if (postProc->IsActive()) {
-                postProc->ProcessFrame();
-            }
+            render->SubmitFrame(decodedFrame);
             return;
         }
     }
     
-    // 非 NativeRender surface 路径也使用同一呈现控制器，保持两步语义一致。
-    NativeRender* render = self->render_;
-    if (render->SubmitFrame(codec, index, pts) != AV_ERR_OK) {
-        OH_VideoDecoder_FreeOutputBuffer(codec, index);
-    }
-    
-    // 后处理：非异步路径也需要处理
-    {
-        GLPostProcessor* postProc = self->postProcessor_;
-        if (postProc->IsActive()) {
-            postProc->ProcessFrame();
-        }
-    }
+    self->render_->SubmitFrame(decodedFrame);
 }
 
 // =============================================================================
@@ -2102,14 +2102,16 @@ int VideoDecoder::SyncProcessOutput(int64_t timeoutUs) {
     OH_AVBuffer* outputBuffer = pfn_GetOutputBuffer(decoder_, outputIndex);
     if (outputBuffer == nullptr) {
         OH_LOG_ERROR(LOG_APP, "Sync GetOutputBuffer failed");
+        OH_VideoDecoder_FreeOutputBuffer(decoder_, outputIndex);
         return -1;  // API 错误
     }
     
     // 获取 buffer 属性
-    OH_AVCodecBufferAttr attr;
+    OH_AVCodecBufferAttr attr = {};
     if (OH_AVBuffer_GetBufferAttr(outputBuffer, &attr) != AV_ERR_OK) {
         OH_LOG_WARN(LOG_APP, "Sync: failed to get buffer attr");
-        memset(&attr, 0, sizeof(attr));
+        OH_VideoDecoder_FreeOutputBuffer(decoder_, outputIndex);
+        return 0;
     }
     
     // 检查 EOS
@@ -2117,6 +2119,26 @@ int VideoDecoder::SyncProcessOutput(int64_t timeoutUs) {
         OH_LOG_INFO(LOG_APP, "Sync: received EOS");
         OH_VideoDecoder_FreeOutputBuffer(decoder_, outputIndex);
         return 0;  // EOS 不是错误
+    }
+
+    // Host-paced presentation must see every PTS. Do not apply the low-latency
+    // drain-to-latest policy before the shared presentation scheduler.
+    if (render_->IsHostPacedPresentationEnabled()) {
+        const int64_t pts = attr.pts;
+        const int64_t enqueueTimeMs = TakeEnqueueTimestamp(pts);
+        const int64_t outputTimeMs = GetSteadyTimeMs();
+        UpdateDecodedStats(pts, enqueueTimeMs, attr.flags, outputTimeMs);
+
+        NativeRender::DecodedFrame decodedFrame;
+        decodedFrame.codec = decoder_;
+        decodedFrame.bufferIndex = outputIndex;
+        decodedFrame.ptsUs = pts;
+        decodedFrame.decodedAtNs = GetSteadyTimeNs();
+        ret = render_->SubmitFrame(decodedFrame);
+        if (ret != AV_ERR_OK) {
+            OH_LOG_WARN(LOG_APP, "Sync host-paced render failed: %{public}d", ret);
+        }
+        return 1;
     }
     
     // ================================================================
@@ -2190,20 +2212,19 @@ int VideoDecoder::SyncProcessOutput(int64_t timeoutUs) {
     // 更新解码统计
     UpdateDecodedStats(pts, enqueueTimeMs, latestAttr.flags, outputTimeMs);
     
-    // 开关关闭时保留同步模式原有的立即呈现基线；开启后仅对最新帧执行 step2。
-    NativeRender* render = render_;
-    ret = render->IsTwoStepPreciseSyncEnabled()
-        ? render->SubmitFrame(decoder_, latestIndex, pts, totalFrames > 1)
-        : OH_VideoDecoder_RenderOutputBuffer(decoder_, latestIndex);
+    // Decoder output selection and presentation are separate policies: sync
+    // mode still drains to the latest frame, while the shared presenter uses
+    // that frame's PTS when legacy VSync is enabled.
+    NativeRender::DecodedFrame decodedFrame;
+    decodedFrame.codec = decoder_;
+    decodedFrame.bufferIndex = latestIndex;
+    decodedFrame.ptsUs = pts;
+    decodedFrame.decodedAtNs = GetSteadyTimeNs();
+    ret = render_->SubmitFrame(decodedFrame);
     if (ret != AV_ERR_OK) {
-        OH_LOG_WARN(LOG_APP, "Sync: render failed (%{public}d), freeing buffer", ret);
-        OH_VideoDecoder_FreeOutputBuffer(decoder_, latestIndex);
+        // SubmitFrame owns the output buffer even when presentation fails.
+        OH_LOG_WARN(LOG_APP, "Sync: render failed (%{public}d)", ret);
         return 0;
-    }
-
-    // Post-processing: apply GL shader pipeline if enabled
-    if (postProcessor_->IsActive()) {
-        postProcessor_->ProcessFrame();
     }
 
     return 1;  // 成功渲染一帧
@@ -2367,9 +2388,8 @@ int SetupInternal(int videoFormat, int width, int height, double fps) {
     g_renderInstance = NativeRender::GetInstance();
     NativeRender* render = g_renderInstance;
     if (render != nullptr) {
-        render->SetConfiguredFps(static_cast<int>(std::round(fps)));  // 四舍五入到最近整数
-        OH_LOG_INFO(LOG_APP, "VideoDecoder: NativeRender configured fps set to %.2f (rounded to %d)", 
-                    fps, static_cast<int>(std::round(fps)));
+        render->SetConfiguredFps(fps);
+        OH_LOG_INFO(LOG_APP, "VideoDecoder: NativeRender configured fps set to %.3f", fps);
     }
     
     return 0;
@@ -2388,17 +2408,12 @@ int Init(int videoFormat, int width, int height, double fps, void* window) {
     return Setup(videoFormat, width, height, fps);
 }
 
-// 辅助函数：转换帧类型 + 选择 common-c host PTS（全局包装器共用）
+// Convert frame type and preserve common-c host PTS for both decoder modes.
 static void PrepareFrameSubmitParams(int frameType, int frameNumber, int64_t presentationTimeUs,
                                       VideoFrameType& outType, int64_t& outTimestamp) {
     // FRAME_TYPE_IDR = 1, FRAME_TYPE_I = 2
     outType = (frameType == 1 || frameType == 2) ? VideoFrameType::I_FRAME : VideoFrameType::P_FRAME;
-    NativeRender* render = g_renderInstance;
-    if (render == nullptr) {
-        render = NativeRender::GetInstance();
-        g_renderInstance = render;
-    }
-    if (presentationTimeUs >= 0 && render->IsTwoStepPreciseSyncEnabled()) {
+    if (presentationTimeUs >= 0) {
         outTimestamp = presentationTimeUs;
     } else {
         double fps = (g_savedFps > 0) ? g_savedFps : 60.0;

--- a/nativelib/src/main/cpp/video_decoder.cpp
+++ b/nativelib/src/main/cpp/video_decoder.cpp
@@ -2144,7 +2144,7 @@ int VideoDecoder::SyncProcessOutput(int64_t timeoutUs) {
     // 开关关闭时保留同步模式原有的立即呈现基线；开启后仅对最新帧执行 step2。
     NativeRender* render = NativeRender::GetInstance();
     ret = render->IsTwoStepPreciseSyncEnabled()
-        ? render->SubmitFrame(decoder_, latestFrame.index, pts)
+        ? render->SubmitFrame(decoder_, latestFrame.index, pts, totalFrames > 1)
         : OH_VideoDecoder_RenderOutputBuffer(decoder_, latestFrame.index);
     if (ret != AV_ERR_OK) {
         OH_LOG_WARN(LOG_APP, "Sync: render failed (%{public}d), freeing buffer", ret);

--- a/nativelib/src/main/cpp/video_decoder.h
+++ b/nativelib/src/main/cpp/video_decoder.h
@@ -20,13 +20,14 @@
 #define VIDEO_DECODER_H
 
 #include <cstdint>
+#include <array>
 #include <mutex>
 #include <shared_mutex>
 #include <queue>
 #include <thread>
 #include <atomic>
 #include <condition_variable>
-#include <unordered_map>
+#include <vector>
 #include <multimedia/player_framework/native_avcodec_videodecoder.h>
 #include <multimedia/player_framework/native_avcapability.h>
 #include <multimedia/player_framework/native_avcodec_base.h>
@@ -34,6 +35,9 @@
 #include <multimedia/player_framework/native_avbuffer.h>
 #include <native_window/external_window.h>
 #include <native_buffer/native_buffer.h>
+
+class NativeRender;
+class GLPostProcessor;
 #include <hilog/log.h>
 
 struct Smpte2086Metadata {
@@ -277,6 +281,16 @@ public:
      */
     bool CheckDecoderValid();
 private:
+    enum class DropReason {
+        L1,
+        L2,
+        L3,
+        L4,
+        L5,
+        QUEUE_OVERFLOW,
+        TIMEOUT,
+    };
+
     // AVCodec 回调
     static void OnError(OH_AVCodec* codec, int32_t errorCode, void* userData);
     static void OnOutputFormatChanged(OH_AVCodec* codec, OH_AVFormat* format, void* userData);
@@ -301,14 +315,19 @@ private:
     void UpdateReceivedStats(int size, int frameNumber, uint16_t hostProcessingLatency);
     
     // 更新解码帧统计
-    void UpdateDecodedStats(int64_t pts, int64_t enqueueTimeMs, uint32_t flags);
+    void UpdateDecodedStats(int64_t pts, int64_t enqueueTimeMs, uint32_t flags,
+                            int64_t currentTimeMs);
+
+    void RecordDroppedFrames(DropReason reason, uint64_t count = 1);
     
     // 延迟恢复：检查是否应丢弃输入帧并请求 IDR
     // 返回 -1 表示应丢弃（需要 IDR），0 表示正常处理
-    int CheckLatencyRecovery(VideoFrameType frameType, int size, int frameNumber, uint16_t hostProcessingLatency);
+    int CheckLatencyRecovery(VideoFrameType frameType, int size, int frameNumber,
+                             uint16_t hostProcessingLatency);
     
     // 记录帧入队时间戳（用于计算解码延迟）
     void RecordEnqueueTimestamp(int64_t timestamp);
+    int64_t TakeEnqueueTimestamp(int64_t timestamp);
     
     // 解码器实例
     OH_AVCodec* decoder_ = nullptr;
@@ -320,6 +339,11 @@ private:
     
     // 渲染窗口
     OHNativeWindow* window_ = nullptr;
+
+    // Singleton lifetimes cover the decoder session. Cache them so output callbacks
+    // do not contend on the singleton mutex for every frame.
+    NativeRender* render_ = nullptr;
+    GLPostProcessor* postProcessor_ = nullptr;
     
     // 配置
     VideoDecoderConfig config_;
@@ -353,9 +377,16 @@ private:
     std::chrono::steady_clock::time_point lastFrameTime_;
     int64_t frameIntervalUs_{0};  // 目标帧间隔（微秒），0 表示不限制
     
-    // 帧时间戳到入队时间的映射（用于计算解码时间）
+    // Fixed-size timestamp ring avoids a node allocation/free for every frame.
+    struct TimestampEntry {
+        int64_t pts = 0;
+        int64_t enqueueTimeMs = 0;
+        bool valid = false;
+    };
+    static constexpr size_t kTimestampEntryCount = 32;
     std::mutex timestampMutex_;
-    std::unordered_map<int64_t, int64_t> timestampToEnqueueTime_;
+    std::array<TimestampEntry, kTimestampEntryCount> timestampEntries_{};
+    size_t timestampWriteIndex_ = 0;
     
     // 统计信息
     mutable std::mutex statsMutex_;
@@ -363,6 +394,27 @@ private:
     uint64_t recentHostLatencyWindowFrames_{0};
     double recentHostLatencyWindowTotalMs_{0.0};
     int64_t recentHostLatencyWindowStartTimeMs_{0};
+
+    // Output/drop counters are updated atomically so decoder callbacks never
+    // wait on the receive-statistics snapshot mutex.
+    std::atomic<uint64_t> decodedFrames_{0};
+    std::atomic<uint64_t> droppedFrames_{0};
+    std::atomic<uint64_t> droppedByL1_{0};
+    std::atomic<uint64_t> droppedByL2_{0};
+    std::atomic<uint64_t> droppedByL3_{0};
+    std::atomic<uint64_t> droppedByL4_{0};
+    std::atomic<uint64_t> droppedByL5_{0};
+    std::atomic<uint64_t> droppedByQueueOverflow_{0};
+    std::atomic<uint64_t> droppedByTimeout_{0};
+    mutable std::mutex decodeStatsMutex_;
+    uint64_t decodeTotalTimeMs_{0};
+    uint64_t decodeValidFrames_{0};
+    double decodeAverageTimeMs_{0.0};
+    int64_t decodeMaxTimeMs_{0};
+
+    // Sync diagnostics are owned by syncDecodeThread_.
+    uint64_t syncDrainEventsSinceLog_{0};
+    uint64_t syncDrainFramesSinceLog_{0};
     
     // 运行状态
     std::atomic<bool> running_{false};
@@ -386,6 +438,7 @@ private:
     // === 异步模式渲染跳帧（Render Skip） ===
     std::atomic<int64_t> lastAsyncRenderTimeMs_{0};     // 上一次异步渲染时间 (ms)
     std::atomic<int64_t> lastAsyncOutputTimeMs_{0};     // 上一次回调到达时间 (ms)，用于 L5 输出间隔检测
+    std::atomic<int64_t> lastPipelineWarningTimeMs_{0};
     
     // 解码器健康检查状态
     std::atomic<int64_t> lastHealthCheckTimeMs_{0};     // 上次健康检查时间 (ms)

--- a/nativelib/src/main/cpp/video_decoder.h
+++ b/nativelib/src/main/cpp/video_decoder.h
@@ -37,7 +37,6 @@
 #include <native_buffer/native_buffer.h>
 
 class NativeRender;
-class GLPostProcessor;
 #include <hilog/log.h>
 
 struct Smpte2086Metadata {
@@ -340,10 +339,9 @@ private:
     // 渲染窗口
     OHNativeWindow* window_ = nullptr;
 
-    // Singleton lifetimes cover the decoder session. Cache them so output callbacks
-    // do not contend on the singleton mutex for every frame.
+    // NativeRender's singleton lifetime covers the decoder session. Cache it so
+    // output callbacks do not contend on the singleton mutex for every frame.
     NativeRender* render_ = nullptr;
-    GLPostProcessor* postProcessor_ = nullptr;
     
     // 配置
     VideoDecoderConfig config_;
@@ -372,10 +370,6 @@ private:
     // 同步模式解码线程
     std::thread syncDecodeThread_;
     std::atomic<bool> syncDecodeRunning_{false};
-    
-    // 帧率限制相关
-    std::chrono::steady_clock::time_point lastFrameTime_;
-    int64_t frameIntervalUs_{0};  // 目标帧间隔（微秒），0 表示不限制
     
     // Fixed-size timestamp ring avoids a node allocation/free for every frame.
     struct TimestampEntry {

--- a/nativelib/src/main/cpp/video_decoder.h
+++ b/nativelib/src/main/cpp/video_decoder.h
@@ -288,6 +288,7 @@ private:
         L5,
         QUEUE_OVERFLOW,
         TIMEOUT,
+        PRESENTATION,
     };
 
     // AVCodec 回调
@@ -314,8 +315,12 @@ private:
     void UpdateReceivedStats(int size, int frameNumber, uint16_t hostProcessingLatency);
     
     // 更新解码帧统计
-    void UpdateDecodedStats(int64_t pts, int64_t enqueueTimeMs, uint32_t flags,
-                            int64_t currentTimeMs);
+    void UpdateDecodedStats(int64_t enqueueTimeMs, uint32_t flags,
+                            int64_t currentTimeMs, bool presented);
+
+    void SubmitDecodedFrame(OH_AVCodec* codec, uint32_t index,
+                            const OH_AVCodecBufferAttr& attr,
+                            int64_t enqueueTimeMs, int64_t outputTimeMs);
 
     void RecordDroppedFrames(DropReason reason, uint64_t count = 1);
     
@@ -391,6 +396,7 @@ private:
 
     // Output/drop counters are updated atomically so decoder callbacks never
     // wait on the receive-statistics snapshot mutex.
+    std::atomic<uint64_t> codecOutputFrames_{0};
     std::atomic<uint64_t> decodedFrames_{0};
     std::atomic<uint64_t> droppedFrames_{0};
     std::atomic<uint64_t> droppedByL1_{0};
@@ -433,6 +439,7 @@ private:
     std::atomic<int64_t> lastAsyncRenderTimeMs_{0};     // 上一次异步渲染时间 (ms)
     std::atomic<int64_t> lastAsyncOutputTimeMs_{0};     // 上一次回调到达时间 (ms)，用于 L5 输出间隔检测
     std::atomic<int64_t> lastPipelineWarningTimeMs_{0};
+    std::atomic<int> consecutiveCriticalPipelineFrames_{0};
     
     // 解码器健康检查状态
     std::atomic<int64_t> lastHealthCheckTimeMs_{0};     // 上次健康检查时间 (ms)

--- a/nativelib/src/test/cpp/presentation_scheduler_test.cpp
+++ b/nativelib/src/test/cpp/presentation_scheduler_test.cpp
@@ -1,0 +1,75 @@
+#include "presentation_scheduler.h"
+
+#include <cassert>
+#include <cstdint>
+#include <iostream>
+
+namespace {
+constexpr int64_t kMs = 1000000LL;
+
+void TestBurstKeepsPtsCadence() {
+    PtsPresentationScheduler scheduler;
+    scheduler.Configure(60.0);
+
+    const PresentationPlan first = scheduler.PlanFrame(0, 1000 * kMs);
+    const PresentationPlan second = scheduler.PlanFrame(16667, 1000 * kMs);
+    const PresentationPlan third = scheduler.PlanFrame(33333, 1001 * kMs);
+
+    assert(first.action == PresentationAction::SCHEDULE);
+    assert(second.action == PresentationAction::SCHEDULE);
+    assert(third.action == PresentationAction::SCHEDULE);
+    assert(second.targetTimeNs - first.targetTimeNs == 16667000LL);
+    assert(third.targetTimeNs - second.targetTimeNs == 16666000LL);
+}
+
+void TestSmallLateFrameShiftsWholeTimeline() {
+    PtsPresentationScheduler scheduler;
+    scheduler.Configure(60.0);
+
+    const PresentationPlan first = scheduler.PlanFrame(0, 1000 * kMs);
+    const PresentationPlan shifted = scheduler.PlanFrame(16667, 1034 * kMs);
+    const PresentationPlan next = scheduler.PlanFrame(33333, 1035 * kMs);
+
+    assert(shifted.action == PresentationAction::SCHEDULE);
+    assert(shifted.event == PresentationEvent::PHASE_SHIFT);
+    assert(next.action == PresentationAction::SCHEDULE);
+    assert(next.targetTimeNs - shifted.targetTimeNs == 16666000LL);
+    assert(shifted.targetTimeNs >= 1035 * kMs);
+    assert(first.targetTimeNs < shifted.targetTimeNs);
+}
+
+void TestSevereLateDropThenRebuffer() {
+    PtsPresentationScheduler scheduler;
+    scheduler.Configure(60.0);
+
+    scheduler.PlanFrame(0, 1000 * kMs);
+    const PresentationPlan dropped = scheduler.PlanFrame(16667, 1100 * kMs);
+    const PresentationPlan rebuffered = scheduler.PlanFrame(33333, 1101 * kMs);
+
+    assert(dropped.action == PresentationAction::DROP);
+    assert(dropped.event == PresentationEvent::LATE_DROP);
+    assert(rebuffered.action == PresentationAction::SCHEDULE);
+    assert(rebuffered.event == PresentationEvent::REBUFFER);
+    assert(rebuffered.targetTimeNs > 1101 * kMs);
+}
+
+void TestDiscontinuityReanchors() {
+    PtsPresentationScheduler scheduler;
+    scheduler.Configure(59.94);
+
+    scheduler.PlanFrame(1000000, 2000 * kMs);
+    const PresentationPlan discontinuity = scheduler.PlanFrame(500000, 2010 * kMs);
+
+    assert(discontinuity.action == PresentationAction::SCHEDULE);
+    assert(discontinuity.event == PresentationEvent::DISCONTINUITY);
+}
+} // namespace
+
+int main() {
+    TestBurstKeepsPtsCadence();
+    TestSmallLateFrameShiftsWholeTimeline();
+    TestSevereLateDropThenRebuffer();
+    TestDiscontinuityReanchors();
+    std::cout << "presentation scheduler tests passed\n";
+    return 0;
+}

--- a/nativelib/src/test/cpp/presentation_scheduler_test.cpp
+++ b/nativelib/src/test/cpp/presentation_scheduler_test.cpp
@@ -1,7 +1,9 @@
 #include "presentation_scheduler.h"
 
 #include <cassert>
+#include <cmath>
 #include <cstdint>
+#include <cstdlib>
 #include <iostream>
 
 namespace {
@@ -63,6 +65,42 @@ void TestDiscontinuityReanchors() {
     assert(discontinuity.action == PresentationAction::SCHEDULE);
     assert(discontinuity.event == PresentationEvent::DISCONTINUITY);
 }
+
+void TestFractionalFpsLead() {
+    PtsPresentationScheduler scheduler;
+    scheduler.Configure(59.94);
+
+    const int64_t decodedAtNs = 2000 * kMs;
+    const PresentationPlan first = scheduler.PlanFrame(0, decodedAtNs);
+    const int64_t expectedLeadNs = static_cast<int64_t>(
+        std::llround(1000000000.0 / 59.94)) + 2 * kMs;
+
+    assert(first.action == PresentationAction::SCHEDULE);
+    assert(first.targetTimeNs - decodedAtNs == expectedLeadNs);
+}
+
+void TestSlowClockDriftStaysBounded() {
+    PtsPresentationScheduler scheduler;
+    scheduler.Configure(60.0);
+
+    constexpr int64_t kStartNs = 1000 * kMs;
+    constexpr double kPtsIntervalUs = 1000000.0 / 60.0;
+    constexpr double kFastLocalIntervalNs = 1000000000.0 / 60.0 * (1.0 - 0.0001);
+    scheduler.PlanFrame(0, kStartNs);
+
+    PresentationPlan plan;
+    int64_t decodedAtNs = kStartNs;
+    for (int i = 1; i <= 20000; ++i) {
+        const int64_t ptsUs = static_cast<int64_t>(std::llround(i * kPtsIntervalUs));
+        decodedAtNs = kStartNs + static_cast<int64_t>(std::llround(i * kFastLocalIntervalNs));
+        plan = scheduler.PlanFrame(ptsUs, decodedAtNs);
+        assert(plan.action == PresentationAction::SCHEDULE);
+    }
+
+    const int64_t finalLeadNs = plan.targetTimeNs - decodedAtNs;
+    const int64_t expectedLeadNs = scheduler.GetInitialLeadNs();
+    assert(std::llabs(finalLeadNs - expectedLeadNs) < 5 * kMs);
+}
 } // namespace
 
 int main() {
@@ -70,6 +108,8 @@ int main() {
     TestSmallLateFrameShiftsWholeTimeline();
     TestSevereLateDropThenRebuffer();
     TestDiscontinuityReanchors();
+    TestFractionalFpsLead();
+    TestSlowClockDriftStaysBounded();
     std::cout << "presentation scheduler tests passed\n";
     return 0;
 }

--- a/nativelib/src/test/cpp/presentation_scheduler_test.cpp
+++ b/nativelib/src/test/cpp/presentation_scheduler_test.cpp
@@ -55,6 +55,62 @@ void TestSevereLateDropThenRebuffer() {
     assert(rebuffered.targetTimeNs > 1101 * kMs);
 }
 
+void TestAccumulatedPhaseShiftRecoversQuickly() {
+    PtsPresentationScheduler scheduler;
+    scheduler.Configure(60.0);
+
+    constexpr int64_t kStartNs = 1000 * kMs;
+    constexpr int64_t kFrameUs = 16667;
+    scheduler.PlanFrame(0, kStartNs);
+
+    int phaseShiftCount = 0;
+    for (int i = 1; i <= 12; ++i) {
+        const int64_t ptsUs = i * kFrameUs;
+        const int64_t nominalDecodeNs = kStartNs + ptsUs * 1000;
+        const int64_t rampDelayNs = (20 + (i - 1) * 6) * kMs;
+        const PresentationPlan delayed = scheduler.PlanFrame(
+            ptsUs, nominalDecodeNs + rampDelayNs);
+        assert(delayed.action == PresentationAction::SCHEDULE);
+        if (delayed.event == PresentationEvent::PHASE_SHIFT) {
+            phaseShiftCount++;
+        }
+    }
+    assert(phaseShiftCount >= 10);
+
+    const int64_t recoveredPtsUs = 13 * kFrameUs;
+    const int64_t recoveredDecodeNs = kStartNs + recoveredPtsUs * 1000;
+    const PresentationPlan recovered = scheduler.PlanFrame(
+        recoveredPtsUs, recoveredDecodeNs);
+
+    assert(recovered.action == PresentationAction::SCHEDULE);
+    assert(recovered.event == PresentationEvent::PHASE_SHIFT);
+    assert(recovered.latenessNs < 0);
+    assert(std::llabs((recovered.targetTimeNs - recoveredDecodeNs) -
+                      scheduler.GetInitialLeadNs()) < kMs);
+
+    const int64_t nextPtsUs = 14 * kFrameUs;
+    const int64_t nextDecodeNs = kStartNs + nextPtsUs * 1000;
+    const PresentationPlan next = scheduler.PlanFrame(nextPtsUs, nextDecodeNs);
+    assert(next.action == PresentationAction::SCHEDULE);
+    assert(std::llabs((next.targetTimeNs - recovered.targetTimeNs) -
+                      kFrameUs * 1000) < kMs);
+}
+
+void TestDuplicatePtsReanchorsInsteadOfFreezing() {
+    PtsPresentationScheduler scheduler;
+    scheduler.Configure(60.0);
+
+    scheduler.PlanFrame(1000, 1000 * kMs);
+    const PresentationPlan firstDuplicate = scheduler.PlanFrame(1000, 1017 * kMs);
+    const PresentationPlan secondDuplicate = scheduler.PlanFrame(1000, 1034 * kMs);
+
+    assert(firstDuplicate.action == PresentationAction::SCHEDULE);
+    assert(firstDuplicate.event == PresentationEvent::DUPLICATE_PTS);
+    assert(secondDuplicate.action == PresentationAction::SCHEDULE);
+    assert(secondDuplicate.event == PresentationEvent::DUPLICATE_PTS);
+    assert(secondDuplicate.targetTimeNs > firstDuplicate.targetTimeNs);
+}
+
 void TestDiscontinuityReanchors() {
     PtsPresentationScheduler scheduler;
     scheduler.Configure(59.94);
@@ -107,6 +163,8 @@ int main() {
     TestBurstKeepsPtsCadence();
     TestSmallLateFrameShiftsWholeTimeline();
     TestSevereLateDropThenRebuffer();
+    TestAccumulatedPhaseShiftRecoversQuickly();
+    TestDuplicatePtsReanchorsInsteadOfFreezing();
     TestDiscontinuityReanchors();
     TestFractionalFpsLead();
     TestSlowClockDriftStaysBounded();


### PR DESCRIPTION
## 改了啥呀

- common-c 的 host PTS 现在始终写入 codec buffer，同步/异步解码统一提交同一个 DecodedFrame，解码模式不再偷偷决定呈现节奏
- host-paced 调度器把 PTS 连续映射到本地单调时钟：初始约一帧 + 2 ms，小幅迟到整体移相，严重迟到先丢一帧再 rebuffer，PTS 跳变才重锚
- sync 开启 host-paced 后不再 drain-to-latest；async 开启后绕过 L2/L5 裁剪和 L4 burst flush，关键的 L3/IDR 参考链恢复仍保留
- NativeImage 后处理改成 FrameAvailable + GL worker；关闭时在同一 mutex 下更新等待谓词，旧会话回调用独立稳定 token 隔离，杂鱼 lost wakeup 和迟到回调都碰不到已析构对象
- 相移现在记录可回收债务：拥塞消退后快速恢复低延迟，同时不会把正常 decoder burst 当成超前队列
- 重复 PTS 改为重新锚定，不再进入无限 DROP 冻结
- 管线延迟需连续 3 帧超阈值才激活 L3，单次 Wi-Fi/队列尖峰不会立刻换来一轮 IDR 冻结
- decoder 的旁路判断改看 timed-render API 是否实际可用；不可用时继续启用原低延迟裁剪策略
- 三条输出路径统一经过 SubmitDecodedFrame，buffer 所有权、失败处理和呈现统计不再各长各的杂鱼分支
- 调度器 DROP 和最终提交失败会进入总丢帧统计，Rd 只统计真正提交显示的帧
- configured FPS 改为原子状态；移除无调用的旧 NAPI 方法别名、只写不读的 render 全局缓存和重复单调时钟来源
- 保留旧 preference key，升级后的实验设置不会丢；设置项名称为“主机 PTS 平滑呈现 (实验性)”

## 为啥要改

旧方案会让 decode burst、同步 drain、Surface 排队和本地 VSync 共同改写节奏；Rx/Rd 看着正常，真正送显间隔还是可能抽一下。

这轮把“怎么拿到解码输出”和“什么时候呈现”拆开，host PTS 成为精确模式唯一节奏来源。review 又抓出了关闭期竞态、相移只进不出、重复 PTS 不自愈、单尖峰 IDR 和统计失真；这些已经按最小范围修掉，没有顺手重构整套 teardown，也没为了 docstring 指标给代码塞棉花啦。

## 验证

- c++ -std=c++17 -Wall -Wextra -Werror ... presentation_scheduler_test.cpp：通过
  - burst 保持 PTS 间隔
  - 小幅迟到整体移相
  - 严重迟到先丢帧再 rebuffer
  - 相移积累后单帧快速恢复
  - 重复 PTS 持续自愈
  - PTS 回退重新锚定
  - 59.94 FPS 初始余量
  - 20,000 帧、100 ppm 时钟偏差下余量有界
- DEVECO_SDK_HOME=... bash ./hvigorw assembleHar --mode module -p module=nativelib@default -p product=default --no-daemon：BUILD SUCCESSFUL
- JAVA_HOME=... DEVECO_SDK_HOME=... bash ./hvigorw assembleApp --mode project -p product=default --no-daemon：BUILD SUCCESSFUL
- git diff --check：通过

当前没有连接 HDC 设备，仍需真机串流验证同步/异步 × 开关开/关四种组合。重点观察 scheduled、dropped、late、phaseShift、rebuffer、resync、apiFailure；稳态应以 scheduled 增长为主。
