### PR TITLE
chore(repo): enforce repository hygiene checks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,13 @@
-# Ensure shell scripts keep LF line endings (run on Linux CI)
-ci/*.sh text eol=lf
+# Keep text files stable across Windows development and Linux CI.
+* text=auto
+*.sh text eol=lf
+*.js text eol=lf
+*.mjs text eol=lf
+*.ts text eol=lf
+*.ets text eol=lf
+*.json text eol=lf
+*.json5 text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+/hvigorw text eol=lf
+*.bat text eol=crlf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,18 @@ jobs:
       with:
         node-version: '18'
 
+    - name: Run repository checks
+      run: npm run check
+
+    - name: Check ignore rules
+      run: |
+        ignored_files="$(git ls-files -ci --exclude-standard)"
+        if [[ -n "$ignored_files" ]]; then
+          echo "Tracked files must not match .gitignore:"
+          echo "$ignored_files"
+          exit 1
+        fi
+
     - name: Setup Java 17
       uses: actions/setup-java@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,15 +50,6 @@ jobs:
     - name: Run repository checks
       run: npm run check
 
-    - name: Check ignore rules
-      run: |
-        ignored_files="$(git ls-files -ci --exclude-standard)"
-        if [[ -n "$ignored_files" ]]; then
-          echo "Tracked files must not match .gitignore:"
-          echo "$ignored_files"
-          exit 1
-        fi
-
     - name: Setup Java 17
       uses: actions/setup-java@v4
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ build/
 oh_modules/
 node_modules/
 .hvigor/
+/.codex-build/
 .local.properties
 local.properties
 .preview/
@@ -15,11 +16,23 @@ nativelib/.preview/
 .github/appmod/
 
 # Build profile (contains signing config)
-build-profile.json5
+/build-profile.json5
+/.signing/
 nativelib/BuildProfile.ets
 nativelib/src/main/cpp/aubio/src/config.h
 nativelib/src/main/cpp/include/
 nativelib/src/main/cpp/rs_include/
+
+# Local test and tooling caches
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.cache/
+cmake-build-*/
+CMakeCache.txt
+CMakeFiles/
+Testing/
+coverage/
 
 # Dev key secret (contains activation salt)
 entry/src/main/ets/config/DevKeySecret.ets
@@ -33,6 +46,8 @@ More
 *.o
 *.so
 *.a
+!nativelib/src/main/cpp/libopus/arm64-v8a/libopus.a
+!nativelib/src/main/cpp/libopus/x86_64/libopus.a
 *.hap
 *.app
 

--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ scripts/*
 !scripts/release.js
 !scripts/sunshine-mock-connection-test.js
 !scripts/archive-native-symbols.js
+!scripts/check-repository.js
 
 # Local release artifacts
 release-symbols/

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ git clone https://github.com/AlkaidLab/moonlight-harmony.git
 # 命令行构建前安装项目依赖（DevEco Studio 可自动完成）
 ohpm install --all
 
-# 运行仓库检查（脚本语法 + Sunshine 协议模型测试）
+# 运行仓库检查（脚本语法 + Git 忽略规则 + Sunshine 协议模型测试）
 npm run check
 
 # 编译调试版应用（与 CI 使用相同的任务）

--- a/README.md
+++ b/README.md
@@ -192,8 +192,14 @@ git clone https://github.com/AlkaidLab/moonlight-harmony.git
 # 使用 DevEco Studio 打开项目
 # File → Open → 选择项目目录
 
-# 编译 HAP
-./hvigorw assembleHap
+# 命令行构建前安装项目依赖（DevEco Studio 可自动完成）
+ohpm install --all
+
+# 运行仓库检查（脚本语法 + Sunshine 协议模型测试）
+npm run check
+
+# 编译调试版应用（与 CI 使用相同的任务）
+node hvigorw.js assembleApp --mode project -p product=default -p buildMode=debug --no-daemon
 ```
 
 ## 🐛 问题反馈

--- a/hvigorw
+++ b/hvigorw
@@ -43,12 +43,5 @@ if [ -d "$PROJECT_DIR/.hvigor" ]; then
     fi
 fi
 
-# 6. Try using npx
-if command -v npx &> /dev/null; then
-    exec npx @ohos/hvigor "$@"
-fi
-
-echo "Error: Cannot find hvigor. Please install it via:"
-echo "  cd hvigor && npm install"
-echo "  or: ohpm install"
+echo 'Error: Cannot find hvigor. Run "ohpm install --all" or open the project in DevEco Studio.'
 exit 1

--- a/hvigorw.bat
+++ b/hvigorw.bat
@@ -19,12 +19,5 @@ if exist "%PROJECT_DIR%node_modules\.bin\hvigor.cmd" (
     exit /b %ERRORLEVEL%
 )
 
-where npx >nul 2>&1
-if %ERRORLEVEL% EQU 0 (
-    npx hvigor %*
-    exit /b %ERRORLEVEL%
-)
-
-echo Error: Cannot find hvigor. Please install it via:
-echo   ohpm install @ohos/hvigor-ohos-plugin
+echo Error: Cannot find hvigor. Run "ohpm install --all" or open the project in DevEco Studio.
 exit /b 1

--- a/hvigorw.js
+++ b/hvigorw.js
@@ -5,7 +5,7 @@
  * For HarmonyOS project CI/CD compatibility
  */
 
