### PR TITLE
fix(render): scope burst headroom to high refresh

### DIFF
--- a/nativelib/src/main/cpp/presentation_scheduler.cpp
+++ b/nativelib/src/main/cpp/presentation_scheduler.cpp
@@ -33,10 +33,12 @@ void PtsPresentationScheduler::Configure(double fps) {
     // for 120 Hz submission overhead.
     submitLeadNs_ = kSubmitLeadNs;
     initialLeadNs_ = submitLeadNs_;
-    // Decoder callbacks commonly arrive in pairs. Preserve one frame of PTS
-    // spacing before treating future lead as backlog. The extra microsecond
-    // covers integer PTS quantization at rates such as 120 and 59.94 FPS.
-    maxFutureLeadNs_ = initialLeadNs_ + frameIntervalNs_ +
+    // High-refresh decoder callbacks commonly arrive in pairs, so preserve one
+    // frame of PTS spacing there. At 60 FPS and below, keep the tighter half-
+    // frame bound to avoid turning a burst into 16-33 ms of extra latency.
+    const int64_t futureCadenceBudgetNs = safeFps > 60.0 ?
+        frameIntervalNs_ : frameIntervalNs_ / 2;
+    maxFutureLeadNs_ = initialLeadNs_ + futureCadenceBudgetNs +
         kPtsQuantizationSlackNs;
     discontinuityNs_ = std::max<int64_t>(250000000LL, frameIntervalNs_ * 12);
     Reset();

--- a/nativelib/src/main/cpp/presentation_scheduler.cpp
+++ b/nativelib/src/main/cpp/presentation_scheduler.cpp
@@ -18,6 +18,8 @@ constexpr int64_t kNanosecondsPerSecond = 1000000000LL;
 constexpr int64_t kNanosecondsPerMicrosecond = 1000LL;
 constexpr int64_t kSubmitLeadNs = 2000000LL;
 constexpr int64_t kPtsQuantizationSlackNs = kNanosecondsPerMicrosecond;
+constexpr double kHighRefreshFps = 60.0;
+constexpr double kTripleBurstFps = 120.0;
 constexpr int64_t kDriftDeadbandNs = 2000000LL;
 constexpr int64_t kMaxDriftCorrectionPerFrameNs = 20000LL;
 constexpr int kSevereLateFramesBeforeRebuffer = 2;
@@ -33,11 +35,14 @@ void PtsPresentationScheduler::Configure(double fps) {
     // for 120 Hz submission overhead.
     submitLeadNs_ = kSubmitLeadNs;
     initialLeadNs_ = submitLeadNs_;
-    // High-refresh decoder callbacks commonly arrive in pairs, so preserve one
-    // frame of PTS spacing there. At 60 FPS and below, keep the tighter half-
-    // frame bound to avoid turning a burst into 16-33 ms of extra latency.
-    const int64_t futureCadenceBudgetNs = safeFps > 60.0 ?
-        frameIntervalNs_ : frameIntervalNs_ / 2;
+    // Preserve enough PTS spacing for the burst depth observed at each refresh
+    // tier without widening the latency budget for lower frame rates.
+    int64_t futureCadenceBudgetNs = frameIntervalNs_ / 2;
+    if (safeFps >= kTripleBurstFps) {
+        futureCadenceBudgetNs = frameIntervalNs_ * 2;
+    } else if (safeFps > kHighRefreshFps) {
+        futureCadenceBudgetNs = frameIntervalNs_;
+    }
     maxFutureLeadNs_ = initialLeadNs_ + futureCadenceBudgetNs +
         kPtsQuantizationSlackNs;
     discontinuityNs_ = std::max<int64_t>(250000000LL, frameIntervalNs_ * 12);

--- a/nativelib/src/main/cpp/presentation_scheduler.cpp
+++ b/nativelib/src/main/cpp/presentation_scheduler.cpp
@@ -19,7 +19,7 @@ constexpr int64_t kNanosecondsPerMicrosecond = 1000LL;
 constexpr int64_t kSubmitLeadNs = 2000000LL;
 constexpr int64_t kPtsQuantizationSlackNs = kNanosecondsPerMicrosecond;
 constexpr double kHighRefreshFps = 60.0;
-constexpr double kTripleBurstFps = 120.0;
+constexpr double kNtscTripleBurstFps = 119.88;
 constexpr int64_t kDriftDeadbandNs = 2000000LL;
 constexpr int64_t kMaxDriftCorrectionPerFrameNs = 20000LL;
 constexpr int kSevereLateFramesBeforeRebuffer = 2;
@@ -38,7 +38,7 @@ void PtsPresentationScheduler::Configure(double fps) {
     // Preserve enough PTS spacing for the burst depth observed at each refresh
     // tier without widening the latency budget for lower frame rates.
     int64_t futureCadenceBudgetNs = frameIntervalNs_ / 2;
-    if (safeFps >= kTripleBurstFps) {
+    if (safeFps >= kNtscTripleBurstFps) {
         futureCadenceBudgetNs = frameIntervalNs_ * 2;
     } else if (safeFps > kHighRefreshFps) {
         futureCadenceBudgetNs = frameIntervalNs_;

--- a/nativelib/src/main/cpp/presentation_scheduler.h
+++ b/nativelib/src/main/cpp/presentation_scheduler.h
@@ -57,7 +57,7 @@ private:
     int64_t frameIntervalNs_ = 16666667LL;
     int64_t initialLeadNs_ = 2000000LL;
     int64_t submitLeadNs_ = 2000000LL;
-    int64_t maxFutureLeadNs_ = 18667667LL;
+    int64_t maxFutureLeadNs_ = 10334333LL;
     int64_t discontinuityNs_ = 250000000LL;
 
     bool initialized_ = false;

--- a/nativelib/src/test/cpp/presentation_scheduler_test.cpp
+++ b/nativelib/src/test/cpp/presentation_scheduler_test.cpp
@@ -9,24 +9,51 @@
 namespace {
 constexpr int64_t kMs = 1000000LL;
 
-void Test120FpsPairBurstKeepsPtsCadence() {
+void Test120FpsTripleBurstKeepsPtsCadence() {
     PtsPresentationScheduler scheduler;
     scheduler.Configure(120.0);
 
     const PresentationPlan first = scheduler.PlanFrame(0, 1000 * kMs);
     const PresentationPlan second = scheduler.PlanFrame(8334, 1000 * kMs);
     const PresentationPlan third = scheduler.PlanFrame(16667, 1001 * kMs);
+    const PresentationPlan fourth = scheduler.PlanFrame(25000, 1001 * kMs);
+    const int64_t frameIntervalNs = static_cast<int64_t>(
+        std::llround(1000000000.0 / 120.0));
+
+    assert(first.action == PresentationAction::SCHEDULE);
+    assert(second.action == PresentationAction::SCHEDULE);
+    assert(third.action == PresentationAction::SCHEDULE);
+    assert(fourth.action == PresentationAction::SCHEDULE);
+    assert(second.event == PresentationEvent::NONE);
+    assert(third.event == PresentationEvent::NONE);
+    assert(fourth.event == PresentationEvent::CATCH_UP);
+    assert(first.targetTimeNs - 1000 * kMs == scheduler.GetInitialLeadNs());
+    assert(scheduler.GetInitialLeadNs() == 2 * kMs);
+    assert(scheduler.GetMaxFutureLeadNs() ==
+        scheduler.GetInitialLeadNs() + frameIntervalNs * 2 + 1000LL);
+    assert(second.targetTimeNs - first.targetTimeNs == 8334 * 1000LL);
+    assert(third.targetTimeNs - second.targetTimeNs == 8333 * 1000LL);
+    assert(fourth.targetTimeNs - 1001 * kMs == scheduler.GetInitialLeadNs());
+}
+
+void Test90FpsPairBurstKeepsSingleFrameBudget() {
+    PtsPresentationScheduler scheduler;
+    scheduler.Configure(90.0);
+
+    const int64_t decodedAtNs = 1000 * kMs;
+    const PresentationPlan first = scheduler.PlanFrame(0, decodedAtNs);
+    const PresentationPlan second = scheduler.PlanFrame(11111, decodedAtNs);
+    const PresentationPlan third = scheduler.PlanFrame(22222, decodedAtNs + kMs);
+    const int64_t frameIntervalNs = static_cast<int64_t>(
+        std::llround(1000000000.0 / 90.0));
 
     assert(first.action == PresentationAction::SCHEDULE);
     assert(second.action == PresentationAction::SCHEDULE);
     assert(third.action == PresentationAction::SCHEDULE);
     assert(second.event == PresentationEvent::NONE);
     assert(third.event == PresentationEvent::CATCH_UP);
-    assert(first.targetTimeNs - 1000 * kMs == scheduler.GetInitialLeadNs());
-    assert(scheduler.GetInitialLeadNs() == 2 * kMs);
-    assert(scheduler.GetMaxFutureLeadNs() == 10334333LL);
-    assert(second.targetTimeNs - first.targetTimeNs == 8334 * 1000LL);
-    assert(third.targetTimeNs - 1001 * kMs == scheduler.GetInitialLeadNs());
+    assert(scheduler.GetMaxFutureLeadNs() ==
+        scheduler.GetInitialLeadNs() + frameIntervalNs + 1000LL);
 }
 
 void AssertLowRefreshBurstCatchesUp(double fps, int64_t framePtsUs) {
@@ -205,7 +232,8 @@ void TestSlowClockDriftStaysBounded() {
 } // namespace
 
 int main() {
-    Test120FpsPairBurstKeepsPtsCadence();
+    Test120FpsTripleBurstKeepsPtsCadence();
+    Test90FpsPairBurstKeepsSingleFrameBudget();
     TestLowRefreshBurstKeepsHalfFrameBudget();
     TestSmallLateFrameShiftsWholeTimeline();
     TestSevereLateDropThenRebuffer();

--- a/nativelib/src/test/cpp/presentation_scheduler_test.cpp
+++ b/nativelib/src/test/cpp/presentation_scheduler_test.cpp
@@ -56,6 +56,22 @@ void Test90FpsPairBurstKeepsSingleFrameBudget() {
         scheduler.GetInitialLeadNs() + frameIntervalNs + 1000LL);
 }
 
+void TestNtsc120FpsUsesTripleBurstBudget() {
+    PtsPresentationScheduler scheduler;
+    scheduler.Configure(119.88);
+
+    const int64_t frameIntervalNs = static_cast<int64_t>(
+        std::llround(1000000000.0 / 119.88));
+    assert(scheduler.GetMaxFutureLeadNs() ==
+        scheduler.GetInitialLeadNs() + frameIntervalNs * 2 + 1000LL);
+
+    scheduler.Configure(119.0);
+    const int64_t lowerFrameIntervalNs = static_cast<int64_t>(
+        std::llround(1000000000.0 / 119.0));
+    assert(scheduler.GetMaxFutureLeadNs() ==
+        scheduler.GetInitialLeadNs() + lowerFrameIntervalNs + 1000LL);
+}
+
 void AssertLowRefreshBurstCatchesUp(double fps, int64_t framePtsUs) {
     PtsPresentationScheduler scheduler;
     scheduler.Configure(fps);
@@ -234,6 +250,7 @@ void TestSlowClockDriftStaysBounded() {
 int main() {
     Test120FpsTripleBurstKeepsPtsCadence();
     Test90FpsPairBurstKeepsSingleFrameBudget();
+    TestNtsc120FpsUsesTripleBurstBudget();
     TestLowRefreshBurstKeepsHalfFrameBudget();
     TestSmallLateFrameShiftsWholeTimeline();
     TestSevereLateDropThenRebuffer();

--- a/nativelib/src/test/cpp/presentation_scheduler_test.cpp
+++ b/nativelib/src/test/cpp/presentation_scheduler_test.cpp
@@ -24,8 +24,32 @@ void Test120FpsPairBurstKeepsPtsCadence() {
     assert(third.event == PresentationEvent::CATCH_UP);
     assert(first.targetTimeNs - 1000 * kMs == scheduler.GetInitialLeadNs());
     assert(scheduler.GetInitialLeadNs() == 2 * kMs);
+    assert(scheduler.GetMaxFutureLeadNs() == 10334333LL);
     assert(second.targetTimeNs - first.targetTimeNs == 8334 * 1000LL);
     assert(third.targetTimeNs - 1001 * kMs == scheduler.GetInitialLeadNs());
+}
+
+void AssertLowRefreshBurstCatchesUp(double fps, int64_t framePtsUs) {
+    PtsPresentationScheduler scheduler;
+    scheduler.Configure(fps);
+
+    const int64_t decodedAtNs = 1000 * kMs;
+    const PresentationPlan first = scheduler.PlanFrame(0, decodedAtNs);
+    const PresentationPlan burst = scheduler.PlanFrame(framePtsUs, decodedAtNs);
+    const int64_t frameIntervalNs = static_cast<int64_t>(
+        std::llround(1000000000.0 / fps));
+
+    assert(first.action == PresentationAction::SCHEDULE);
+    assert(burst.action == PresentationAction::SCHEDULE);
+    assert(burst.event == PresentationEvent::CATCH_UP);
+    assert(burst.targetTimeNs - decodedAtNs == scheduler.GetInitialLeadNs());
+    assert(scheduler.GetMaxFutureLeadNs() ==
+        scheduler.GetInitialLeadNs() + frameIntervalNs / 2 + 1000LL);
+}
+
+void TestLowRefreshBurstKeepsHalfFrameBudget() {
+    AssertLowRefreshBurstCatchesUp(30.0, 33333);
+    AssertLowRefreshBurstCatchesUp(60.0, 16667);
 }
 
 void TestSmallLateFrameShiftsWholeTimeline() {
@@ -153,7 +177,7 @@ void TestFractionalFpsLatencyBudget() {
     assert(first.action == PresentationAction::SCHEDULE);
     assert(first.targetTimeNs - decodedAtNs == expectedLeadNs);
     assert(scheduler.GetMaxFutureLeadNs() ==
-        expectedLeadNs + frameIntervalNs + 1000LL);
+        expectedLeadNs + frameIntervalNs / 2 + 1000LL);
 }
 
 void TestSlowClockDriftStaysBounded() {
@@ -182,6 +206,7 @@ void TestSlowClockDriftStaysBounded() {
 
 int main() {
     Test120FpsPairBurstKeepsPtsCadence();
+    TestLowRefreshBurstKeepsHalfFrameBudget();
     TestSmallLateFrameShiftsWholeTimeline();
     TestSevereLateDropThenRebuffer();
     TestAccumulatedPhaseShiftRecoversQuickly();


### PR DESCRIPTION
## 改了啥呀

- 使用三级 future-lead 预算：`<=60 FPS` 半帧、`61-119 FPS` 一帧、`>=119.88 FPS` 两帧
- 119.88/120+ FPS 现在可保留三帧 decoder burst 的 PTS 间隔，第四帧才触发 catch-up
- 所有帧率继续使用 2 ms 稳态提交余量；30/60 FPS 的延迟边界不变
- 增加 30、60、90、119、119.88、120 FPS 边界测试，并修正 59.94 FPS 预算断言

## 为啥要改

一帧 future lead 已让 120 FPS 比 PR63 更容易跑满，但真机仍会间歇掉帧，说明这个小杂鱼硬解偶尔会一次吐出三帧。120 FPS 下把瞬时预算从约 10.33 ms 放宽到 18.67 ms，可以保留第三帧的 PTS 节奏；稳态 lead 仍是 2 ms，不固定增加两帧延迟。

NTSC 119.88 FPS 同样进入两帧预算。阈值精确设为 119.88，而不是宽泛的 119.0，因此真正的 119 FPS 自定义流仍保持一帧预算；90 FPS、30/60 FPS 的边界也不变。

## 验证

- `c++ -std=c++17 -Wall -Wextra -Werror nativelib/src/main/cpp/presentation_scheduler.cpp nativelib/src/test/cpp/presentation_scheduler_test.cpp -I nativelib/src/main/cpp -o /tmp/moonlight_presentation_scheduler_test && /tmp/moonlight_presentation_scheduler_test`
- `npm run check`
- `node hvigorw.js assembleApp --mode project -p product=default -p buildMode=debug --no-daemon`（DevEco SDK 6.1 / JBR 21，BUILD SUCCESSFUL）