### PR TITLE
fix(render): preserve 120 fps pacing headroom

### DIFF
--- a/nativelib/src/main/cpp/presentation_scheduler.cpp
+++ b/nativelib/src/main/cpp/presentation_scheduler.cpp
@@ -16,8 +16,8 @@
 namespace {
 constexpr int64_t kNanosecondsPerSecond = 1000000000LL;
 constexpr int64_t kNanosecondsPerMicrosecond = 1000LL;
-constexpr int64_t kMinSubmitLeadNs = 1000000LL;
-constexpr int64_t kMaxSubmitLeadNs = 2000000LL;
+constexpr int64_t kSubmitLeadNs = 2000000LL;
+constexpr int64_t kPtsQuantizationSlackNs = kNanosecondsPerMicrosecond;
 constexpr int64_t kDriftDeadbandNs = 2000000LL;
 constexpr int64_t kMaxDriftCorrectionPerFrameNs = 20000LL;
 constexpr int kSevereLateFramesBeforeRebuffer = 2;
@@ -28,13 +28,16 @@ void PtsPresentationScheduler::Configure(double fps) {
     frameIntervalNs_ = static_cast<int64_t>(
         std::llround(static_cast<double>(kNanosecondsPerSecond) / safeFps));
     frameIntervalNs_ = std::max<int64_t>(frameIntervalNs_, 1000000LL);
-    submitLeadNs_ = std::clamp(frameIntervalNs_ / 8,
-                               kMinSubmitLeadNs, kMaxSubmitLeadNs);
-    // RenderOutputBufferAtTime only needs a small submission margin. A full
-    // frame of fixed lead makes the next VSync become the following VSync on
-    // part of every refresh cycle, adding latency even in steady state.
+    // RenderService needs an absolute latch margin that does not shrink with
+    // the stream frame interval. Keep steady-state lead small, but large enough
+    // for 120 Hz submission overhead.
+    submitLeadNs_ = kSubmitLeadNs;
     initialLeadNs_ = submitLeadNs_;
-    maxFutureLeadNs_ = initialLeadNs_ + frameIntervalNs_ / 2;
+    // Decoder callbacks commonly arrive in pairs. Preserve one frame of PTS
+    // spacing before treating future lead as backlog. The extra microsecond
+    // covers integer PTS quantization at rates such as 120 and 59.94 FPS.
+    maxFutureLeadNs_ = initialLeadNs_ + frameIntervalNs_ +
+        kPtsQuantizationSlackNs;
     discontinuityNs_ = std::max<int64_t>(250000000LL, frameIntervalNs_ * 12);
     Reset();
 }

--- a/nativelib/src/main/cpp/presentation_scheduler.h
+++ b/nativelib/src/main/cpp/presentation_scheduler.h
@@ -57,7 +57,7 @@ private:
     int64_t frameIntervalNs_ = 16666667LL;
     int64_t initialLeadNs_ = 2000000LL;
     int64_t submitLeadNs_ = 2000000LL;
-    int64_t maxFutureLeadNs_ = 10333333LL;
+    int64_t maxFutureLeadNs_ = 18667667LL;
     int64_t discontinuityNs_ = 250000000LL;
 
     bool initialized_ = false;

--- a/nativelib/src/test/cpp/presentation_scheduler_test.cpp
+++ b/nativelib/src/test/cpp/presentation_scheduler_test.cpp
@@ -9,21 +9,22 @@
 namespace {
 constexpr int64_t kMs = 1000000LL;
 
-void TestBurstCollapsesToLatestWithinLatencyBudget() {
+void Test120FpsPairBurstKeepsPtsCadence() {
     PtsPresentationScheduler scheduler;
-    scheduler.Configure(60.0);
+    scheduler.Configure(120.0);
 
     const PresentationPlan first = scheduler.PlanFrame(0, 1000 * kMs);
-    const PresentationPlan second = scheduler.PlanFrame(16667, 1000 * kMs);
-    const PresentationPlan third = scheduler.PlanFrame(33333, 1001 * kMs);
+    const PresentationPlan second = scheduler.PlanFrame(8334, 1000 * kMs);
+    const PresentationPlan third = scheduler.PlanFrame(16667, 1001 * kMs);
 
     assert(first.action == PresentationAction::SCHEDULE);
     assert(second.action == PresentationAction::SCHEDULE);
     assert(third.action == PresentationAction::SCHEDULE);
-    assert(second.event == PresentationEvent::CATCH_UP);
+    assert(second.event == PresentationEvent::NONE);
     assert(third.event == PresentationEvent::CATCH_UP);
     assert(first.targetTimeNs - 1000 * kMs == scheduler.GetInitialLeadNs());
-    assert(second.targetTimeNs - 1000 * kMs == scheduler.GetInitialLeadNs());
+    assert(scheduler.GetInitialLeadNs() == 2 * kMs);
+    assert(second.targetTimeNs - first.targetTimeNs == 8334 * 1000LL);
     assert(third.targetTimeNs - 1001 * kMs == scheduler.GetInitialLeadNs());
 }
 
@@ -151,7 +152,8 @@ void TestFractionalFpsLatencyBudget() {
 
     assert(first.action == PresentationAction::SCHEDULE);
     assert(first.targetTimeNs - decodedAtNs == expectedLeadNs);
-    assert(scheduler.GetMaxFutureLeadNs() == expectedLeadNs + frameIntervalNs / 2);
+    assert(scheduler.GetMaxFutureLeadNs() ==
+        expectedLeadNs + frameIntervalNs + 1000LL);
 }
 
 void TestSlowClockDriftStaysBounded() {
@@ -179,7 +181,7 @@ void TestSlowClockDriftStaysBounded() {
 } // namespace
 
 int main() {
-    TestBurstCollapsesToLatestWithinLatencyBudget();
+    Test120FpsPairBurstKeepsPtsCadence();
     TestSmallLateFrameShiftsWholeTimeline();
     TestSevereLateDropThenRebuffer();
     TestAccumulatedPhaseShiftRecoversQuickly();


### PR DESCRIPTION
## 改了啥呀

- 把定时呈现的绝对提交余量固定为 2 ms，给 120 Hz 的 RenderService latch 留出稳定空间
- future lead 从半帧放宽到一帧，并加入 1 us PTS 量化容差
- 新增 120 FPS 双帧 burst 测试，保证两帧继续按 PTS 间隔送显；真正超过预算时才 catch-up

## 为啥要改

PR63 的半帧预算在 120 FPS 下只有约 5.21 ms。解码器只要同批吐出两帧，第二帧就会被这个小杂鱼阈值重新锚定到同一个 VSync，Surface 随后丢掉其中一帧，实际显示帧率因此跑不满。

修复后稳态 lead 是 2 ms，相比 PR63 只增加约 0.96 ms；一帧 future lead 只吸收瞬时 decoder burst，不恢复旧版固定一整帧排队。

## 验证

- `c++ -std=c++17 -Wall -Wextra -Werror nativelib/src/main/cpp/presentation_scheduler.cpp nativelib/src/test/cpp/presentation_scheduler_test.cpp -I nativelib/src/main/cpp -o /tmp/moonlight_presentation_scheduler_test && /tmp/moonlight_presentation_scheduler_test`
- `npm run check`
- `node hvigorw.js assembleApp --mode project -p product=default -p buildMode=debug --no-daemon`（DevEco SDK 6.1 / JBR 21，BUILD SUCCESSFUL）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 优化高刷新率场景下的画面呈现调度，提升连续帧的时间一致性。
  - 改善成对帧突发到达时的处理，减少不必要的帧合并或跳过。
  - 调整未来帧调度窗口，使不同帧率和小数帧率下的延迟控制更加稳定。

- **测试**
  - 新增并更新高刷新率及突发帧场景验证，确保追帧行为符合预期。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->