-const { spawn, execSync } = require('child_process');
+const { spawn, execFileSync } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 
@@ -47,26 +47,42 @@ function findAndRunHvigor() {
   
   // 4. Try global hvigor
   try {
-    const hvigorPath = execSync('which hvigor', { encoding: 'utf8' }).trim();
+    const locator = process.platform === 'win32' ? 'where.exe' : 'which';
+    const hvigorPaths = execFileSync(locator, ['hvigor'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      windowsHide: true
+    }).split(/\r?\n/).map((candidate) => candidate.trim()).filter(Boolean);
+
+    if (process.platform === 'win32') {
+      for (const commandPath of hvigorPaths) {
+        for (const prefix of [path.dirname(commandPath), path.resolve(path.dirname(commandPath), '..')]) {
+          const globalEntry = path.join(prefix, 'node_modules', '@ohos', 'hvigor', 'bin', 'hvigor.js');
+          if (fs.existsSync(globalEntry)) {
+            require(globalEntry);
+            return;
+          }
+        }
+      }
+    }
+
+    const hvigorPath = hvigorPaths.find((candidate) =>
+      process.platform !== 'win32' || /\.(?:com|exe)$/i.test(candidate));
     if (hvigorPath) {
-      const child = spawn(hvigorPath, args, { stdio: 'inherit' });
-      child.on('exit', (code) => process.exit(code || 0));
+      const child = spawn(hvigorPath, args, { stdio: 'inherit', windowsHide: true });
+      child.on('exit', (code) => process.exit(code ?? 1));
+      child.on('error', (error) => {
+        console.error(`Error: Failed to start hvigor: ${error.message}`);
+        process.exit(1);
+      });
       return;
     }
   } catch (e) {
     // Global hvigor not found
   }
-  
-  // 5. Try npx
-  console.log('Trying npx @ohos/hvigor...');
-  const child = spawn('npx', ['@ohos/hvigor', ...args], { stdio: 'inherit', shell: true });
-  child.on('exit', (code) => process.exit(code || 0));
-  child.on('error', () => {
-    console.error('Error: Cannot find hvigor. Please install it via:');
-    console.error('  cd hvigor && npm install');
-    console.error('  or: ohpm install');
-    process.exit(1);
-  });
+
+  console.error('Error: Cannot find hvigor. Run "ohpm install --all" or open the project in DevEco Studio.');
+  process.exit(1);
 }
 
 function findFilesRecursive(dir, filename) {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "description": "Moonlight for HarmonyOS - PC Game Streaming",
   "scripts": {
+    "check": "npm run check:scripts && npm test",
+    "check:scripts": "node --check hvigorw.js && node --check scripts/gen-changelog.js && node --check scripts/release.js && node --check scripts/sunshine-mock-connection-test.js",
+    "test": "npm run test:sunshine-mock",
     "release": "node scripts/release.js",
     "changelog": "node scripts/gen-changelog.js",
     "test:sunshine-mock": "node scripts/sunshine-mock-connection-test.js"

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "private": true,
   "description": "Moonlight for HarmonyOS - PC Game Streaming",
   "scripts": {
-    "check": "npm run check:scripts && npm test",
-    "check:scripts": "node --check hvigorw.js && node --check scripts/gen-changelog.js && node --check scripts/release.js && node --check scripts/sunshine-mock-connection-test.js",
+    "check": "npm run check:scripts && npm run check:repository && npm test",
+    "check:repository": "node scripts/check-repository.js",
+    "check:scripts": "node --check hvigorw.js && node --check scripts/check-repository.js && node --check scripts/gen-changelog.js && node --check scripts/release.js && node --check scripts/sunshine-mock-connection-test.js",
     "test": "npm run test:sunshine-mock",
     "release": "node scripts/release.js",
     "changelog": "node scripts/gen-changelog.js",

--- a/scripts/check-repository.js
+++ b/scripts/check-repository.js
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+/*
+ * Repository hygiene checks shared by local development and CI.
+ */
+
+const { execFileSync } = require('child_process');
+
+function findIgnoredTrackedFiles() {
+  return execFileSync('git', ['ls-files', '-ci', '--exclude-standard'], {
+    encoding: 'utf8'
+  }).trim();
+}
+
+try {
+  const ignoredFiles = findIgnoredTrackedFiles();
+  if (ignoredFiles) {
+    console.error('Tracked files must not match .gitignore:');
+    console.error(ignoredFiles);
+    process.exit(1);
+  }
+
+  console.log('Repository hygiene checks passed.');
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`Repository hygiene checks failed: ${message}`);
+  process.exit(1);
+}


### PR DESCRIPTION
## 改了啥呀

- 增加统一的 `npm run check` 入口，覆盖 Hvigor/发布脚本语法检查和 Sunshine 协议模型测试。
- 在 HarmonyOS 构建工作流前置运行仓库检查，并阻止已跟踪文件继续命中 `.gitignore`。
- 整理跨平台行尾规则、本地签名/测试/CMake 缓存忽略项，并明确保留 vendored Opus 库。
- 修正三个 Hvigor 包装器：Windows 不再硬编码 `which`，缺少工具时也不会偷偷让 `npx` 下载未锁定包。
- 更新 README 的依赖安装、检查和 `assembleApp` 构建命令。

## 为啥要改

现有 Sunshine 协议测试没有进入 CI，旧构建文档还指向 `assembleHap`，包装器的兜底路径也会制造一只会乱下载包的杂鱼状态。顺便把“文件已经跟踪、却又被忽略”的规则漂移清干净，以后让 CI 帮忙守门。

这次只调整仓库基础设施，不改变应用运行时行为。

## 验证

- `npm run check`（11 个 Sunshine 协议模型用例通过）
- `bash -n hvigorw ci/normalize-sdk.sh ci/patch-sdk.sh`
- `python -c "import yaml; yaml.safe_load(open('.github/workflows/build.yml', encoding='utf-8'))"`
- `git diff --check`
- `git ls-files -ci --exclude-standard`（无输出）
- 已跟踪文件密钥模式扫描（无匹配）

本机未安装可调用的 Hvigor，因此完整 HarmonyOS 构建交由本 PR 的标准 Build HarmonyOS 工作流验证。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新增功能**
  - 新增项目检查与测试命令，构建前会自动验证脚本、测试结果及仓库文件状态。
  - 改进构建工具的跨平台查找与启动支持。

- **改进**
  - 未安装构建工具时提供更清晰的错误提示和解决建议。
  - 更新开发指南，补充依赖安装、项目检查及调试版应用构建步骤。

- **维护**
  - 统一不同文件类型的换行格式，减少跨平台协作差异。
  - 优化忽略规则，避免本地缓存和构建产物干扰版本管理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->