### PR TITLE
fix(stats): improve presentation pacing observability

### DIFF
--- a/nativelib/src/main/cpp/CMakeLists.txt
+++ b/nativelib/src/main/cpp/CMakeLists.txt
@@ -86,6 +86,8 @@ set(SOURCE_FILES
     usb_ddk_poller.cpp
     native_render.cpp
     presentation_scheduler.cpp
+    presentation_diagnostics.cpp
+    rolling_frame_rate.cpp
     gl_post_processor.cpp
     sdl_gamecontrollerdb.cpp
 )

--- a/nativelib/src/main/cpp/native_render.cpp
+++ b/nativelib/src/main/cpp/native_render.cpp
@@ -249,7 +249,7 @@ void NativeRender::SetVsyncEnabled(bool enable) {
     bool wasEnabled = vsyncEnabled_.exchange(enable);
     if (wasEnabled != enable) {
         {
-            std::lock_guard<std::mutex> lock(presentationMutex_);
+            std::unique_lock<std::mutex> lock(presentationMutex_);
             ResetPresentationClockLocked();
             ResetPresentationStatsLocked();
         }
@@ -438,6 +438,8 @@ void NativeRender::ResetPresentationStatsLocked() {
     precisePhaseShiftCount_ = 0;
     preciseRebufferCount_ = 0;
     preciseResyncCount_ = 0;
+    preciseQueueFullCount_ = 0;
+    preciseWaitForDrainCount_ = 0;
     preciseApiFailureCount_ = 0;
     preciseMaxTargetLeadNs_ = 0;
     presentationDiagnostics_.Reset();
@@ -551,69 +553,77 @@ NativeRender::FrameSubmitResult NativeRender::SubmitFrame(const DecodedFrame& fr
         } else {
             const int64_t decodedAtNs = GetMonotonicTimeNs();
             RequestVSyncSample(decodedAtNs);
-            PresentationPlan plan;
-            {
-                std::lock_guard<std::mutex> lock(presentationMutex_);
-                plan = ptsScheduler_.PlanFrame(frame.ptsUs, decodedAtNs);
-                if (plan.action == PresentationAction::SCHEDULE) {
-                    preciseScheduledCount_++;
-                } else {
-                    preciseDroppedCount_++;
-                }
-                if (plan.latenessNs > 0) preciseLateCount_++;
-                if (plan.event == PresentationEvent::CATCH_UP) {
-                    preciseCatchUpCount_++;
-                }
-                if (plan.event == PresentationEvent::PHASE_SHIFT) precisePhaseShiftCount_++;
-                if (plan.event == PresentationEvent::REBUFFER) preciseRebufferCount_++;
-                if (plan.event == PresentationEvent::DISCONTINUITY ||
-                    plan.event == PresentationEvent::DUPLICATE_PTS) {
-                    preciseResyncCount_++;
-                }
-                const int64_t observedVsyncNs =
-                    g_observedVsyncTimestampNs.load(std::memory_order_acquire);
-                const int64_t observedVsyncPeriodNs =
-                    g_observedVsyncPeriodNs.load(std::memory_order_acquire);
-                if (plan.action == PresentationAction::SCHEDULE) {
-                    preciseMaxTargetLeadNs_ = std::max(
-                        preciseMaxTargetLeadNs_, plan.targetTimeNs - decodedAtNs);
-                    presentationDiagnostics_.Record(
-                        plan.targetTimeNs, decodedAtNs,
-                        observedVsyncNs, observedVsyncPeriodNs);
-                }
+            const int64_t observedVsyncNs =
+                g_observedVsyncTimestampNs.load(std::memory_order_acquire);
+            const int64_t observedVsyncPeriodNs =
+                g_observedVsyncPeriodNs.load(std::memory_order_acquire);
+            const PresentationVsyncTiming vsyncTiming = {
+                observedVsyncNs, observedVsyncPeriodNs};
 
-                const int64_t totalFrames = preciseScheduledCount_ + preciseDroppedCount_;
-                if (totalFrames % kHostPacedStatsLogIntervalFrames == 0) {
-                    const PresentationTimingStats& timing =
-                        presentationDiagnostics_.GetStats();
-                    OH_LOG_INFO(LOG_APP,
-                        "Host-paced stats: frames=%{public}lld, scheduled=%{public}lld, dropped=%{public}lld, late=%{public}lld, catchUp=%{public}lld, phaseShift=%{public}lld, rebuffer=%{public}lld, resync=%{public}lld, apiFailure=%{public}lld, lead=%{public}lldus, maxLead=%{public}lldus, sameSlot=%{public}lld, slotRegression=%{public}lld, targetRegression=%{public}lld, maxRegression=%{public}lldus, maxQueueSlots=%{public}lld, vsyncPeriod=%{public}lldus, vsyncAge=%{public}lldus, vsyncSampleFailure=%{public}lld",
-                        static_cast<long long>(totalFrames),
-                        static_cast<long long>(preciseScheduledCount_),
-                        static_cast<long long>(preciseDroppedCount_),
-                        static_cast<long long>(preciseLateCount_),
-                        static_cast<long long>(preciseCatchUpCount_),
-                        static_cast<long long>(precisePhaseShiftCount_),
-                        static_cast<long long>(preciseRebufferCount_),
-                        static_cast<long long>(preciseResyncCount_),
-                        static_cast<long long>(preciseApiFailureCount_),
-                        static_cast<long long>(ptsScheduler_.GetInitialLeadNs() / 1000),
-                        static_cast<long long>(preciseMaxTargetLeadNs_ / 1000),
-                        static_cast<long long>(timing.sameVsyncSlotCount),
-                        static_cast<long long>(timing.vsyncSlotRegressionCount),
-                        static_cast<long long>(timing.targetRegressionCount),
-                        static_cast<long long>(timing.maxTargetRegressionNs / 1000),
-                        static_cast<long long>(timing.maxQueueDepthSlots),
-                        static_cast<long long>(observedVsyncPeriodNs / 1000),
-                        static_cast<long long>(observedVsyncNs > 0
-                            ? std::max<int64_t>(0, decodedAtNs - observedVsyncNs) / 1000
-                            : 0),
-                        static_cast<long long>(g_vsyncSampleRequestFailures.load(
-                            std::memory_order_relaxed)));
-                }
+            // Keep planning and timed submission ordered even if a codec emits
+            // output callbacks concurrently.
+            std::unique_lock<std::mutex> lock(presentationMutex_);
+            const PresentationPlan plan = ptsScheduler_.PlanFrame(
+                frame.ptsUs, decodedAtNs, vsyncTiming);
+            if (plan.action == PresentationAction::SCHEDULE) {
+                preciseScheduledCount_++;
+            } else {
+                preciseDroppedCount_++;
+            }
+            if (plan.latenessNs > 0) preciseLateCount_++;
+            if (plan.event == PresentationEvent::CATCH_UP) preciseCatchUpCount_++;
+            if (plan.event == PresentationEvent::PHASE_SHIFT) precisePhaseShiftCount_++;
+            if (plan.event == PresentationEvent::REBUFFER) preciseRebufferCount_++;
+            if (plan.event == PresentationEvent::DISCONTINUITY ||
+                plan.event == PresentationEvent::DUPLICATE_PTS) {
+                preciseResyncCount_++;
+            }
+            if (plan.event == PresentationEvent::QUEUE_FULL) preciseQueueFullCount_++;
+            if (plan.event == PresentationEvent::WAIT_FOR_DRAIN) {
+                preciseWaitForDrainCount_++;
+            }
+            if (plan.action == PresentationAction::SCHEDULE) {
+                preciseMaxTargetLeadNs_ = std::max(
+                    preciseMaxTargetLeadNs_, plan.targetTimeNs - decodedAtNs);
+                presentationDiagnostics_.Record(
+                    plan.targetTimeNs, decodedAtNs,
+                    observedVsyncNs, observedVsyncPeriodNs);
+            }
+
+            const int64_t totalFrames = preciseScheduledCount_ + preciseDroppedCount_;
+            if (totalFrames % kHostPacedStatsLogIntervalFrames == 0) {
+                const PresentationTimingStats& timing =
+                    presentationDiagnostics_.GetStats();
+                OH_LOG_INFO(LOG_APP,
+                    "Host-paced stats: frames=%{public}lld, scheduled=%{public}lld, dropped=%{public}lld, late=%{public}lld, catchUp=%{public}lld, phaseShift=%{public}lld, rebuffer=%{public}lld, resync=%{public}lld, queueFull=%{public}lld, waitDrain=%{public}lld, apiFailure=%{public}lld, lead=%{public}lldus, maxLead=%{public}lldus, sameSlot=%{public}lld, slotRegression=%{public}lld, targetRegression=%{public}lld, maxRegression=%{public}lldus, maxQueueSlots=%{public}lld, vsyncPeriod=%{public}lldus, vsyncAge=%{public}lldus, vsyncSampleFailure=%{public}lld",
+                    static_cast<long long>(totalFrames),
+                    static_cast<long long>(preciseScheduledCount_),
+                    static_cast<long long>(preciseDroppedCount_),
+                    static_cast<long long>(preciseLateCount_),
+                    static_cast<long long>(preciseCatchUpCount_),
+                    static_cast<long long>(precisePhaseShiftCount_),
+                    static_cast<long long>(preciseRebufferCount_),
+                    static_cast<long long>(preciseResyncCount_),
+                    static_cast<long long>(preciseQueueFullCount_),
+                    static_cast<long long>(preciseWaitForDrainCount_),
+                    static_cast<long long>(preciseApiFailureCount_),
+                    static_cast<long long>(ptsScheduler_.GetInitialLeadNs() / 1000),
+                    static_cast<long long>(preciseMaxTargetLeadNs_ / 1000),
+                    static_cast<long long>(timing.sameVsyncSlotCount),
+                    static_cast<long long>(timing.vsyncSlotRegressionCount),
+                    static_cast<long long>(timing.targetRegressionCount),
+                    static_cast<long long>(timing.maxTargetRegressionNs / 1000),
+                    static_cast<long long>(timing.maxQueueDepthSlots),
+                    static_cast<long long>(observedVsyncPeriodNs / 1000),
+                    static_cast<long long>(observedVsyncNs > 0
+                        ? std::max<int64_t>(0, decodedAtNs - observedVsyncNs) / 1000
+                        : 0),
+                    static_cast<long long>(g_vsyncSampleRequestFailures.load(
+                        std::memory_order_relaxed)));
             }
 
             if (plan.action == PresentationAction::DROP) {
+                lock.unlock();
                 renderResult = freeFrame();
             } else {
                 renderResult = renderAtTime(
@@ -622,10 +632,7 @@ NativeRender::FrameSubmitResult NativeRender::SubmitFrame(const DecodedFrame& fr
                     bufferConsumed = true;
                     framePresented = true;
                 } else {
-                    {
-                        std::lock_guard<std::mutex> lock(presentationMutex_);
-                        preciseApiFailureCount_++;
-                    }
+                    preciseApiFailureCount_++;
                     OH_LOG_WARN(LOG_APP,
                         "Host-paced render failed: %{public}d, pts=%{public}lld, targetNs=%{public}lld; falling back",
                         renderResult, static_cast<long long>(frame.ptsUs),

--- a/nativelib/src/main/cpp/native_render.cpp
+++ b/nativelib/src/main/cpp/native_render.cpp
@@ -31,6 +31,26 @@
 #undef LOG_TAG
 #define LOG_TAG "NativeRender"
 
+namespace {
+constexpr int64_t kNanosecondsPerMillisecond = 1000000LL;
+constexpr int64_t kVsyncSampleIntervalNs = 250 * kNanosecondsPerMillisecond;
+constexpr int64_t kHostPacedStatsLogIntervalFrames = 600;
+
+std::atomic<uint64_t> g_vsyncSampleGeneration{0};
+std::atomic<int64_t> g_observedVsyncTimestampNs{0};
+std::atomic<int64_t> g_observedVsyncPeriodNs{0};
+std::atomic<int64_t> g_vsyncSampleRequestFailures{0};
+
+void OnVSyncSample(long long timestamp, void* data) {
+    const uint64_t generation = static_cast<uint64_t>(
+        reinterpret_cast<uintptr_t>(data));
+    if (generation == g_vsyncSampleGeneration.load(std::memory_order_acquire)) {
+        g_observedVsyncTimestampNs.store(
+            static_cast<int64_t>(timestamp), std::memory_order_release);
+    }
+}
+} // namespace
+
 // RenderOutputBufferAtTime 是 API 12+ 的函数，旧设备或不完整运行时可能不存在
 // 通过 dlsym 动态加载，避免硬依赖
 typedef OH_AVErrCode (*PFN_RenderOutputBufferAtTime)(OH_AVCodec*, uint32_t, int64_t);
@@ -149,6 +169,12 @@ void NativeRender::InitNativeVSync() {
     const char* name = "moonlight_render";
     nativeVSync_ = OH_NativeVSync_Create(name, strlen(name));
     if (nativeVSync_ != nullptr) {
+        nativeVsyncGeneration_ =
+            g_vsyncSampleGeneration.fetch_add(1, std::memory_order_acq_rel) + 1;
+        g_observedVsyncTimestampNs.store(0, std::memory_order_release);
+        g_observedVsyncPeriodNs.store(0, std::memory_order_release);
+        g_vsyncSampleRequestFailures.store(0, std::memory_order_relaxed);
+        lastVsyncSampleRequestNs_.store(0, std::memory_order_relaxed);
         OH_LOG_INFO(LOG_APP, "NativeVSync created successfully");
     } else {
         OH_LOG_WARN(LOG_APP, "Failed to create NativeVSync");
@@ -161,6 +187,10 @@ void NativeRender::ReleaseNativeVSync() {
         return;
     }
 
+    g_vsyncSampleGeneration.fetch_add(1, std::memory_order_acq_rel);
+    nativeVsyncGeneration_ = 0;
+    g_observedVsyncTimestampNs.store(0, std::memory_order_release);
+    g_observedVsyncPeriodNs.store(0, std::memory_order_release);
     OH_NativeVSync_Destroy(nativeVSync_);
     nativeVSync_ = nullptr;
     OH_LOG_INFO(LOG_APP, "NativeVSync destroyed");
@@ -352,6 +382,38 @@ void NativeRender::ApplyFrameRateRange() {
     }
 }
 
+void NativeRender::RequestVSyncSample(int64_t nowNs) {
+    int64_t previousRequestNs =
+        lastVsyncSampleRequestNs_.load(std::memory_order_relaxed);
+    if (previousRequestNs > 0 &&
+        nowNs - previousRequestNs < kVsyncSampleIntervalNs) {
+        return;
+    }
+    if (!lastVsyncSampleRequestNs_.compare_exchange_strong(
+            previousRequestNs, nowNs, std::memory_order_relaxed)) {
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(nativeVsyncMutex_);
+    if (nativeVSync_ == nullptr || nativeVsyncGeneration_ == 0) {
+        return;
+    }
+
+    long long periodNs = 0;
+    if (OH_NativeVSync_GetPeriod(nativeVSync_, &periodNs) == 0 &&
+        periodNs > 0) {
+        g_observedVsyncPeriodNs.store(
+            static_cast<int64_t>(periodNs), std::memory_order_release);
+    }
+
+    const int result = OH_NativeVSync_RequestFrame(
+        nativeVSync_, OnVSyncSample,
+        reinterpret_cast<void*>(static_cast<uintptr_t>(nativeVsyncGeneration_)));
+    if (result != 0) {
+        g_vsyncSampleRequestFailures.fetch_add(1, std::memory_order_relaxed);
+    }
+}
+
 // =============================================================================
 // PTS presentation clocks
 // =============================================================================
@@ -378,6 +440,7 @@ void NativeRender::ResetPresentationStatsLocked() {
     preciseResyncCount_ = 0;
     preciseApiFailureCount_ = 0;
     preciseMaxTargetLeadNs_ = 0;
+    presentationDiagnostics_.Reset();
 }
 
 void NativeRender::ResetPresentationClock() {
@@ -487,6 +550,7 @@ NativeRender::FrameSubmitResult NativeRender::SubmitFrame(const DecodedFrame& fr
             }
         } else {
             const int64_t decodedAtNs = GetMonotonicTimeNs();
+            RequestVSyncSample(decodedAtNs);
             PresentationPlan plan;
             {
                 std::lock_guard<std::mutex> lock(presentationMutex_);
@@ -506,15 +570,24 @@ NativeRender::FrameSubmitResult NativeRender::SubmitFrame(const DecodedFrame& fr
                     plan.event == PresentationEvent::DUPLICATE_PTS) {
                     preciseResyncCount_++;
                 }
+                const int64_t observedVsyncNs =
+                    g_observedVsyncTimestampNs.load(std::memory_order_acquire);
+                const int64_t observedVsyncPeriodNs =
+                    g_observedVsyncPeriodNs.load(std::memory_order_acquire);
                 if (plan.action == PresentationAction::SCHEDULE) {
                     preciseMaxTargetLeadNs_ = std::max(
                         preciseMaxTargetLeadNs_, plan.targetTimeNs - decodedAtNs);
+                    presentationDiagnostics_.Record(
+                        plan.targetTimeNs, decodedAtNs,
+                        observedVsyncNs, observedVsyncPeriodNs);
                 }
 
                 const int64_t totalFrames = preciseScheduledCount_ + preciseDroppedCount_;
-                if (totalFrames % 6000 == 0) {
+                if (totalFrames % kHostPacedStatsLogIntervalFrames == 0) {
+                    const PresentationTimingStats& timing =
+                        presentationDiagnostics_.GetStats();
                     OH_LOG_INFO(LOG_APP,
-                        "Host-paced stats: frames=%{public}lld, scheduled=%{public}lld, dropped=%{public}lld, late=%{public}lld, catchUp=%{public}lld, phaseShift=%{public}lld, rebuffer=%{public}lld, resync=%{public}lld, apiFailure=%{public}lld, lead=%{public}lldus, maxLead=%{public}lldus",
+                        "Host-paced stats: frames=%{public}lld, scheduled=%{public}lld, dropped=%{public}lld, late=%{public}lld, catchUp=%{public}lld, phaseShift=%{public}lld, rebuffer=%{public}lld, resync=%{public}lld, apiFailure=%{public}lld, lead=%{public}lldus, maxLead=%{public}lldus, sameSlot=%{public}lld, slotRegression=%{public}lld, targetRegression=%{public}lld, maxRegression=%{public}lldus, maxQueueSlots=%{public}lld, vsyncPeriod=%{public}lldus, vsyncAge=%{public}lldus, vsyncSampleFailure=%{public}lld",
                         static_cast<long long>(totalFrames),
                         static_cast<long long>(preciseScheduledCount_),
                         static_cast<long long>(preciseDroppedCount_),
@@ -525,7 +598,18 @@ NativeRender::FrameSubmitResult NativeRender::SubmitFrame(const DecodedFrame& fr
                         static_cast<long long>(preciseResyncCount_),
                         static_cast<long long>(preciseApiFailureCount_),
                         static_cast<long long>(ptsScheduler_.GetInitialLeadNs() / 1000),
-                        static_cast<long long>(preciseMaxTargetLeadNs_ / 1000));
+                        static_cast<long long>(preciseMaxTargetLeadNs_ / 1000),
+                        static_cast<long long>(timing.sameVsyncSlotCount),
+                        static_cast<long long>(timing.vsyncSlotRegressionCount),
+                        static_cast<long long>(timing.targetRegressionCount),
+                        static_cast<long long>(timing.maxTargetRegressionNs / 1000),
+                        static_cast<long long>(timing.maxQueueDepthSlots),
+                        static_cast<long long>(observedVsyncPeriodNs / 1000),
+                        static_cast<long long>(observedVsyncNs > 0
+                            ? std::max<int64_t>(0, decodedAtNs - observedVsyncNs) / 1000
+                            : 0),
+                        static_cast<long long>(g_vsyncSampleRequestFailures.load(
+                            std::memory_order_relaxed)));
                 }
             }
 

--- a/nativelib/src/main/cpp/native_render.h
+++ b/nativelib/src/main/cpp/native_render.h
@@ -30,6 +30,7 @@
 #include <multimedia/player_framework/native_avcodec_videodecoder.h>
 #include <hilog/log.h>
 
+#include "presentation_diagnostics.h"
 #include "presentation_scheduler.h"
 
 #include <cstdint>
@@ -125,6 +126,9 @@ private:
     
     // 应用帧率范围（通过 NativeVSync，API 20+）
     void ApplyFrameRateRange();
+
+    // 请求低频率的只读 VSync 时间样本，用于呈现诊断
+    void RequestVSyncSample(int64_t nowNs);
     
     // 应用 NativeWindow 帧率（Surface buffer queue 级别，API 12+）
     void ApplyNativeWindowFrameRate();
@@ -162,6 +166,7 @@ private:
     // separate clocks so switching decoder modes cannot perturb PTS cadence.
     mutable std::mutex presentationMutex_;
     PtsPresentationScheduler ptsScheduler_;
+    PresentationDiagnostics presentationDiagnostics_;
 
     // Legacy VSync clock, kept isolated from the host-paced scheduler.
     int64_t estimatedOffsetNs_ = 0;  // 平滑后的 (本地 - host) 偏移均值(纳秒)
@@ -186,6 +191,8 @@ private:
     // NativeVSync（用于设置期望帧率范围，API 20+）
     std::mutex nativeVsyncMutex_;
     OH_NativeVSync* nativeVSync_ = nullptr;
+    uint64_t nativeVsyncGeneration_ = 0;
+    std::atomic<int64_t> lastVsyncSampleRequestNs_{0};
     
 };
 

--- a/nativelib/src/main/cpp/native_render.h
+++ b/nativelib/src/main/cpp/native_render.h
@@ -185,6 +185,8 @@ private:
     int64_t precisePhaseShiftCount_ = 0;
     int64_t preciseRebufferCount_ = 0;
     int64_t preciseResyncCount_ = 0;
+    int64_t preciseQueueFullCount_ = 0;
+    int64_t preciseWaitForDrainCount_ = 0;
     int64_t preciseApiFailureCount_ = 0;
     int64_t preciseMaxTargetLeadNs_ = 0;
     

--- a/nativelib/src/main/cpp/presentation_diagnostics.cpp
+++ b/nativelib/src/main/cpp/presentation_diagnostics.cpp
@@ -1,0 +1,60 @@
+#include "presentation_diagnostics.h"
+
+#include <algorithm>
+
+void PresentationDiagnostics::Reset() {
+    stats_ = {};
+    lastTargetTimeNs_ = 0;
+}
+
+int64_t PresentationDiagnostics::NormalizeVsyncAnchor(
+        int64_t observedVsyncNs, int64_t nowNs, int64_t vsyncPeriodNs) {
+    if (nowNs <= observedVsyncNs) {
+        return observedVsyncNs;
+    }
+    return observedVsyncNs +
+        ((nowNs - observedVsyncNs) / vsyncPeriodNs) * vsyncPeriodNs;
+}
+
+int64_t PresentationDiagnostics::VsyncSlotAtOrAfter(
+        int64_t targetTimeNs, int64_t anchorNs, int64_t vsyncPeriodNs) {
+    const int64_t deltaNs = targetTimeNs - anchorNs;
+    const int64_t slotOffset = deltaNs >= 0
+        ? (deltaNs + vsyncPeriodNs - 1) / vsyncPeriodNs
+        : deltaNs / vsyncPeriodNs;
+    return anchorNs + slotOffset * vsyncPeriodNs;
+}
+
+void PresentationDiagnostics::Record(
+        int64_t targetTimeNs, int64_t nowNs,
+        int64_t observedVsyncNs, int64_t vsyncPeriodNs) {
+    if (lastTargetTimeNs_ > 0 && targetTimeNs < lastTargetTimeNs_) {
+        const int64_t regressionNs = lastTargetTimeNs_ - targetTimeNs;
+        stats_.targetRegressionCount++;
+        stats_.maxTargetRegressionNs = std::max(
+            stats_.maxTargetRegressionNs, regressionNs);
+    }
+
+    if (observedVsyncNs > 0 && vsyncPeriodNs > 0) {
+        const int64_t anchorNs = NormalizeVsyncAnchor(
+            observedVsyncNs, nowNs, vsyncPeriodNs);
+        const int64_t currentSlotNs = VsyncSlotAtOrAfter(
+            targetTimeNs, anchorNs, vsyncPeriodNs);
+        if (lastTargetTimeNs_ > 0) {
+            const int64_t previousSlotNs = VsyncSlotAtOrAfter(
+                lastTargetTimeNs_, anchorNs, vsyncPeriodNs);
+            if (currentSlotNs == previousSlotNs) {
+                stats_.sameVsyncSlotCount++;
+            } else if (currentSlotNs < previousSlotNs) {
+                stats_.vsyncSlotRegressionCount++;
+            }
+        }
+
+        const int64_t queueDepthSlots = std::max<int64_t>(
+            0, (currentSlotNs - anchorNs) / vsyncPeriodNs);
+        stats_.maxQueueDepthSlots = std::max(
+            stats_.maxQueueDepthSlots, queueDepthSlots);
+    }
+
+    lastTargetTimeNs_ = targetTimeNs;
+}

--- a/nativelib/src/main/cpp/presentation_diagnostics.h
+++ b/nativelib/src/main/cpp/presentation_diagnostics.h
@@ -1,0 +1,32 @@
+#ifndef PRESENTATION_DIAGNOSTICS_H
+#define PRESENTATION_DIAGNOSTICS_H
+
+#include <cstdint>
+
+struct PresentationTimingStats {
+    int64_t targetRegressionCount = 0;
+    int64_t maxTargetRegressionNs = 0;
+    int64_t sameVsyncSlotCount = 0;
+    int64_t vsyncSlotRegressionCount = 0;
+    int64_t maxQueueDepthSlots = 0;
+};
+
+class PresentationDiagnostics {
+public:
+    void Reset();
+    void Record(int64_t targetTimeNs, int64_t nowNs,
+                int64_t observedVsyncNs, int64_t vsyncPeriodNs);
+
+    const PresentationTimingStats& GetStats() const { return stats_; }
+
+private:
+    static int64_t NormalizeVsyncAnchor(
+        int64_t observedVsyncNs, int64_t nowNs, int64_t vsyncPeriodNs);
+    static int64_t VsyncSlotAtOrAfter(
+        int64_t targetTimeNs, int64_t anchorNs, int64_t vsyncPeriodNs);
+
+    PresentationTimingStats stats_;
+    int64_t lastTargetTimeNs_ = 0;
+};
+
+#endif // PRESENTATION_DIAGNOSTICS_H

--- a/nativelib/src/main/cpp/presentation_scheduler.cpp
+++ b/nativelib/src/main/cpp/presentation_scheduler.cpp
@@ -26,6 +26,30 @@ constexpr int64_t kDriftDeadbandNs = 2 * kNanosecondsPerMillisecond;
 constexpr int64_t kMaxDriftCorrectionPerFrameNs = 20 * kNanosecondsPerMicrosecond;
 constexpr int kSevereLateFramesBeforeRebuffer = 2;
 
+int64_t FloorDiv(int64_t value, int64_t divisor) {
+    int64_t quotient = value / divisor;
+    if (value % divisor < 0) {
+        quotient--;
+    }
+    return quotient;
+}
+
+int64_t CeilDiv(int64_t value, int64_t divisor) {
+    int64_t quotient = value / divisor;
+    if (value % divisor > 0) {
+        quotient++;
+    }
+    return quotient;
+}
+
+int64_t FloorToSlot(int64_t timeNs, int64_t anchorNs, int64_t periodNs) {
+    return anchorNs + FloorDiv(timeNs - anchorNs, periodNs) * periodNs;
+}
+
+int64_t CeilToSlot(int64_t timeNs, int64_t anchorNs, int64_t periodNs) {
+    return anchorNs + CeilDiv(timeNs - anchorNs, periodNs) * periodNs;
+}
+
 int64_t CalculateFutureCadenceBudgetNs(double fps, int64_t frameIntervalNs) {
     if (fps >= kNtscTripleBurstFps) {
         return frameIntervalNs * 2;
@@ -62,11 +86,15 @@ void PtsPresentationScheduler::Reset() {
     lastPtsUs_ = 0;
     driftErrorEmaNs_ = 0;
     phaseShiftDebtNs_ = 0;
+    lastScheduledTargetNs_ = 0;
     consecutiveSevereLateFrames_ = 0;
+    reanchorPending_ = false;
+    pendingReanchorEvent_ = PresentationEvent::CATCH_UP;
 }
 
 PresentationPlan PtsPresentationScheduler::AnchorFrame(
-        int64_t ptsUs, int64_t decodedAtNs, PresentationEvent event) {
+        int64_t ptsUs, int64_t decodedAtNs, PresentationEvent event,
+        const SlotClock& slotClock) {
     initialized_ = true;
     anchorPtsUs_ = ptsUs;
     anchorTargetNs_ = decodedAtNs + initialLeadNs_;
@@ -74,12 +102,86 @@ PresentationPlan PtsPresentationScheduler::AnchorFrame(
     driftErrorEmaNs_ = 0;
     phaseShiftDebtNs_ = 0;
     consecutiveSevereLateFrames_ = 0;
+    reanchorPending_ = false;
+    pendingReanchorEvent_ = PresentationEvent::CATCH_UP;
+
+    return ScheduleTarget(anchorTargetNs_, decodedAtNs, event, 0, slotClock);
+}
+
+PresentationPlan PtsPresentationScheduler::ScheduleTarget(
+        int64_t targetTimeNs, int64_t decodedAtNs,
+        PresentationEvent event, int64_t latenessNs,
+        const SlotClock& slotClock) {
+    const int64_t requiredTargetNs = decodedAtNs + submitLeadNs_;
+    int64_t scheduledSlotNs = CeilToSlot(
+        std::max(targetTimeNs, requiredTargetNs),
+        slotClock.anchorNs, slotClock.periodNs);
+
+    if (lastScheduledTargetNs_ > 0) {
+        // Re-map the previous target when a real VSync sample first arrives or
+        // its phase changes, so two submissions still cannot share a latch.
+        const int64_t lastOccupiedSlotNs = CeilToSlot(
+            lastScheduledTargetNs_, slotClock.anchorNs, slotClock.periodNs);
+        if (scheduledSlotNs <= lastOccupiedSlotNs) {
+            scheduledSlotNs = lastOccupiedSlotNs + slotClock.periodNs;
+        }
+    }
+
+    // Start the existing cadence budget at the first slot that still has the
+    // submit margin. Being close to a VSync must not reduce burst capacity.
+    const int64_t firstEligibleSlotNs = CeilToSlot(
+        requiredTargetNs, slotClock.anchorNs, slotClock.periodNs);
+    const int64_t maxScheduledSlotNs = firstEligibleSlotNs +
+        GetAdditionalQueueSlots(slotClock.periodNs) * slotClock.periodNs;
+    if (scheduledSlotNs > maxScheduledSlotNs) {
+        reanchorPending_ = true;
+        pendingReanchorEvent_ = PresentationEvent::CATCH_UP;
+        PresentationPlan plan;
+        plan.event = PresentationEvent::QUEUE_FULL;
+        plan.latenessNs = latenessNs;
+        return plan;
+    }
+
+    lastScheduledTargetNs_ = scheduledSlotNs;
 
     PresentationPlan plan;
     plan.action = PresentationAction::SCHEDULE;
     plan.event = event;
-    plan.targetTimeNs = anchorTargetNs_;
+    plan.targetTimeNs = scheduledSlotNs;
+    plan.latenessNs = latenessNs;
     return plan;
+}
+
+PtsPresentationScheduler::SlotClock PtsPresentationScheduler::ResolveSlotClock(
+        int64_t decodedAtNs,
+        const PresentationVsyncTiming& vsyncTiming) const {
+    SlotClock clock;
+    clock.periodNs = vsyncTiming.periodNs > 0
+        ? vsyncTiming.periodNs
+        : frameIntervalNs_;
+    clock.anchorNs = vsyncTiming.timestampNs > 0
+        ? vsyncTiming.timestampNs
+        : 0;
+    clock.currentSlotNs = FloorToSlot(
+        decodedAtNs, clock.anchorNs, clock.periodNs);
+    return clock;
+}
+
+bool PtsPresentationScheduler::IsPresentationQueueEmpty(
+        const SlotClock& slotClock) const {
+    if (lastScheduledTargetNs_ <= 0) {
+        return true;
+    }
+    const int64_t lastOccupiedSlotNs = CeilToSlot(
+        lastScheduledTargetNs_, slotClock.anchorNs, slotClock.periodNs);
+    return lastOccupiedSlotNs <= slotClock.currentSlotNs;
+}
+
+int64_t PtsPresentationScheduler::GetAdditionalQueueSlots(
+        int64_t vsyncPeriodNs) const {
+    const int64_t cadenceBudgetNs = std::max<int64_t>(
+        0, maxFutureLeadNs_ - initialLeadNs_);
+    return cadenceBudgetNs / vsyncPeriodNs;
 }
 
 void PtsPresentationScheduler::ApplySlowDriftCorrection(
@@ -105,26 +207,62 @@ void PtsPresentationScheduler::ApplySlowDriftCorrection(
 
 PresentationPlan PtsPresentationScheduler::PlanFrame(
         int64_t ptsUs, int64_t decodedAtNs) {
+    return PlanFrame(ptsUs, decodedAtNs, {});
+}
+
+PresentationPlan PtsPresentationScheduler::PlanFrame(
+        int64_t ptsUs, int64_t decodedAtNs,
+        const PresentationVsyncTiming& vsyncTiming) {
     if (ptsUs < 0 || decodedAtNs <= 0) {
         PresentationPlan plan;
         plan.event = PresentationEvent::INVALID_PTS;
         return plan;
     }
 
+    const SlotClock slotClock = ResolveSlotClock(decodedAtNs, vsyncTiming);
+    const bool queueEmpty = IsPresentationQueueEmpty(slotClock);
+
+    if (reanchorPending_) {
+        if (queueEmpty) {
+            return AnchorFrame(
+                ptsUs, decodedAtNs, pendingReanchorEvent_, slotClock);
+        }
+        PresentationPlan plan;
+        plan.event = PresentationEvent::WAIT_FOR_DRAIN;
+        return plan;
+    }
+
     if (!initialized_) {
-        return AnchorFrame(ptsUs, decodedAtNs, PresentationEvent::INITIAL_ANCHOR);
+        return AnchorFrame(
+            ptsUs, decodedAtNs, PresentationEvent::INITIAL_ANCHOR, slotClock);
     }
 
     if (ptsUs == lastPtsUs_) {
         // A permanently repeated timestamp must not become a permanent DROP
         // state. Treat it as a broken host timeline and fall back to a fresh
         // local anchor until valid PTS progression resumes.
-        return AnchorFrame(ptsUs, decodedAtNs, PresentationEvent::DUPLICATE_PTS);
+        if (queueEmpty) {
+            return AnchorFrame(
+                ptsUs, decodedAtNs, PresentationEvent::DUPLICATE_PTS, slotClock);
+        }
+        reanchorPending_ = true;
+        pendingReanchorEvent_ = PresentationEvent::DUPLICATE_PTS;
+        PresentationPlan plan;
+        plan.event = PresentationEvent::WAIT_FOR_DRAIN;
+        return plan;
     }
 
     const int64_t ptsDeltaUs = ptsUs - lastPtsUs_;
     if (ptsDeltaUs < 0 || ptsDeltaUs > discontinuityNs_ / kNanosecondsPerMicrosecond) {
-        return AnchorFrame(ptsUs, decodedAtNs, PresentationEvent::DISCONTINUITY);
+        if (queueEmpty) {
+            return AnchorFrame(
+                ptsUs, decodedAtNs, PresentationEvent::DISCONTINUITY, slotClock);
+        }
+        reanchorPending_ = true;
+        pendingReanchorEvent_ = PresentationEvent::DISCONTINUITY;
+        PresentationPlan plan;
+        plan.event = PresentationEvent::WAIT_FOR_DRAIN;
+        return plan;
     }
     lastPtsUs_ = ptsUs;
 
@@ -137,36 +275,30 @@ PresentationPlan PtsPresentationScheduler::PlanFrame(
     // normal decoder output burst (which has no debt) for excessive queuing.
     const int64_t surplusLeadNs =
         targetTimeNs - decodedAtNs - initialLeadNs_;
-    if (phaseShiftDebtNs_ > 0 && surplusLeadNs > kDriftDeadbandNs) {
+    PresentationEvent event = PresentationEvent::NONE;
+    int64_t latenessNs = 0;
+    if (queueEmpty && phaseShiftDebtNs_ > 0 &&
+        surplusLeadNs > kDriftDeadbandNs) {
         const int64_t repaymentNs = std::min(phaseShiftDebtNs_, surplusLeadNs);
         anchorTargetNs_ -= repaymentNs;
         targetTimeNs -= repaymentNs;
         phaseShiftDebtNs_ -= repaymentNs;
         driftErrorEmaNs_ = 0;
-        consecutiveSevereLateFrames_ = 0;
-
-        if (targetTimeNs - decodedAtNs <= maxFutureLeadNs_) {
-            PresentationPlan plan;
-            plan.action = PresentationAction::SCHEDULE;
-            plan.event = PresentationEvent::PHASE_SHIFT;
-            plan.targetTimeNs = targetTimeNs;
-            plan.latenessNs = -repaymentNs;
-            return plan;
-        }
+        event = PresentationEvent::PHASE_SHIFT;
+        latenessNs = -repaymentNs;
     }
 
-    if (targetTimeNs - decodedAtNs > maxFutureLeadNs_) {
-        // This is not jitter absorbed by our own phase shift; it is decoded
-        // output arriving in a burst ahead of the presentation timeline. A
-        // fresh anchor gives all queued burst frames an immediate timestamp,
-        // so the Surface can keep the newest frame instead of preserving lag.
-        return AnchorFrame(ptsUs, decodedAtNs, PresentationEvent::CATCH_UP);
+    if (queueEmpty && targetTimeNs - decodedAtNs > maxFutureLeadNs_) {
+        return AnchorFrame(
+            ptsUs, decodedAtNs, PresentationEvent::CATCH_UP, slotClock);
     }
 
-    ApplySlowDriftCorrection(decodedAtNs, targetTimeNs);
+    if (queueEmpty) {
+        ApplySlowDriftCorrection(decodedAtNs, targetTimeNs);
+    }
 
     const int64_t requiredTargetNs = decodedAtNs + submitLeadNs_;
-    if (targetTimeNs < requiredTargetNs) {
+    if (queueEmpty && targetTimeNs < requiredTargetNs) {
         const int64_t latenessNs = requiredTargetNs - targetTimeNs;
         if (latenessNs <= frameIntervalNs_ / 2) {
             // Move the complete timeline forward. This keeps all following PTS
@@ -175,18 +307,16 @@ PresentationPlan PtsPresentationScheduler::PlanFrame(
             phaseShiftDebtNs_ += latenessNs;
             driftErrorEmaNs_ = 0;
             consecutiveSevereLateFrames_ = 0;
-
-            PresentationPlan plan;
-            plan.action = PresentationAction::SCHEDULE;
-            plan.event = PresentationEvent::PHASE_SHIFT;
-            plan.targetTimeNs = requiredTargetNs;
-            plan.latenessNs = latenessNs;
-            return plan;
+            event = PresentationEvent::PHASE_SHIFT;
+            targetTimeNs = requiredTargetNs;
+            return ScheduleTarget(
+                targetTimeNs, decodedAtNs, event, latenessNs, slotClock);
         }
 
         consecutiveSevereLateFrames_++;
         if (consecutiveSevereLateFrames_ >= kSevereLateFramesBeforeRebuffer) {
-            return AnchorFrame(ptsUs, decodedAtNs, PresentationEvent::REBUFFER);
+            return AnchorFrame(
+                ptsUs, decodedAtNs, PresentationEvent::REBUFFER, slotClock);
         }
 
         PresentationPlan plan;
@@ -196,8 +326,6 @@ PresentationPlan PtsPresentationScheduler::PlanFrame(
     }
 
     consecutiveSevereLateFrames_ = 0;
-    PresentationPlan plan;
-    plan.action = PresentationAction::SCHEDULE;
-    plan.targetTimeNs = targetTimeNs;
-    return plan;
+    return ScheduleTarget(
+        targetTimeNs, decodedAtNs, event, latenessNs, slotClock);
 }

--- a/nativelib/src/main/cpp/presentation_scheduler.h
+++ b/nativelib/src/main/cpp/presentation_scheduler.h
@@ -28,6 +28,13 @@ enum class PresentationEvent {
     DUPLICATE_PTS,
     INVALID_PTS,
     LATE_DROP,
+    QUEUE_FULL,
+    WAIT_FOR_DRAIN,
+};
+
+struct PresentationVsyncTiming {
+    int64_t timestampNs = 0;
+    int64_t periodNs = 0;
 };
 
 struct PresentationPlan {
@@ -37,22 +44,38 @@ struct PresentationPlan {
     int64_t latenessNs = 0;
 };
 
-// Maps host PTS to a continuous local presentation timeline. Decoder output
-// arrival is used only for initial buffering and slow clock-drift correction;
-// it never replaces the PTS cadence on a normal frame.
+// Maps host PTS to a continuous local timeline, then assigns each submitted
+// frame a unique VSync slot. Decoder arrival never replaces normal PTS cadence.
 class PtsPresentationScheduler {
 public:
     void Configure(double fps);
     void Reset();
     PresentationPlan PlanFrame(int64_t ptsUs, int64_t decodedAtNs);
+    PresentationPlan PlanFrame(int64_t ptsUs, int64_t decodedAtNs,
+                               const PresentationVsyncTiming& vsyncTiming);
 
     int64_t GetInitialLeadNs() const { return initialLeadNs_; }
     int64_t GetMaxFutureLeadNs() const { return maxFutureLeadNs_; }
 
 private:
+    struct SlotClock {
+        int64_t anchorNs = 0;
+        int64_t periodNs = 0;
+        int64_t currentSlotNs = 0;
+    };
+
     PresentationPlan AnchorFrame(int64_t ptsUs, int64_t decodedAtNs,
-                                 PresentationEvent event);
+                                 PresentationEvent event,
+                                 const SlotClock& slotClock);
+    PresentationPlan ScheduleTarget(int64_t targetTimeNs, int64_t decodedAtNs,
+                                    PresentationEvent event, int64_t latenessNs,
+                                    const SlotClock& slotClock);
     void ApplySlowDriftCorrection(int64_t decodedAtNs, int64_t& targetTimeNs);
+    SlotClock ResolveSlotClock(
+        int64_t decodedAtNs,
+        const PresentationVsyncTiming& vsyncTiming) const;
+    bool IsPresentationQueueEmpty(const SlotClock& slotClock) const;
+    int64_t GetAdditionalQueueSlots(int64_t vsyncPeriodNs) const;
 
     int64_t frameIntervalNs_ = 16666667LL;
     int64_t initialLeadNs_ = 2000000LL;
@@ -66,7 +89,10 @@ private:
     int64_t lastPtsUs_ = 0;
     int64_t driftErrorEmaNs_ = 0;
     int64_t phaseShiftDebtNs_ = 0;
+    int64_t lastScheduledTargetNs_ = 0;
     int consecutiveSevereLateFrames_ = 0;
+    bool reanchorPending_ = false;
+    PresentationEvent pendingReanchorEvent_ = PresentationEvent::CATCH_UP;
 };
 
 #endif // PRESENTATION_SCHEDULER_H

--- a/nativelib/src/main/cpp/rolling_frame_rate.cpp
+++ b/nativelib/src/main/cpp/rolling_frame_rate.cpp
@@ -61,11 +61,9 @@ double RollingFrameRateTracker::GetRate(int64_t nowMs) const {
 
     const int64_t cutoffMs = nowMs - windowMs_;
     size_t baselineOffset = 0;
-    for (size_t i = 1; i < size_; ++i) {
-        if (SampleAt(i).timestampMs > cutoffMs) {
-            break;
-        }
-        baselineOffset = i;
+    while (baselineOffset + 1 < size_ &&
+           SampleAt(baselineOffset).timestampMs < cutoffMs) {
+        baselineOffset++;
     }
 
     const Sample& baseline = SampleAt(baselineOffset);

--- a/nativelib/src/main/cpp/rolling_frame_rate.cpp
+++ b/nativelib/src/main/cpp/rolling_frame_rate.cpp
@@ -1,0 +1,84 @@
+#include "rolling_frame_rate.h"
+
+#include <algorithm>
+
+namespace {
+constexpr int64_t kRecentSampleGraceMs = 100;
+}
+
+RollingFrameRateTracker::RollingFrameRateTracker(int64_t windowMs)
+    : windowMs_(std::max<int64_t>(windowMs, 1)) {
+}
+
+void RollingFrameRateTracker::Reset() {
+    start_ = 0;
+    size_ = 0;
+}
+
+const RollingFrameRateTracker::Sample& RollingFrameRateTracker::SampleAt(
+        size_t offset) const {
+    return samples_[(start_ + offset) % kSampleCapacity];
+}
+
+RollingFrameRateTracker::Sample& RollingFrameRateTracker::LastSample() {
+    return samples_[(start_ + size_ - 1) % kSampleCapacity];
+}
+
+void RollingFrameRateTracker::Record(
+        int64_t timestampMs, uint64_t cumulativeFrames) {
+    if (size_ > 0) {
+        Sample& last = LastSample();
+        if (timestampMs < last.timestampMs ||
+            cumulativeFrames < last.cumulativeFrames) {
+            Reset();
+        } else if (timestampMs == last.timestampMs) {
+            last.cumulativeFrames = cumulativeFrames;
+            return;
+        }
+    }
+
+    size_t insertIndex = 0;
+    if (size_ < kSampleCapacity) {
+        insertIndex = (start_ + size_) % kSampleCapacity;
+        size_++;
+    } else {
+        insertIndex = start_;
+        start_ = (start_ + 1) % kSampleCapacity;
+    }
+    samples_[insertIndex] = {timestampMs, cumulativeFrames};
+}
+
+double RollingFrameRateTracker::GetRate(int64_t nowMs) const {
+    if (size_ < 2) {
+        return 0.0;
+    }
+
+    const Sample& latest = SampleAt(size_ - 1);
+    if (nowMs < latest.timestampMs ||
+        nowMs - latest.timestampMs >= windowMs_) {
+        return 0.0;
+    }
+
+    const int64_t cutoffMs = nowMs - windowMs_;
+    size_t baselineOffset = 0;
+    for (size_t i = 1; i < size_; ++i) {
+        if (SampleAt(i).timestampMs > cutoffMs) {
+            break;
+        }
+        baselineOffset = i;
+    }
+
+    const Sample& baseline = SampleAt(baselineOffset);
+    const int64_t rateEndMs = nowMs - latest.timestampMs <= kRecentSampleGraceMs
+        ? latest.timestampMs
+        : nowMs;
+    const int64_t elapsedMs = rateEndMs - baseline.timestampMs;
+    if (elapsedMs <= 0 || latest.cumulativeFrames < baseline.cumulativeFrames) {
+        return 0.0;
+    }
+
+    const uint64_t frameDelta =
+        latest.cumulativeFrames - baseline.cumulativeFrames;
+    return static_cast<double>(frameDelta) * 1000.0 /
+        static_cast<double>(elapsedMs);
+}

--- a/nativelib/src/main/cpp/rolling_frame_rate.h
+++ b/nativelib/src/main/cpp/rolling_frame_rate.h
@@ -1,0 +1,33 @@
+#ifndef ROLLING_FRAME_RATE_H
+#define ROLLING_FRAME_RATE_H
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+class RollingFrameRateTracker {
+public:
+    explicit RollingFrameRateTracker(int64_t windowMs = 3000);
+
+    void Reset();
+    void Record(int64_t timestampMs, uint64_t cumulativeFrames);
+    double GetRate(int64_t nowMs) const;
+
+private:
+    struct Sample {
+        int64_t timestampMs = 0;
+        uint64_t cumulativeFrames = 0;
+    };
+
+    static constexpr size_t kSampleCapacity = 1024;
+
+    const Sample& SampleAt(size_t offset) const;
+    Sample& LastSample();
+
+    std::array<Sample, kSampleCapacity> samples_{};
+    size_t start_ = 0;
+    size_t size_ = 0;
+    int64_t windowMs_ = 3000;
+};
+
+#endif // ROLLING_FRAME_RATE_H

--- a/nativelib/src/main/cpp/video_decoder.cpp
+++ b/nativelib/src/main/cpp/video_decoder.cpp
@@ -1608,9 +1608,9 @@ void VideoDecoder::UpdateDecodedStats(int64_t enqueueTimeMs, uint32_t flags,
     const uint64_t outputFrames =
         codecOutputFrames_.fetch_add(1, std::memory_order_relaxed) + 1;
     if (presented) {
+        std::lock_guard<std::mutex> lock(renderedRateMutex_);
         const uint64_t decodedFrames =
             decodedFrames_.fetch_add(1, std::memory_order_relaxed) + 1;
-        std::lock_guard<std::mutex> lock(renderedRateMutex_);
         renderedFrameRate_.Record(currentTimeMs, decodedFrames);
     }
     

--- a/nativelib/src/main/cpp/video_decoder.cpp
+++ b/nativelib/src/main/cpp/video_decoder.cpp
@@ -1339,6 +1339,7 @@ void VideoDecoder::UpdateReceivedStats(int size, int frameNumber, uint16_t hostP
         }
     }
     stats_.lastFrameNumber = frameNumber;
+    receivedFrameRate_.Record(currentTimeMs, stats_.totalFrames);
     
     // Keep the live overlay responsive to recovery instead of letting old
     // high-latency frames affect the value for the rest of the session.
@@ -1361,48 +1362,22 @@ void VideoDecoder::UpdateReceivedStats(int size, int frameNumber, uint16_t hostP
             static_cast<double>(recentHostLatencyWindowFrames_);
     }
     
-    if (stats_.lastFpsCalculationTime == 0) {
-        // 初始化统计基线 - 注意：这是在增加 totalFrames 之后
-        // 两个 lastCount 都设为当前值，这样后续计算的 delta 是正确的增量
-        stats_.lastFpsCalculationTime = currentTimeMs;
-        stats_.lastFrameCount = stats_.totalFrames;  // 基线 = 当前总帧数 (已包含第一帧)
-        stats_.lastDecodedFrameCount = decodedFrames_.load(std::memory_order_relaxed);
-        stats_.lastRenderedFpsCalculationTime = currentTimeMs;
+    if (stats_.lastStatsCalculationTime == 0) {
+        stats_.lastStatsCalculationTime = currentTimeMs;
         stats_.lastBytesCount = stats_.totalBytesReceived;
         stats_.lastBitrateCalculationTime = currentTimeMs;
         stats_.sessionStartTime = currentTimeMs;  // 记录会话开始时间
-    } else if (currentTimeMs - stats_.lastFpsCalculationTime >= kStatsUpdateIntervalMs) {
-        int64_t elapsedMs = currentTimeMs - stats_.lastFpsCalculationTime;
-        
-        // 计算接收帧率 (RX)
-        // framesDelta = 当前总帧数 - 上个窗口结束时的帧数
-        uint64_t framesDelta = stats_.totalFrames - stats_.lastFrameCount;
-        stats_.currentFps = static_cast<double>(framesDelta) * 1000.0 / static_cast<double>(elapsedMs);
-        stats_.lastFrameCount = stats_.totalFrames;
-        
-        // 计算渲染帧率 (RD) - 使用相同的时间窗口
-        // decodedDelta = 当前解码帧数 - 上个窗口结束时的解码帧数
-        const uint64_t decodedFrames = decodedFrames_.load(std::memory_order_relaxed);
-        uint64_t decodedDelta = decodedFrames - stats_.lastDecodedFrameCount;
-        stats_.renderedFps = static_cast<double>(decodedDelta) * 1000.0 / static_cast<double>(elapsedMs);
-        stats_.lastDecodedFrameCount = decodedFrames;
-        
-        // 更新公共时间基线
-        stats_.lastFpsCalculationTime = currentTimeMs;
-        stats_.lastRenderedFpsCalculationTime = currentTimeMs;
-        
-        // 计算全局平均渲染帧率（会话级别）
-        if (stats_.sessionStartTime > 0) {
-            int64_t sessionMs = currentTimeMs - stats_.sessionStartTime;
-            if (sessionMs > 0) {
-                stats_.globalAvgFps = static_cast<double>(decodedFrames) * 1000.0 /
-                    static_cast<double>(sessionMs);
-            }
-        }
-        
+    } else if (currentTimeMs - stats_.lastStatsCalculationTime >=
+               kStatsUpdateIntervalMs) {
+        const int64_t elapsedMs =
+            currentTimeMs - stats_.lastStatsCalculationTime;
+        stats_.lastStatsCalculationTime = currentTimeMs;
+
         // 计算比特率
-        uint64_t bytesDelta = stats_.totalBytesReceived - stats_.lastBytesCount;
-        stats_.currentBitrate = static_cast<double>(bytesDelta) * 8.0 * 1000.0 / static_cast<double>(elapsedMs);
+        const uint64_t bytesDelta =
+            stats_.totalBytesReceived - stats_.lastBytesCount;
+        stats_.currentBitrate = static_cast<double>(bytesDelta) * 8.0 *
+            1000.0 / static_cast<double>(elapsedMs);
         stats_.lastBytesCount = stats_.totalBytesReceived;
         stats_.lastBitrateCalculationTime = currentTimeMs;
         
@@ -1414,10 +1389,16 @@ void VideoDecoder::UpdateReceivedStats(int size, int frameNumber, uint16_t hostP
 }
 
 VideoDecoderStats VideoDecoder::GetStats() const {
+    const int64_t currentTimeMs = GetSteadyTimeMs();
     VideoDecoderStats snapshot;
     {
         std::lock_guard<std::mutex> lock(statsMutex_);
         snapshot = stats_;
+        snapshot.currentFps = receivedFrameRate_.GetRate(currentTimeMs);
+    }
+    {
+        std::lock_guard<std::mutex> lock(renderedRateMutex_);
+        snapshot.renderedFps = renderedFrameRate_.GetRate(currentTimeMs);
     }
 
     snapshot.decodedFrames = decodedFrames_.load(std::memory_order_relaxed);
@@ -1429,6 +1410,12 @@ VideoDecoderStats VideoDecoder::GetStats() const {
     snapshot.droppedByL5 = droppedByL5_.load(std::memory_order_relaxed);
     snapshot.droppedByQueueOverflow = droppedByQueueOverflow_.load(std::memory_order_relaxed);
     snapshot.droppedByTimeout = droppedByTimeout_.load(std::memory_order_relaxed);
+    if (snapshot.sessionStartTime > 0 &&
+        currentTimeMs > snapshot.sessionStartTime) {
+        snapshot.globalAvgFps =
+            static_cast<double>(snapshot.decodedFrames) * 1000.0 /
+            static_cast<double>(currentTimeMs - snapshot.sessionStartTime);
+    }
     {
         std::lock_guard<std::mutex> lock(decodeStatsMutex_);
         snapshot.totalDecodeTimeMs = static_cast<double>(decodeTotalTimeMs_);
@@ -1621,7 +1608,10 @@ void VideoDecoder::UpdateDecodedStats(int64_t enqueueTimeMs, uint32_t flags,
     const uint64_t outputFrames =
         codecOutputFrames_.fetch_add(1, std::memory_order_relaxed) + 1;
     if (presented) {
-        decodedFrames_.fetch_add(1, std::memory_order_relaxed);
+        const uint64_t decodedFrames =
+            decodedFrames_.fetch_add(1, std::memory_order_relaxed) + 1;
+        std::lock_guard<std::mutex> lock(renderedRateMutex_);
+        renderedFrameRate_.Record(currentTimeMs, decodedFrames);
     }
     
     if (enqueueTimeMs > 0) {

--- a/nativelib/src/main/cpp/video_decoder.h
+++ b/nativelib/src/main/cpp/video_decoder.h
@@ -36,6 +36,8 @@
 #include <native_window/external_window.h>
 #include <native_buffer/native_buffer.h>
 
+#include "rolling_frame_rate.h"
+
 class NativeRender;
 #include <hilog/log.h>
 
@@ -147,14 +149,9 @@ struct VideoDecoderStats {
     int lastFrameNumber;         // 上一帧的帧号（用于丢包检测）
     double averageDecodeTimeMs;
     double maxDecodeTimeMs;
-    // 用于接收 FPS 计算
-    uint64_t lastFrameCount;
-    int64_t lastFpsCalculationTime;  // 毫秒
-    double currentFps;           // 接收帧率 (Rx)
-    // 用于渲染 FPS 计算
-    uint64_t lastDecodedFrameCount;
-    int64_t lastRenderedFpsCalculationTime;
-    double renderedFps;          // 渲染帧率 (Rd)
+    int64_t lastStatsCalculationTime; // 周期统计更新时间（毫秒）
+    double currentFps;           // 最近 3 秒接收帧率 (Rx)
+    double renderedFps;          // 最近 3 秒成功提交帧率 (Rd)
     // 会话平均帧率（用于串流结束后的 toast）
     int64_t sessionStartTime;           // 会话开始时间（毫秒）
     double globalAvgFps;                // 全局平均渲染帧率
@@ -393,6 +390,9 @@ private:
     uint64_t recentHostLatencyWindowFrames_{0};
     double recentHostLatencyWindowTotalMs_{0.0};
     int64_t recentHostLatencyWindowStartTimeMs_{0};
+    RollingFrameRateTracker receivedFrameRate_;
+    mutable std::mutex renderedRateMutex_;
+    RollingFrameRateTracker renderedFrameRate_;
 
     // Output/drop counters are updated atomically so decoder callbacks never
     // wait on the receive-statistics snapshot mutex.

--- a/nativelib/src/test/cpp/presentation_observability_test.cpp
+++ b/nativelib/src/test/cpp/presentation_observability_test.cpp
@@ -49,6 +49,17 @@ void TestRollingRateResetsWithCounter() {
     AssertNear(tracker.GetRate(4000), 120.0, 0.1);
 }
 
+void TestRollingRateExcludesOldCadence() {
+    RollingFrameRateTracker tracker;
+    tracker.Record(500, 500);
+    tracker.Record(1100, 510);
+    tracker.Record(2000, 600);
+    tracker.Record(3000, 700);
+    tracker.Record(4000, 800);
+
+    AssertNear(tracker.GetRate(4000), 100.0, 0.1);
+}
+
 void TestPresentationDiagnosticsTrackSlotConflicts() {
     PresentationDiagnostics diagnostics;
     constexpr int64_t kPeriodNs = 8333333;
@@ -76,6 +87,7 @@ int main() {
     TestRollingRateTracksSteadyCadence();
     TestRollingRateAbsorbsGroupedCallbacks();
     TestRollingRateResetsWithCounter();
+    TestRollingRateExcludesOldCadence();
     TestPresentationDiagnosticsTrackSlotConflicts();
     std::cout << "presentation observability tests passed\n";
     return 0;

--- a/nativelib/src/test/cpp/presentation_observability_test.cpp
+++ b/nativelib/src/test/cpp/presentation_observability_test.cpp
@@ -1,0 +1,82 @@
+#include "presentation_diagnostics.h"
+#include "rolling_frame_rate.h"
+
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+
+namespace {
+constexpr int64_t kMs = 1000000LL;
+
+void AssertNear(double actual, double expected, double tolerance) {
+    assert(std::fabs(actual - expected) <= tolerance);
+}
+
+void TestRollingRateTracksSteadyCadence() {
+    RollingFrameRateTracker tracker;
+    for (uint64_t frame = 1; frame <= 360; ++frame) {
+        const int64_t timestampMs = static_cast<int64_t>(
+            std::llround(static_cast<double>(frame - 1) * 1000.0 / 120.0));
+        tracker.Record(timestampMs, frame);
+    }
+
+    AssertNear(tracker.GetRate(3000), 120.0, 1.0);
+}
+
+void TestRollingRateAbsorbsGroupedCallbacks() {
+    RollingFrameRateTracker tracker;
+    uint64_t frames = 0;
+    for (int group = 0; group < 90; ++group) {
+        frames += 4;
+        const int64_t timestampMs = static_cast<int64_t>(
+            std::llround(static_cast<double>(group) * 1000.0 / 30.0));
+        tracker.Record(timestampMs, frames);
+    }
+
+    AssertNear(tracker.GetRate(3000), 120.0, 0.1);
+    assert(tracker.GetRate(3200) < 115.0);
+    assert(tracker.GetRate(6000) == 0.0);
+}
+
+void TestRollingRateResetsWithCounter() {
+    RollingFrameRateTracker tracker;
+    tracker.Record(1000, 120);
+    tracker.Record(2000, 240);
+    tracker.Record(3000, 1);
+    tracker.Record(4000, 121);
+
+    AssertNear(tracker.GetRate(4000), 120.0, 0.1);
+}
+
+void TestPresentationDiagnosticsTrackSlotConflicts() {
+    PresentationDiagnostics diagnostics;
+    constexpr int64_t kPeriodNs = 8333333;
+    constexpr int64_t kVsyncNs = 1000 * kMs;
+
+    diagnostics.Record(kVsyncNs + 2 * kMs, kVsyncNs,
+                       kVsyncNs, kPeriodNs);
+    diagnostics.Record(kVsyncNs + 4 * kMs, kVsyncNs + kMs,
+                       kVsyncNs, kPeriodNs);
+    diagnostics.Record(kVsyncNs + 27 * kMs, kVsyncNs + 2 * kMs,
+                       kVsyncNs, kPeriodNs);
+    diagnostics.Record(kVsyncNs + 3 * kMs, kVsyncNs + 3 * kMs,
+                       kVsyncNs, kPeriodNs);
+
+    const PresentationTimingStats& stats = diagnostics.GetStats();
+    assert(stats.sameVsyncSlotCount == 1);
+    assert(stats.targetRegressionCount == 1);
+    assert(stats.maxTargetRegressionNs == 24 * kMs);
+    assert(stats.vsyncSlotRegressionCount == 1);
+    assert(stats.maxQueueDepthSlots == 4);
+}
+} // namespace
+
+int main() {
+    TestRollingRateTracksSteadyCadence();
+    TestRollingRateAbsorbsGroupedCallbacks();
+    TestRollingRateResetsWithCounter();
+    TestPresentationDiagnosticsTrackSlotConflicts();
+    std::cout << "presentation observability tests passed\n";
+    return 0;
+}

--- a/nativelib/src/test/cpp/presentation_scheduler_test.cpp
+++ b/nativelib/src/test/cpp/presentation_scheduler_test.cpp
@@ -3,7 +3,6 @@
 #include <cassert>
 #include <cmath>
 #include <cstdint>
-#include <cstdlib>
 #include <iostream>
 
 namespace {
@@ -18,17 +17,25 @@ int64_t FrameIntervalNs(double fps) {
         std::llround(static_cast<double>(kNanosecondsPerSecond) / fps));
 }
 
+PresentationVsyncTiming Timing(double refreshRate) {
+    return {kStartNs, FrameIntervalNs(refreshRate)};
+}
+
+void AssertOnVsyncSlot(
+        const PresentationPlan& plan,
+        const PresentationVsyncTiming& timing) {
+    assert(plan.action == PresentationAction::SCHEDULE);
+    assert((plan.targetTimeNs - timing.timestampNs) % timing.periodNs == 0);
+}
+
 void AssertFutureCadenceBudget(double fps, int numerator, int denominator) {
     PtsPresentationScheduler scheduler;
     scheduler.Configure(fps);
 
-    const PresentationPlan first = scheduler.PlanFrame(0, kStartNs);
     const int64_t expectedCadenceBudgetNs =
         FrameIntervalNs(fps) * numerator / denominator;
 
-    assert(first.action == PresentationAction::SCHEDULE);
     assert(scheduler.GetInitialLeadNs() == kExpectedSubmitLeadNs);
-    assert(first.targetTimeNs - kStartNs == kExpectedSubmitLeadNs);
     assert(scheduler.GetMaxFutureLeadNs() ==
         kExpectedSubmitLeadNs + expectedCadenceBudgetNs +
         kNanosecondsPerMicrosecond);
@@ -45,212 +52,228 @@ void TestRefreshRateTierBudgets() {
     AssertFutureCadenceBudget(144.0, 2, 1);
 }
 
-void Test120FpsTripleBurstKeepsPtsCadence() {
+void Test120FpsBurstUsesThreeUniqueSlots() {
     PtsPresentationScheduler scheduler;
     scheduler.Configure(120.0);
+    const PresentationVsyncTiming timing = Timing(120.0);
+    const int64_t decodedAtNs = kStartNs + kMs;
 
-    const PresentationPlan first = scheduler.PlanFrame(0, kStartNs);
-    const PresentationPlan second = scheduler.PlanFrame(8334, kStartNs);
-    const PresentationPlan third = scheduler.PlanFrame(16667, kStartNs + kMs);
-    const PresentationPlan fourth = scheduler.PlanFrame(25000, kStartNs + kMs);
+    const PresentationPlan first = scheduler.PlanFrame(0, decodedAtNs, timing);
+    const PresentationPlan second = scheduler.PlanFrame(8334, decodedAtNs, timing);
+    const PresentationPlan third = scheduler.PlanFrame(16667, decodedAtNs, timing);
+    const PresentationPlan fourth = scheduler.PlanFrame(25000, decodedAtNs, timing);
 
-    assert(first.action == PresentationAction::SCHEDULE);
-    assert(second.action == PresentationAction::SCHEDULE);
-    assert(third.action == PresentationAction::SCHEDULE);
-    assert(fourth.action == PresentationAction::SCHEDULE);
-    assert(second.event == PresentationEvent::NONE);
-    assert(third.event == PresentationEvent::NONE);
-    assert(fourth.event == PresentationEvent::CATCH_UP);
-    assert(second.targetTimeNs - first.targetTimeNs ==
-        8334 * kNanosecondsPerMicrosecond);
-    assert(third.targetTimeNs - second.targetTimeNs ==
-        8333 * kNanosecondsPerMicrosecond);
-    assert(fourth.targetTimeNs - (kStartNs + kMs) ==
-        scheduler.GetInitialLeadNs());
+    AssertOnVsyncSlot(first, timing);
+    AssertOnVsyncSlot(second, timing);
+    AssertOnVsyncSlot(third, timing);
+    assert(second.targetTimeNs - first.targetTimeNs == timing.periodNs);
+    assert(third.targetTimeNs - second.targetTimeNs == timing.periodNs);
+    assert(fourth.action == PresentationAction::DROP);
+    assert(fourth.event == PresentationEvent::QUEUE_FULL);
 }
 
-void Test90FpsPairBurstKeepsSingleFrameBudget() {
+void TestQueueFullWaitsForDrainBeforeReanchor() {
+    PtsPresentationScheduler scheduler;
+    scheduler.Configure(120.0);
+    const PresentationVsyncTiming timing = Timing(120.0);
+    const int64_t burstTimeNs = kStartNs + kMs;
+
+    const PresentationPlan first = scheduler.PlanFrame(0, burstTimeNs, timing);
+    scheduler.PlanFrame(8334, burstTimeNs, timing);
+    const PresentationPlan third = scheduler.PlanFrame(16667, burstTimeNs, timing);
+    const PresentationPlan full = scheduler.PlanFrame(25000, burstTimeNs, timing);
+    const PresentationPlan waiting = scheduler.PlanFrame(
+        33333, first.targetTimeNs + kMs, timing);
+    const PresentationPlan recovered = scheduler.PlanFrame(
+        41667, third.targetTimeNs + kMs, timing);
+
+    assert(full.event == PresentationEvent::QUEUE_FULL);
+    assert(waiting.action == PresentationAction::DROP);
+    assert(waiting.event == PresentationEvent::WAIT_FOR_DRAIN);
+    assert(recovered.action == PresentationAction::SCHEDULE);
+    assert(recovered.event == PresentationEvent::CATCH_UP);
+    assert(recovered.targetTimeNs == third.targetTimeNs + timing.periodNs);
+}
+
+void Test90FpsPairBurstUsesTwoSlots() {
     PtsPresentationScheduler scheduler;
     scheduler.Configure(90.0);
+    const PresentationVsyncTiming timing = Timing(90.0);
+    const int64_t decodedAtNs = kStartNs + kMs;
 
-    const PresentationPlan first = scheduler.PlanFrame(0, kStartNs);
-    const PresentationPlan second = scheduler.PlanFrame(11111, kStartNs);
-    const PresentationPlan third = scheduler.PlanFrame(22222, kStartNs + kMs);
+    const PresentationPlan first = scheduler.PlanFrame(0, decodedAtNs, timing);
+    const PresentationPlan second = scheduler.PlanFrame(11111, decodedAtNs, timing);
+    const PresentationPlan third = scheduler.PlanFrame(22222, decodedAtNs, timing);
 
-    assert(first.action == PresentationAction::SCHEDULE);
-    assert(second.action == PresentationAction::SCHEDULE);
-    assert(third.action == PresentationAction::SCHEDULE);
-    assert(second.event == PresentationEvent::NONE);
-    assert(third.event == PresentationEvent::CATCH_UP);
+    AssertOnVsyncSlot(first, timing);
+    AssertOnVsyncSlot(second, timing);
+    assert(second.targetTimeNs - first.targetTimeNs == timing.periodNs);
+    assert(third.action == PresentationAction::DROP);
+    assert(third.event == PresentationEvent::QUEUE_FULL);
 }
 
-void AssertLowRefreshBurstCatchesUp(double fps, int64_t framePtsUs) {
+void Test60FpsDoesNotGrowPresentationQueue() {
     PtsPresentationScheduler scheduler;
-    scheduler.Configure(fps);
+    scheduler.Configure(60.0);
+    const PresentationVsyncTiming timing = Timing(60.0);
+    const int64_t decodedAtNs = kStartNs + kMs;
 
-    const PresentationPlan first = scheduler.PlanFrame(0, kStartNs);
-    const PresentationPlan burst = scheduler.PlanFrame(framePtsUs, kStartNs);
+    const PresentationPlan first = scheduler.PlanFrame(0, decodedAtNs, timing);
+    const PresentationPlan burst = scheduler.PlanFrame(16667, decodedAtNs, timing);
+    const PresentationPlan recovered = scheduler.PlanFrame(
+        33333, first.targetTimeNs + kMs, timing);
 
-    assert(first.action == PresentationAction::SCHEDULE);
-    assert(burst.action == PresentationAction::SCHEDULE);
-    assert(burst.event == PresentationEvent::CATCH_UP);
-    assert(burst.targetTimeNs - kStartNs == scheduler.GetInitialLeadNs());
-}
-
-void TestLowRefreshBurstKeepsHalfFrameBudget() {
-    AssertLowRefreshBurstCatchesUp(30.0, 33333);
-    AssertLowRefreshBurstCatchesUp(60.0, 16667);
+    AssertOnVsyncSlot(first, timing);
+    assert(burst.action == PresentationAction::DROP);
+    assert(burst.event == PresentationEvent::QUEUE_FULL);
+    assert(recovered.action == PresentationAction::SCHEDULE);
+    assert(recovered.event == PresentationEvent::CATCH_UP);
+    assert(recovered.targetTimeNs == first.targetTimeNs + timing.periodNs);
 }
 
 void TestSmallLateFrameShiftsWholeTimeline() {
     PtsPresentationScheduler scheduler;
     scheduler.Configure(60.0);
+    const PresentationVsyncTiming timing = Timing(60.0);
 
-    const PresentationPlan first = scheduler.PlanFrame(0, kStartNs);
-    const PresentationPlan shifted = scheduler.PlanFrame(16667, 1018 * kMs);
-    const PresentationPlan next = scheduler.PlanFrame(33333, 1034 * kMs);
+    const PresentationPlan first = scheduler.PlanFrame(
+        0, kStartNs + kMs, timing);
+    const PresentationPlan shifted = scheduler.PlanFrame(
+        16667, kStartNs + 18 * kMs, timing);
+    const PresentationPlan next = scheduler.PlanFrame(
+        33333, kStartNs + 34 * kMs, timing);
 
     assert(shifted.action == PresentationAction::SCHEDULE);
     assert(shifted.event == PresentationEvent::PHASE_SHIFT);
     assert(next.action == PresentationAction::SCHEDULE);
-    assert(next.targetTimeNs - shifted.targetTimeNs == 16666000LL);
-    assert(shifted.targetTimeNs >= 1020 * kMs);
     assert(first.targetTimeNs < shifted.targetTimeNs);
+    assert(next.targetTimeNs - shifted.targetTimeNs == timing.periodNs);
 }
 
-void TestSevereLateDropThenRebuffer() {
+void TestSevereLateFrameDropsBeforeRebuffer() {
     PtsPresentationScheduler scheduler;
     scheduler.Configure(60.0);
+    const PresentationVsyncTiming timing = Timing(60.0);
 
-    scheduler.PlanFrame(0, kStartNs);
-    const PresentationPlan dropped = scheduler.PlanFrame(16667, 1100 * kMs);
-    const PresentationPlan rebuffered = scheduler.PlanFrame(33333, 1101 * kMs);
+    scheduler.PlanFrame(0, kStartNs + kMs, timing);
+    const PresentationPlan dropped = scheduler.PlanFrame(
+        16667, kStartNs + 100 * kMs, timing);
+    const PresentationPlan rebuffered = scheduler.PlanFrame(
+        33333, kStartNs + 101 * kMs, timing);
 
     assert(dropped.action == PresentationAction::DROP);
     assert(dropped.event == PresentationEvent::LATE_DROP);
     assert(rebuffered.action == PresentationAction::SCHEDULE);
     assert(rebuffered.event == PresentationEvent::REBUFFER);
-    assert(rebuffered.targetTimeNs > 1101 * kMs);
+    assert(rebuffered.targetTimeNs > kStartNs + 100 * kMs);
 }
 
-void TestAccumulatedPhaseShiftRecoversQuickly() {
+void TestDiscontinuityWaitsForQueuedSlot() {
+    PtsPresentationScheduler scheduler;
+    scheduler.Configure(120.0);
+    const PresentationVsyncTiming timing = Timing(120.0);
+    const int64_t decodedAtNs = kStartNs + kMs;
+
+    const PresentationPlan first = scheduler.PlanFrame(1000000, decodedAtNs, timing);
+    const PresentationPlan waiting = scheduler.PlanFrame(500000, decodedAtNs, timing);
+    const PresentationPlan reanchored = scheduler.PlanFrame(
+        500001, first.targetTimeNs + kMs, timing);
+
+    assert(waiting.action == PresentationAction::DROP);
+    assert(waiting.event == PresentationEvent::WAIT_FOR_DRAIN);
+    assert(reanchored.action == PresentationAction::SCHEDULE);
+    assert(reanchored.event == PresentationEvent::DISCONTINUITY);
+    assert(reanchored.targetTimeNs == first.targetTimeNs + timing.periodNs);
+}
+
+void TestDuplicatePtsRecoversAfterQueuedSlot() {
     PtsPresentationScheduler scheduler;
     scheduler.Configure(60.0);
+    const PresentationVsyncTiming timing = Timing(60.0);
+    const int64_t decodedAtNs = kStartNs + kMs;
 
-    constexpr int64_t kFrameUs = 16667;
-    scheduler.PlanFrame(0, kStartNs);
+    const PresentationPlan first = scheduler.PlanFrame(1000, decodedAtNs, timing);
+    const PresentationPlan waiting = scheduler.PlanFrame(1000, decodedAtNs, timing);
+    const PresentationPlan reanchored = scheduler.PlanFrame(
+        1000, first.targetTimeNs + kMs, timing);
 
-    int phaseShiftCount = 0;
-    for (int i = 1; i <= 12; ++i) {
-        const int64_t ptsUs = i * kFrameUs;
-        const int64_t nominalDecodeNs =
-            kStartNs + ptsUs * kNanosecondsPerMicrosecond;
-        const int64_t rampDelayNs = (3 + (i - 1) * 6) * kMs;
-        const PresentationPlan delayed = scheduler.PlanFrame(
-            ptsUs, nominalDecodeNs + rampDelayNs);
-        assert(delayed.action == PresentationAction::SCHEDULE);
-        if (delayed.event == PresentationEvent::PHASE_SHIFT) {
-            phaseShiftCount++;
-        }
+    assert(waiting.action == PresentationAction::DROP);
+    assert(waiting.event == PresentationEvent::WAIT_FOR_DRAIN);
+    assert(reanchored.action == PresentationAction::SCHEDULE);
+    assert(reanchored.event == PresentationEvent::DUPLICATE_PTS);
+}
+
+void TestNtscCadenceSkipsARealSlotWithoutRegression() {
+    PtsPresentationScheduler scheduler;
+    scheduler.Configure(119.88);
+    const PresentationVsyncTiming timing = Timing(120.0);
+    constexpr double kPtsIntervalUs = 1000000.0 / 119.88;
+    const int64_t firstDecodedAtNs = kStartNs + kMs;
+
+    PresentationPlan previous = scheduler.PlanFrame(
+        0, firstDecodedAtNs, timing);
+    bool skippedSlot = false;
+    for (int i = 1; i <= 2500; ++i) {
+        const int64_t ptsUs = static_cast<int64_t>(
+            std::llround(i * kPtsIntervalUs));
+        const int64_t decodedAtNs =
+            firstDecodedAtNs + ptsUs * kNanosecondsPerMicrosecond;
+        const PresentationPlan current = scheduler.PlanFrame(
+            ptsUs, decodedAtNs, timing);
+
+        AssertOnVsyncSlot(current, timing);
+        assert(current.targetTimeNs > previous.targetTimeNs);
+        const int64_t slotDelta =
+            (current.targetTimeNs - previous.targetTimeNs) / timing.periodNs;
+        assert(slotDelta == 1 || slotDelta == 2);
+        skippedSlot = skippedSlot || slotDelta == 2;
+        previous = current;
     }
-    assert(phaseShiftCount >= 10);
-
-    const int64_t recoveredPtsUs = 13 * kFrameUs;
-    const int64_t recoveredDecodeNs =
-        kStartNs + recoveredPtsUs * kNanosecondsPerMicrosecond;
-    const PresentationPlan recovered = scheduler.PlanFrame(
-        recoveredPtsUs, recoveredDecodeNs);
-
-    assert(recovered.action == PresentationAction::SCHEDULE);
-    assert(recovered.event == PresentationEvent::PHASE_SHIFT);
-    assert(recovered.latenessNs < 0);
-    assert(std::llabs((recovered.targetTimeNs - recoveredDecodeNs) -
-                      scheduler.GetInitialLeadNs()) < kMs);
-
-    const int64_t nextPtsUs = 14 * kFrameUs;
-    const int64_t nextDecodeNs =
-        kStartNs + nextPtsUs * kNanosecondsPerMicrosecond;
-    const PresentationPlan next = scheduler.PlanFrame(nextPtsUs, nextDecodeNs);
-    assert(next.action == PresentationAction::SCHEDULE);
-    assert(std::llabs((next.targetTimeNs - recovered.targetTimeNs) -
-                      kFrameUs * kNanosecondsPerMicrosecond) < kMs);
+    assert(skippedSlot);
 }
 
-void TestBurstCatchesUpAfterPartialPhaseDebtRepayment() {
+void TestObservedVsyncPhaseCannotReuseFallbackSlot() {
+    PtsPresentationScheduler scheduler;
+    scheduler.Configure(120.0);
+    const int64_t decodedAtNs = kStartNs + kMs;
+
+    const PresentationPlan fallback = scheduler.PlanFrame(0, decodedAtNs);
+    const PresentationVsyncTiming observed = {
+        kStartNs + 3 * kMs, FrameIntervalNs(120.0)};
+    const PresentationPlan phased = scheduler.PlanFrame(
+        8334, decodedAtNs, observed);
+
+    AssertOnVsyncSlot(phased, observed);
+    const int64_t fallbackOccupiedSlot = observed.timestampNs +
+        static_cast<int64_t>(std::ceil(
+            static_cast<double>(fallback.targetTimeNs - observed.timestampNs) /
+            static_cast<double>(observed.periodNs))) * observed.periodNs;
+    assert(phased.targetTimeNs > fallbackOccupiedSlot);
+}
+
+void TestInvalidPtsDropsWithoutScheduling() {
     PtsPresentationScheduler scheduler;
     scheduler.Configure(60.0);
 
-    scheduler.PlanFrame(0, kStartNs);
-    const PresentationPlan shifted = scheduler.PlanFrame(16667, 1022 * kMs);
-    const PresentationPlan burst = scheduler.PlanFrame(50000, 1023 * kMs);
-
-    assert(shifted.event == PresentationEvent::PHASE_SHIFT);
-    assert(burst.action == PresentationAction::SCHEDULE);
-    assert(burst.event == PresentationEvent::CATCH_UP);
-    assert(burst.targetTimeNs - 1023 * kMs == scheduler.GetInitialLeadNs());
-}
-
-void TestDuplicatePtsReanchorsInsteadOfFreezing() {
-    PtsPresentationScheduler scheduler;
-    scheduler.Configure(60.0);
-
-    scheduler.PlanFrame(1000, 1000 * kMs);
-    const PresentationPlan firstDuplicate = scheduler.PlanFrame(1000, 1017 * kMs);
-    const PresentationPlan secondDuplicate = scheduler.PlanFrame(1000, 1034 * kMs);
-
-    assert(firstDuplicate.action == PresentationAction::SCHEDULE);
-    assert(firstDuplicate.event == PresentationEvent::DUPLICATE_PTS);
-    assert(secondDuplicate.action == PresentationAction::SCHEDULE);
-    assert(secondDuplicate.event == PresentationEvent::DUPLICATE_PTS);
-    assert(secondDuplicate.targetTimeNs > firstDuplicate.targetTimeNs);
-}
-
-void TestDiscontinuityReanchors() {
-    PtsPresentationScheduler scheduler;
-    scheduler.Configure(59.94);
-
-    scheduler.PlanFrame(1000000, 2000 * kMs);
-    const PresentationPlan discontinuity = scheduler.PlanFrame(500000, 2010 * kMs);
-
-    assert(discontinuity.action == PresentationAction::SCHEDULE);
-    assert(discontinuity.event == PresentationEvent::DISCONTINUITY);
-}
-
-void TestSlowClockDriftStaysBounded() {
-    PtsPresentationScheduler scheduler;
-    scheduler.Configure(60.0);
-
-    constexpr double kPtsIntervalUs = 1000000.0 / 60.0;
-    constexpr double kFastLocalIntervalNs = 1000000000.0 / 60.0 * (1.0 - 0.0001);
-    scheduler.PlanFrame(0, kStartNs);
-
-    PresentationPlan plan;
-    int64_t decodedAtNs = kStartNs;
-    for (int i = 1; i <= 20000; ++i) {
-        const int64_t ptsUs = static_cast<int64_t>(std::llround(i * kPtsIntervalUs));
-        decodedAtNs = kStartNs + static_cast<int64_t>(std::llround(i * kFastLocalIntervalNs));
-        plan = scheduler.PlanFrame(ptsUs, decodedAtNs);
-        assert(plan.action == PresentationAction::SCHEDULE);
-    }
-
-    const int64_t finalLeadNs = plan.targetTimeNs - decodedAtNs;
-    const int64_t expectedLeadNs = scheduler.GetInitialLeadNs();
-    assert(std::llabs(finalLeadNs - expectedLeadNs) < 5 * kMs);
+    const PresentationPlan invalid = scheduler.PlanFrame(-1, kStartNs);
+    assert(invalid.action == PresentationAction::DROP);
+    assert(invalid.event == PresentationEvent::INVALID_PTS);
 }
 } // namespace
 
 int main() {
     TestRefreshRateTierBudgets();
-    Test120FpsTripleBurstKeepsPtsCadence();
-    Test90FpsPairBurstKeepsSingleFrameBudget();
-    TestLowRefreshBurstKeepsHalfFrameBudget();
+    Test120FpsBurstUsesThreeUniqueSlots();
+    TestQueueFullWaitsForDrainBeforeReanchor();
+    Test90FpsPairBurstUsesTwoSlots();
+    Test60FpsDoesNotGrowPresentationQueue();
     TestSmallLateFrameShiftsWholeTimeline();
-    TestSevereLateDropThenRebuffer();
-    TestAccumulatedPhaseShiftRecoversQuickly();
-    TestBurstCatchesUpAfterPartialPhaseDebtRepayment();
-    TestDuplicatePtsReanchorsInsteadOfFreezing();
-    TestDiscontinuityReanchors();
-    TestSlowClockDriftStaysBounded();
+    TestSevereLateFrameDropsBeforeRebuffer();
+    TestDiscontinuityWaitsForQueuedSlot();
+    TestDuplicatePtsRecoversAfterQueuedSlot();
+    TestNtscCadenceSkipsARealSlotWithoutRegression();
+    TestObservedVsyncPhaseCannotReuseFallbackSlot();
+    TestInvalidPtsDropsWithoutScheduling();
     std::cout << "presentation scheduler tests passed\n";
     return 0;
 }


### PR DESCRIPTION
## 改了啥呀

- 把 Rx/Rd 从 1 秒翻滚计数改成最近 3 秒的滚动速率，解码器成组回调不再把正常帧挤到相邻窗口里呀。
- 每 250ms 最多请求一次只读 NativeVSync 样本，记录真实周期和样本年龄。
- 给 host-paced 日志补上同槽碰撞、槽位倒退、目标时间倒退、最大倒退和最大未来队列槽数。
- 新增纯 C++ 观测组件与测试；现有 PTS 调度、CATCH_UP 和丢帧策略完全没动。

## 为啥要改

之前那个杂鱼 1 秒窗口会把 120 FPS 的批量回调显示成偶发 115–117，害我们拿统计抖动去调未来余量。现在先把统计口径和 VSync 证据补齐，下一轮才能区分是真掉帧、同槽覆盖，还是目标时间倒退啦。

## 验证

- `c++ -std=c++17 -Wall -Wextra -Werror nativelib/src/main/cpp/rolling_frame_rate.cpp nativelib/src/main/cpp/presentation_diagnostics.cpp nativelib/src/test/cpp/presentation_observability_test.cpp -I nativelib/src/main/cpp -o /tmp/moonlight_presentation_observability_test && /tmp/moonlight_presentation_observability_test`
- `c++ -std=c++17 -Wall -Wextra -Werror nativelib/src/main/cpp/presentation_scheduler.cpp nativelib/src/test/cpp/presentation_scheduler_test.cpp -I nativelib/src/main/cpp -o /tmp/moonlight_presentation_scheduler_test && /tmp/moonlight_presentation_scheduler_test`
- `npm run check`
- `env JAVA_HOME=/Applications/DevEco-Studio.app/Contents/jbr/Contents/Home OHOS_SDK_HOME=/Users/mac/ohos-sdk-cache/6.1-Release-mac/sdk-ci-shape HOS_SDK_HOME=/Users/mac/ohos-sdk-cache/6.1-Release-mac/sdk-ci-shape OHOS_BASE_SDK_HOME=/Users/mac/ohos-sdk-cache/6.1-Release-mac/sdk-ci-shape DEVECO_SDK_HOME=/Users/mac/ohos-sdk-cache/6.1-Release-mac/sdk-ci-shape node hvigorw.js assembleApp --mode project -p product=default -p buildMode=debug --no-daemon`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 优化视频接收与渲染帧率统计：引入滚动窗口机制，提升实时性与稳定性。
  * 增强呈现时序与垂直同步监测：在渲染侧采样并记录 VSync 观测与失败情况，输出更细粒度统计。
  * 改进统计刷新与重置策略，确保在时间变化、采样不足或回退场景下结果更可靠。
* **新增**
  * 增加呈现诊断统计能力，用于衡量目标时间回归与队列深度等表现。
* **测试**
  * 新增呈现可观测性相关测试用例，覆盖滚动帧率与时序诊断结果校验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->