### PR TITLE
fix(render): schedule frames on unique vsync slots

### DIFF
--- a/nativelib/src/main/cpp/native_render.cpp
+++ b/nativelib/src/main/cpp/native_render.cpp
@@ -249,7 +249,7 @@ void NativeRender::SetVsyncEnabled(bool enable) {
     bool wasEnabled = vsyncEnabled_.exchange(enable);
     if (wasEnabled != enable) {
         {
-            std::lock_guard<std::mutex> lock(presentationMutex_);
+            std::unique_lock<std::mutex> lock(presentationMutex_);
             ResetPresentationClockLocked();
             ResetPresentationStatsLocked();
         }
@@ -438,6 +438,8 @@ void NativeRender::ResetPresentationStatsLocked() {
     precisePhaseShiftCount_ = 0;
     preciseRebufferCount_ = 0;
     preciseResyncCount_ = 0;
+    preciseQueueFullCount_ = 0;
+    preciseWaitForDrainCount_ = 0;
     preciseApiFailureCount_ = 0;
     preciseMaxTargetLeadNs_ = 0;
     presentationDiagnostics_.Reset();
@@ -551,69 +553,77 @@ NativeRender::FrameSubmitResult NativeRender::SubmitFrame(const DecodedFrame& fr
         } else {
             const int64_t decodedAtNs = GetMonotonicTimeNs();
             RequestVSyncSample(decodedAtNs);
-            PresentationPlan plan;
-            {
-                std::lock_guard<std::mutex> lock(presentationMutex_);
-                plan = ptsScheduler_.PlanFrame(frame.ptsUs, decodedAtNs);
-                if (plan.action == PresentationAction::SCHEDULE) {
-                    preciseScheduledCount_++;
-                } else {
-                    preciseDroppedCount_++;
-                }
-                if (plan.latenessNs > 0) preciseLateCount_++;
-                if (plan.event == PresentationEvent::CATCH_UP) {
-                    preciseCatchUpCount_++;
-                }
-                if (plan.event == PresentationEvent::PHASE_SHIFT) precisePhaseShiftCount_++;
-                if (plan.event == PresentationEvent::REBUFFER) preciseRebufferCount_++;
-                if (plan.event == PresentationEvent::DISCONTINUITY ||
-                    plan.event == PresentationEvent::DUPLICATE_PTS) {
-                    preciseResyncCount_++;
-                }
-                const int64_t observedVsyncNs =
-                    g_observedVsyncTimestampNs.load(std::memory_order_acquire);
-                const int64_t observedVsyncPeriodNs =
-                    g_observedVsyncPeriodNs.load(std::memory_order_acquire);
-                if (plan.action == PresentationAction::SCHEDULE) {
-                    preciseMaxTargetLeadNs_ = std::max(
-                        preciseMaxTargetLeadNs_, plan.targetTimeNs - decodedAtNs);
-                    presentationDiagnostics_.Record(
-                        plan.targetTimeNs, decodedAtNs,
-                        observedVsyncNs, observedVsyncPeriodNs);
-                }
+            const int64_t observedVsyncNs =
+                g_observedVsyncTimestampNs.load(std::memory_order_acquire);
+            const int64_t observedVsyncPeriodNs =
+                g_observedVsyncPeriodNs.load(std::memory_order_acquire);
+            const PresentationVsyncTiming vsyncTiming = {
+                observedVsyncNs, observedVsyncPeriodNs};
 
-                const int64_t totalFrames = preciseScheduledCount_ + preciseDroppedCount_;
-                if (totalFrames % kHostPacedStatsLogIntervalFrames == 0) {
-                    const PresentationTimingStats& timing =
-                        presentationDiagnostics_.GetStats();
-                    OH_LOG_INFO(LOG_APP,
-                        "Host-paced stats: frames=%{public}lld, scheduled=%{public}lld, dropped=%{public}lld, late=%{public}lld, catchUp=%{public}lld, phaseShift=%{public}lld, rebuffer=%{public}lld, resync=%{public}lld, apiFailure=%{public}lld, lead=%{public}lldus, maxLead=%{public}lldus, sameSlot=%{public}lld, slotRegression=%{public}lld, targetRegression=%{public}lld, maxRegression=%{public}lldus, maxQueueSlots=%{public}lld, vsyncPeriod=%{public}lldus, vsyncAge=%{public}lldus, vsyncSampleFailure=%{public}lld",
-                        static_cast<long long>(totalFrames),
-                        static_cast<long long>(preciseScheduledCount_),
-                        static_cast<long long>(preciseDroppedCount_),
-                        static_cast<long long>(preciseLateCount_),
-                        static_cast<long long>(preciseCatchUpCount_),
-                        static_cast<long long>(precisePhaseShiftCount_),
-                        static_cast<long long>(preciseRebufferCount_),
-                        static_cast<long long>(preciseResyncCount_),
-                        static_cast<long long>(preciseApiFailureCount_),
-                        static_cast<long long>(ptsScheduler_.GetInitialLeadNs() / 1000),
-                        static_cast<long long>(preciseMaxTargetLeadNs_ / 1000),
-                        static_cast<long long>(timing.sameVsyncSlotCount),
-                        static_cast<long long>(timing.vsyncSlotRegressionCount),
-                        static_cast<long long>(timing.targetRegressionCount),
-                        static_cast<long long>(timing.maxTargetRegressionNs / 1000),
-                        static_cast<long long>(timing.maxQueueDepthSlots),
-                        static_cast<long long>(observedVsyncPeriodNs / 1000),
-                        static_cast<long long>(observedVsyncNs > 0
-                            ? std::max<int64_t>(0, decodedAtNs - observedVsyncNs) / 1000
-                            : 0),
-                        static_cast<long long>(g_vsyncSampleRequestFailures.load(
-                            std::memory_order_relaxed)));
-                }
+            // Keep planning and timed submission ordered even if a codec emits
+            // output callbacks concurrently.
+            std::unique_lock<std::mutex> lock(presentationMutex_);
+            const PresentationPlan plan = ptsScheduler_.PlanFrame(
+                frame.ptsUs, decodedAtNs, vsyncTiming);
+            if (plan.action == PresentationAction::SCHEDULE) {
+                preciseScheduledCount_++;
+            } else {
+                preciseDroppedCount_++;
+            }
+            if (plan.latenessNs > 0) preciseLateCount_++;
+            if (plan.event == PresentationEvent::CATCH_UP) preciseCatchUpCount_++;
+            if (plan.event == PresentationEvent::PHASE_SHIFT) precisePhaseShiftCount_++;
+            if (plan.event == PresentationEvent::REBUFFER) preciseRebufferCount_++;
+            if (plan.event == PresentationEvent::DISCONTINUITY ||
+                plan.event == PresentationEvent::DUPLICATE_PTS) {
+                preciseResyncCount_++;
+            }
+            if (plan.event == PresentationEvent::QUEUE_FULL) preciseQueueFullCount_++;
+            if (plan.event == PresentationEvent::WAIT_FOR_DRAIN) {
+                preciseWaitForDrainCount_++;
+            }
+            if (plan.action == PresentationAction::SCHEDULE) {
+                preciseMaxTargetLeadNs_ = std::max(
+                    preciseMaxTargetLeadNs_, plan.targetTimeNs - decodedAtNs);
+                presentationDiagnostics_.Record(
+                    plan.targetTimeNs, decodedAtNs,
+                    observedVsyncNs, observedVsyncPeriodNs);
+            }
+
+            const int64_t totalFrames = preciseScheduledCount_ + preciseDroppedCount_;
+            if (totalFrames % kHostPacedStatsLogIntervalFrames == 0) {
+                const PresentationTimingStats& timing =
+                    presentationDiagnostics_.GetStats();
+                OH_LOG_INFO(LOG_APP,
+                    "Host-paced stats: frames=%{public}lld, scheduled=%{public}lld, dropped=%{public}lld, late=%{public}lld, catchUp=%{public}lld, phaseShift=%{public}lld, rebuffer=%{public}lld, resync=%{public}lld, queueFull=%{public}lld, waitDrain=%{public}lld, apiFailure=%{public}lld, lead=%{public}lldus, maxLead=%{public}lldus, sameSlot=%{public}lld, slotRegression=%{public}lld, targetRegression=%{public}lld, maxRegression=%{public}lldus, maxQueueSlots=%{public}lld, vsyncPeriod=%{public}lldus, vsyncAge=%{public}lldus, vsyncSampleFailure=%{public}lld",
+                    static_cast<long long>(totalFrames),
+                    static_cast<long long>(preciseScheduledCount_),
+                    static_cast<long long>(preciseDroppedCount_),
+                    static_cast<long long>(preciseLateCount_),
+                    static_cast<long long>(preciseCatchUpCount_),
+                    static_cast<long long>(precisePhaseShiftCount_),
+                    static_cast<long long>(preciseRebufferCount_),
+                    static_cast<long long>(preciseResyncCount_),
+                    static_cast<long long>(preciseQueueFullCount_),
+                    static_cast<long long>(preciseWaitForDrainCount_),
+                    static_cast<long long>(preciseApiFailureCount_),
+                    static_cast<long long>(ptsScheduler_.GetInitialLeadNs() / 1000),
+                    static_cast<long long>(preciseMaxTargetLeadNs_ / 1000),
+                    static_cast<long long>(timing.sameVsyncSlotCount),
+                    static_cast<long long>(timing.vsyncSlotRegressionCount),
+                    static_cast<long long>(timing.targetRegressionCount),
+                    static_cast<long long>(timing.maxTargetRegressionNs / 1000),
+                    static_cast<long long>(timing.maxQueueDepthSlots),
+                    static_cast<long long>(observedVsyncPeriodNs / 1000),
+                    static_cast<long long>(observedVsyncNs > 0
+                        ? std::max<int64_t>(0, decodedAtNs - observedVsyncNs) / 1000
+                        : 0),
+                    static_cast<long long>(g_vsyncSampleRequestFailures.load(
+                        std::memory_order_relaxed)));
             }
 
             if (plan.action == PresentationAction::DROP) {
+                lock.unlock();
                 renderResult = freeFrame();
             } else {
                 renderResult = renderAtTime(
@@ -622,10 +632,7 @@ NativeRender::FrameSubmitResult NativeRender::SubmitFrame(const DecodedFrame& fr
                     bufferConsumed = true;
                     framePresented = true;
                 } else {
-                    {
-                        std::lock_guard<std::mutex> lock(presentationMutex_);
-                        preciseApiFailureCount_++;
-                    }
+                    preciseApiFailureCount_++;
                     OH_LOG_WARN(LOG_APP,
                         "Host-paced render failed: %{public}d, pts=%{public}lld, targetNs=%{public}lld; falling back",
                         renderResult, static_cast<long long>(frame.ptsUs),

--- a/nativelib/src/main/cpp/native_render.h
+++ b/nativelib/src/main/cpp/native_render.h
@@ -185,6 +185,8 @@ private:
     int64_t precisePhaseShiftCount_ = 0;
     int64_t preciseRebufferCount_ = 0;
     int64_t preciseResyncCount_ = 0;
+    int64_t preciseQueueFullCount_ = 0;
+    int64_t preciseWaitForDrainCount_ = 0;
     int64_t preciseApiFailureCount_ = 0;
     int64_t preciseMaxTargetLeadNs_ = 0;
     

--- a/nativelib/src/main/cpp/presentation_scheduler.cpp
+++ b/nativelib/src/main/cpp/presentation_scheduler.cpp
@@ -24,7 +24,30 @@ constexpr double kHighRefreshFps = kDefaultFps;
 constexpr double kNtscTripleBurstFps = 119.88;
 constexpr int64_t kDriftDeadbandNs = 2 * kNanosecondsPerMillisecond;
 constexpr int64_t kMaxDriftCorrectionPerFrameNs = 20 * kNanosecondsPerMicrosecond;
-constexpr int kSevereLateFramesBeforeRebuffer = 2;
+
+int64_t FloorDiv(int64_t value, int64_t divisor) {
+    int64_t quotient = value / divisor;
+    if (value % divisor < 0) {
+        quotient--;
+    }
+    return quotient;
+}
+
+int64_t CeilDiv(int64_t value, int64_t divisor) {
+    int64_t quotient = value / divisor;
+    if (value % divisor > 0) {
+        quotient++;
+    }
+    return quotient;
+}
+
+int64_t FloorToSlot(int64_t timeNs, int64_t anchorNs, int64_t periodNs) {
+    return anchorNs + FloorDiv(timeNs - anchorNs, periodNs) * periodNs;
+}
+
+int64_t CeilToSlot(int64_t timeNs, int64_t anchorNs, int64_t periodNs) {
+    return anchorNs + CeilDiv(timeNs - anchorNs, periodNs) * periodNs;
+}
 
 int64_t CalculateFutureCadenceBudgetNs(double fps, int64_t frameIntervalNs) {
     if (fps >= kNtscTripleBurstFps) {
@@ -62,24 +85,100 @@ void PtsPresentationScheduler::Reset() {
     lastPtsUs_ = 0;
     driftErrorEmaNs_ = 0;
     phaseShiftDebtNs_ = 0;
-    consecutiveSevereLateFrames_ = 0;
+    lastScheduledTargetNs_ = 0;
+    reanchorPending_ = false;
+    pendingReanchorEvent_ = PresentationEvent::CATCH_UP;
 }
 
 PresentationPlan PtsPresentationScheduler::AnchorFrame(
-        int64_t ptsUs, int64_t decodedAtNs, PresentationEvent event) {
+        int64_t ptsUs, int64_t decodedAtNs, PresentationEvent event,
+        const SlotClock& slotClock) {
     initialized_ = true;
     anchorPtsUs_ = ptsUs;
     anchorTargetNs_ = decodedAtNs + initialLeadNs_;
     lastPtsUs_ = ptsUs;
     driftErrorEmaNs_ = 0;
     phaseShiftDebtNs_ = 0;
-    consecutiveSevereLateFrames_ = 0;
+    reanchorPending_ = false;
+    pendingReanchorEvent_ = PresentationEvent::CATCH_UP;
+
+    return ScheduleTarget(anchorTargetNs_, decodedAtNs, event, 0, slotClock);
+}
+
+PresentationPlan PtsPresentationScheduler::ScheduleTarget(
+        int64_t targetTimeNs, int64_t decodedAtNs,
+        PresentationEvent event, int64_t latenessNs,
+        const SlotClock& slotClock) {
+    const int64_t requiredTargetNs = decodedAtNs + submitLeadNs_;
+    int64_t scheduledSlotNs = CeilToSlot(
+        std::max(targetTimeNs, requiredTargetNs),
+        slotClock.anchorNs, slotClock.periodNs);
+
+    if (lastScheduledTargetNs_ > 0) {
+        // Re-map the previous target when a real VSync sample first arrives or
+        // its phase changes, so two submissions still cannot share a latch.
+        const int64_t lastOccupiedSlotNs = CeilToSlot(
+            lastScheduledTargetNs_, slotClock.anchorNs, slotClock.periodNs);
+        if (scheduledSlotNs <= lastOccupiedSlotNs) {
+            scheduledSlotNs = lastOccupiedSlotNs + slotClock.periodNs;
+        }
+    }
+
+    // Start the existing cadence budget at the first slot that still has the
+    // submit margin. Being close to a VSync must not reduce burst capacity.
+    const int64_t firstEligibleSlotNs = CeilToSlot(
+        requiredTargetNs, slotClock.anchorNs, slotClock.periodNs);
+    const int64_t maxScheduledSlotNs = firstEligibleSlotNs +
+        GetAdditionalQueueSlots(slotClock.periodNs) * slotClock.periodNs;
+    if (scheduledSlotNs > maxScheduledSlotNs) {
+        reanchorPending_ = true;
+        pendingReanchorEvent_ = PresentationEvent::CATCH_UP;
+        PresentationPlan plan;
+        plan.event = PresentationEvent::QUEUE_FULL;
+        plan.latenessNs = latenessNs;
+        return plan;
+    }
+
+    lastScheduledTargetNs_ = scheduledSlotNs;
 
     PresentationPlan plan;
     plan.action = PresentationAction::SCHEDULE;
     plan.event = event;
-    plan.targetTimeNs = anchorTargetNs_;
+    plan.targetTimeNs = scheduledSlotNs;
+    plan.latenessNs = latenessNs;
     return plan;
+}
+
+PtsPresentationScheduler::SlotClock PtsPresentationScheduler::ResolveSlotClock(
+        int64_t decodedAtNs,
+        const PresentationVsyncTiming& vsyncTiming) const {
+    SlotClock clock;
+    clock.periodNs = vsyncTiming.periodNs > 0
+        ? vsyncTiming.periodNs
+        : frameIntervalNs_;
+    clock.anchorNs = vsyncTiming.timestampNs > 0
+        ? vsyncTiming.timestampNs
+        : 0;
+    clock.currentSlotNs = FloorToSlot(
+        decodedAtNs, clock.anchorNs, clock.periodNs);
+    return clock;
+}
+
+bool PtsPresentationScheduler::IsPresentationQueueEmpty(
+        const SlotClock& slotClock) const {
+    if (lastScheduledTargetNs_ <= 0) {
+        return true;
+    }
+    const int64_t lastOccupiedSlotNs = CeilToSlot(
+        lastScheduledTargetNs_, slotClock.anchorNs, slotClock.periodNs);
+    return lastOccupiedSlotNs <= slotClock.currentSlotNs;
+}
+
+int64_t PtsPresentationScheduler::GetAdditionalQueueSlots(
+        int64_t vsyncPeriodNs) const {
+    const int64_t cadenceBudgetNs = std::max<int64_t>(
+        0, maxFutureLeadNs_ - initialLeadNs_);
+    return cadenceBudgetNs / vsyncPeriodNs;
 }
 
 void PtsPresentationScheduler::ApplySlowDriftCorrection(
@@ -105,26 +204,62 @@ void PtsPresentationScheduler::ApplySlowDriftCorrection(
 
 PresentationPlan PtsPresentationScheduler::PlanFrame(
         int64_t ptsUs, int64_t decodedAtNs) {
+    return PlanFrame(ptsUs, decodedAtNs, {});
+}
+
+PresentationPlan PtsPresentationScheduler::PlanFrame(
+        int64_t ptsUs, int64_t decodedAtNs,
+        const PresentationVsyncTiming& vsyncTiming) {
     if (ptsUs < 0 || decodedAtNs <= 0) {
         PresentationPlan plan;
         plan.event = PresentationEvent::INVALID_PTS;
         return plan;
     }
 
+    const SlotClock slotClock = ResolveSlotClock(decodedAtNs, vsyncTiming);
+    const bool queueEmpty = IsPresentationQueueEmpty(slotClock);
+
+    if (reanchorPending_) {
+        if (queueEmpty) {
+            return AnchorFrame(
+                ptsUs, decodedAtNs, pendingReanchorEvent_, slotClock);
+        }
+        PresentationPlan plan;
+        plan.event = PresentationEvent::WAIT_FOR_DRAIN;
+        return plan;
+    }
+
     if (!initialized_) {
-        return AnchorFrame(ptsUs, decodedAtNs, PresentationEvent::INITIAL_ANCHOR);
+        return AnchorFrame(
+            ptsUs, decodedAtNs, PresentationEvent::INITIAL_ANCHOR, slotClock);
     }
 
     if (ptsUs == lastPtsUs_) {
         // A permanently repeated timestamp must not become a permanent DROP
         // state. Treat it as a broken host timeline and fall back to a fresh
         // local anchor until valid PTS progression resumes.
-        return AnchorFrame(ptsUs, decodedAtNs, PresentationEvent::DUPLICATE_PTS);
+        if (queueEmpty) {
+            return AnchorFrame(
+                ptsUs, decodedAtNs, PresentationEvent::DUPLICATE_PTS, slotClock);
+        }
+        reanchorPending_ = true;
+        pendingReanchorEvent_ = PresentationEvent::DUPLICATE_PTS;
+        PresentationPlan plan;
+        plan.event = PresentationEvent::WAIT_FOR_DRAIN;
+        return plan;
     }
 
     const int64_t ptsDeltaUs = ptsUs - lastPtsUs_;
     if (ptsDeltaUs < 0 || ptsDeltaUs > discontinuityNs_ / kNanosecondsPerMicrosecond) {
-        return AnchorFrame(ptsUs, decodedAtNs, PresentationEvent::DISCONTINUITY);
+        if (queueEmpty) {
+            return AnchorFrame(
+                ptsUs, decodedAtNs, PresentationEvent::DISCONTINUITY, slotClock);
+        }
+        reanchorPending_ = true;
+        pendingReanchorEvent_ = PresentationEvent::DISCONTINUITY;
+        PresentationPlan plan;
+        plan.event = PresentationEvent::WAIT_FOR_DRAIN;
+        return plan;
     }
     lastPtsUs_ = ptsUs;
 
@@ -137,36 +272,30 @@ PresentationPlan PtsPresentationScheduler::PlanFrame(
     // normal decoder output burst (which has no debt) for excessive queuing.
     const int64_t surplusLeadNs =
         targetTimeNs - decodedAtNs - initialLeadNs_;
-    if (phaseShiftDebtNs_ > 0 && surplusLeadNs > kDriftDeadbandNs) {
+    PresentationEvent event = PresentationEvent::NONE;
+    int64_t latenessNs = 0;
+    if (queueEmpty && phaseShiftDebtNs_ > 0 &&
+        surplusLeadNs > kDriftDeadbandNs) {
         const int64_t repaymentNs = std::min(phaseShiftDebtNs_, surplusLeadNs);
         anchorTargetNs_ -= repaymentNs;
         targetTimeNs -= repaymentNs;
         phaseShiftDebtNs_ -= repaymentNs;
         driftErrorEmaNs_ = 0;
-        consecutiveSevereLateFrames_ = 0;
-
-        if (targetTimeNs - decodedAtNs <= maxFutureLeadNs_) {
-            PresentationPlan plan;
-            plan.action = PresentationAction::SCHEDULE;
-            plan.event = PresentationEvent::PHASE_SHIFT;
-            plan.targetTimeNs = targetTimeNs;
-            plan.latenessNs = -repaymentNs;
-            return plan;
-        }
+        event = PresentationEvent::PHASE_SHIFT;
+        latenessNs = -repaymentNs;
     }
 
-    if (targetTimeNs - decodedAtNs > maxFutureLeadNs_) {
-        // This is not jitter absorbed by our own phase shift; it is decoded
-        // output arriving in a burst ahead of the presentation timeline. A
-        // fresh anchor gives all queued burst frames an immediate timestamp,
-        // so the Surface can keep the newest frame instead of preserving lag.
-        return AnchorFrame(ptsUs, decodedAtNs, PresentationEvent::CATCH_UP);
+    if (queueEmpty && targetTimeNs - decodedAtNs > maxFutureLeadNs_) {
+        return AnchorFrame(
+            ptsUs, decodedAtNs, PresentationEvent::CATCH_UP, slotClock);
     }
 
-    ApplySlowDriftCorrection(decodedAtNs, targetTimeNs);
+    if (queueEmpty) {
+        ApplySlowDriftCorrection(decodedAtNs, targetTimeNs);
+    }
 
     const int64_t requiredTargetNs = decodedAtNs + submitLeadNs_;
-    if (targetTimeNs < requiredTargetNs) {
+    if (queueEmpty && targetTimeNs < requiredTargetNs) {
         const int64_t latenessNs = requiredTargetNs - targetTimeNs;
         if (latenessNs <= frameIntervalNs_ / 2) {
             // Move the complete timeline forward. This keeps all following PTS
@@ -174,30 +303,16 @@ PresentationPlan PtsPresentationScheduler::PlanFrame(
             anchorTargetNs_ += latenessNs;
             phaseShiftDebtNs_ += latenessNs;
             driftErrorEmaNs_ = 0;
-            consecutiveSevereLateFrames_ = 0;
-
-            PresentationPlan plan;
-            plan.action = PresentationAction::SCHEDULE;
-            plan.event = PresentationEvent::PHASE_SHIFT;
-            plan.targetTimeNs = requiredTargetNs;
-            plan.latenessNs = latenessNs;
-            return plan;
+            event = PresentationEvent::PHASE_SHIFT;
+            targetTimeNs = requiredTargetNs;
+            return ScheduleTarget(
+                targetTimeNs, decodedAtNs, event, latenessNs, slotClock);
         }
 
-        consecutiveSevereLateFrames_++;
-        if (consecutiveSevereLateFrames_ >= kSevereLateFramesBeforeRebuffer) {
-            return AnchorFrame(ptsUs, decodedAtNs, PresentationEvent::REBUFFER);
-        }
-
-        PresentationPlan plan;
-        plan.event = PresentationEvent::LATE_DROP;
-        plan.latenessNs = latenessNs;
-        return plan;
+        return AnchorFrame(
+            ptsUs, decodedAtNs, PresentationEvent::REBUFFER, slotClock);
     }
 
-    consecutiveSevereLateFrames_ = 0;
-    PresentationPlan plan;
-    plan.action = PresentationAction::SCHEDULE;
-    plan.targetTimeNs = targetTimeNs;
-    return plan;
+    return ScheduleTarget(
+        targetTimeNs, decodedAtNs, event, latenessNs, slotClock);
 }

--- a/nativelib/src/main/cpp/presentation_scheduler.cpp
+++ b/nativelib/src/main/cpp/presentation_scheduler.cpp
@@ -24,6 +24,7 @@ constexpr double kHighRefreshFps = kDefaultFps;
 constexpr double kNtscTripleBurstFps = 119.88;
 constexpr int64_t kDriftDeadbandNs = 2 * kNanosecondsPerMillisecond;
 constexpr int64_t kMaxDriftCorrectionPerFrameNs = 20 * kNanosecondsPerMicrosecond;
+constexpr int kSevereLateFramesBeforeRebuffer = 2;
 
 int64_t FloorDiv(int64_t value, int64_t divisor) {
     int64_t quotient = value / divisor;
@@ -86,6 +87,7 @@ void PtsPresentationScheduler::Reset() {
     driftErrorEmaNs_ = 0;
     phaseShiftDebtNs_ = 0;
     lastScheduledTargetNs_ = 0;
+    consecutiveSevereLateFrames_ = 0;
     reanchorPending_ = false;
     pendingReanchorEvent_ = PresentationEvent::CATCH_UP;
 }
@@ -99,6 +101,7 @@ PresentationPlan PtsPresentationScheduler::AnchorFrame(
     lastPtsUs_ = ptsUs;
     driftErrorEmaNs_ = 0;
     phaseShiftDebtNs_ = 0;
+    consecutiveSevereLateFrames_ = 0;
     reanchorPending_ = false;
     pendingReanchorEvent_ = PresentationEvent::CATCH_UP;
 
@@ -303,16 +306,26 @@ PresentationPlan PtsPresentationScheduler::PlanFrame(
             anchorTargetNs_ += latenessNs;
             phaseShiftDebtNs_ += latenessNs;
             driftErrorEmaNs_ = 0;
+            consecutiveSevereLateFrames_ = 0;
             event = PresentationEvent::PHASE_SHIFT;
             targetTimeNs = requiredTargetNs;
             return ScheduleTarget(
                 targetTimeNs, decodedAtNs, event, latenessNs, slotClock);
         }
 
-        return AnchorFrame(
-            ptsUs, decodedAtNs, PresentationEvent::REBUFFER, slotClock);
+        consecutiveSevereLateFrames_++;
+        if (consecutiveSevereLateFrames_ >= kSevereLateFramesBeforeRebuffer) {
+            return AnchorFrame(
+                ptsUs, decodedAtNs, PresentationEvent::REBUFFER, slotClock);
+        }
+
+        PresentationPlan plan;
+        plan.event = PresentationEvent::LATE_DROP;
+        plan.latenessNs = latenessNs;
+        return plan;
     }
 
+    consecutiveSevereLateFrames_ = 0;
     return ScheduleTarget(
         targetTimeNs, decodedAtNs, event, latenessNs, slotClock);
 }

--- a/nativelib/src/main/cpp/presentation_scheduler.h
+++ b/nativelib/src/main/cpp/presentation_scheduler.h
@@ -27,6 +27,7 @@ enum class PresentationEvent {
     REBUFFER,
     DUPLICATE_PTS,
     INVALID_PTS,
+    LATE_DROP,
     QUEUE_FULL,
     WAIT_FOR_DRAIN,
 };
@@ -89,6 +90,7 @@ private:
     int64_t driftErrorEmaNs_ = 0;
     int64_t phaseShiftDebtNs_ = 0;
     int64_t lastScheduledTargetNs_ = 0;
+    int consecutiveSevereLateFrames_ = 0;
     bool reanchorPending_ = false;
     PresentationEvent pendingReanchorEvent_ = PresentationEvent::CATCH_UP;
 };

--- a/nativelib/src/main/cpp/presentation_scheduler.h
+++ b/nativelib/src/main/cpp/presentation_scheduler.h
@@ -27,7 +27,13 @@ enum class PresentationEvent {
     REBUFFER,
     DUPLICATE_PTS,
     INVALID_PTS,
-    LATE_DROP,
+    QUEUE_FULL,
+    WAIT_FOR_DRAIN,
+};
+
+struct PresentationVsyncTiming {
+    int64_t timestampNs = 0;
+    int64_t periodNs = 0;
 };
 
 struct PresentationPlan {
@@ -37,22 +43,38 @@ struct PresentationPlan {
     int64_t latenessNs = 0;
 };
 
-// Maps host PTS to a continuous local presentation timeline. Decoder output
-// arrival is used only for initial buffering and slow clock-drift correction;
-// it never replaces the PTS cadence on a normal frame.
+// Maps host PTS to a continuous local timeline, then assigns each submitted
+// frame a unique VSync slot. Decoder arrival never replaces normal PTS cadence.
 class PtsPresentationScheduler {
 public:
     void Configure(double fps);
     void Reset();
     PresentationPlan PlanFrame(int64_t ptsUs, int64_t decodedAtNs);
+    PresentationPlan PlanFrame(int64_t ptsUs, int64_t decodedAtNs,
+                               const PresentationVsyncTiming& vsyncTiming);
 
     int64_t GetInitialLeadNs() const { return initialLeadNs_; }
     int64_t GetMaxFutureLeadNs() const { return maxFutureLeadNs_; }
 
 private:
+    struct SlotClock {
+        int64_t anchorNs = 0;
+        int64_t periodNs = 0;
+        int64_t currentSlotNs = 0;
+    };
+
     PresentationPlan AnchorFrame(int64_t ptsUs, int64_t decodedAtNs,
-                                 PresentationEvent event);
+                                 PresentationEvent event,
+                                 const SlotClock& slotClock);
+    PresentationPlan ScheduleTarget(int64_t targetTimeNs, int64_t decodedAtNs,
+                                    PresentationEvent event, int64_t latenessNs,
+                                    const SlotClock& slotClock);
     void ApplySlowDriftCorrection(int64_t decodedAtNs, int64_t& targetTimeNs);
+    SlotClock ResolveSlotClock(
+        int64_t decodedAtNs,
+        const PresentationVsyncTiming& vsyncTiming) const;
+    bool IsPresentationQueueEmpty(const SlotClock& slotClock) const;
+    int64_t GetAdditionalQueueSlots(int64_t vsyncPeriodNs) const;
 
     int64_t frameIntervalNs_ = 16666667LL;
     int64_t initialLeadNs_ = 2000000LL;
@@ -66,7 +88,9 @@ private:
     int64_t lastPtsUs_ = 0;
     int64_t driftErrorEmaNs_ = 0;
     int64_t phaseShiftDebtNs_ = 0;
-    int consecutiveSevereLateFrames_ = 0;
+    int64_t lastScheduledTargetNs_ = 0;
+    bool reanchorPending_ = false;
+    PresentationEvent pendingReanchorEvent_ = PresentationEvent::CATCH_UP;
 };
 
 #endif // PRESENTATION_SCHEDULER_H

--- a/nativelib/src/test/cpp/presentation_scheduler_test.cpp
+++ b/nativelib/src/test/cpp/presentation_scheduler_test.cpp
@@ -3,7 +3,6 @@
 #include <cassert>
 #include <cmath>
 #include <cstdint>
-#include <cstdlib>
 #include <iostream>
 
 namespace {
@@ -18,17 +17,25 @@ int64_t FrameIntervalNs(double fps) {
         std::llround(static_cast<double>(kNanosecondsPerSecond) / fps));
 }
 
+PresentationVsyncTiming Timing(double refreshRate) {
+    return {kStartNs, FrameIntervalNs(refreshRate)};
+}
+
+void AssertOnVsyncSlot(
+        const PresentationPlan& plan,
+        const PresentationVsyncTiming& timing) {
+    assert(plan.action == PresentationAction::SCHEDULE);
+    assert((plan.targetTimeNs - timing.timestampNs) % timing.periodNs == 0);
+}
+
 void AssertFutureCadenceBudget(double fps, int numerator, int denominator) {
     PtsPresentationScheduler scheduler;
     scheduler.Configure(fps);
 
-    const PresentationPlan first = scheduler.PlanFrame(0, kStartNs);
     const int64_t expectedCadenceBudgetNs =
         FrameIntervalNs(fps) * numerator / denominator;
 
-    assert(first.action == PresentationAction::SCHEDULE);
     assert(scheduler.GetInitialLeadNs() == kExpectedSubmitLeadNs);
-    assert(first.targetTimeNs - kStartNs == kExpectedSubmitLeadNs);
     assert(scheduler.GetMaxFutureLeadNs() ==
         kExpectedSubmitLeadNs + expectedCadenceBudgetNs +
         kNanosecondsPerMicrosecond);
@@ -45,212 +52,224 @@ void TestRefreshRateTierBudgets() {
     AssertFutureCadenceBudget(144.0, 2, 1);
 }
 
-void Test120FpsTripleBurstKeepsPtsCadence() {
+void Test120FpsBurstUsesThreeUniqueSlots() {
     PtsPresentationScheduler scheduler;
     scheduler.Configure(120.0);
+    const PresentationVsyncTiming timing = Timing(120.0);
+    const int64_t decodedAtNs = kStartNs + kMs;
 
-    const PresentationPlan first = scheduler.PlanFrame(0, kStartNs);
-    const PresentationPlan second = scheduler.PlanFrame(8334, kStartNs);
-    const PresentationPlan third = scheduler.PlanFrame(16667, kStartNs + kMs);
-    const PresentationPlan fourth = scheduler.PlanFrame(25000, kStartNs + kMs);
+    const PresentationPlan first = scheduler.PlanFrame(0, decodedAtNs, timing);
+    const PresentationPlan second = scheduler.PlanFrame(8334, decodedAtNs, timing);
+    const PresentationPlan third = scheduler.PlanFrame(16667, decodedAtNs, timing);
+    const PresentationPlan fourth = scheduler.PlanFrame(25000, decodedAtNs, timing);
 
-    assert(first.action == PresentationAction::SCHEDULE);
-    assert(second.action == PresentationAction::SCHEDULE);
-    assert(third.action == PresentationAction::SCHEDULE);
-    assert(fourth.action == PresentationAction::SCHEDULE);
-    assert(second.event == PresentationEvent::NONE);
-    assert(third.event == PresentationEvent::NONE);
-    assert(fourth.event == PresentationEvent::CATCH_UP);
-    assert(second.targetTimeNs - first.targetTimeNs ==
-        8334 * kNanosecondsPerMicrosecond);
-    assert(third.targetTimeNs - second.targetTimeNs ==
-        8333 * kNanosecondsPerMicrosecond);
-    assert(fourth.targetTimeNs - (kStartNs + kMs) ==
-        scheduler.GetInitialLeadNs());
+    AssertOnVsyncSlot(first, timing);
+    AssertOnVsyncSlot(second, timing);
+    AssertOnVsyncSlot(third, timing);
+    assert(second.targetTimeNs - first.targetTimeNs == timing.periodNs);
+    assert(third.targetTimeNs - second.targetTimeNs == timing.periodNs);
+    assert(fourth.action == PresentationAction::DROP);
+    assert(fourth.event == PresentationEvent::QUEUE_FULL);
 }
 
-void Test90FpsPairBurstKeepsSingleFrameBudget() {
+void TestQueueFullWaitsForDrainBeforeReanchor() {
+    PtsPresentationScheduler scheduler;
+    scheduler.Configure(120.0);
+    const PresentationVsyncTiming timing = Timing(120.0);
+    const int64_t burstTimeNs = kStartNs + kMs;
+
+    const PresentationPlan first = scheduler.PlanFrame(0, burstTimeNs, timing);
+    scheduler.PlanFrame(8334, burstTimeNs, timing);
+    const PresentationPlan third = scheduler.PlanFrame(16667, burstTimeNs, timing);
+    const PresentationPlan full = scheduler.PlanFrame(25000, burstTimeNs, timing);
+    const PresentationPlan waiting = scheduler.PlanFrame(
+        33333, first.targetTimeNs + kMs, timing);
+    const PresentationPlan recovered = scheduler.PlanFrame(
+        41667, third.targetTimeNs + kMs, timing);
+
+    assert(full.event == PresentationEvent::QUEUE_FULL);
+    assert(waiting.action == PresentationAction::DROP);
+    assert(waiting.event == PresentationEvent::WAIT_FOR_DRAIN);
+    assert(recovered.action == PresentationAction::SCHEDULE);
+    assert(recovered.event == PresentationEvent::CATCH_UP);
+    assert(recovered.targetTimeNs == third.targetTimeNs + timing.periodNs);
+}
+
+void Test90FpsPairBurstUsesTwoSlots() {
     PtsPresentationScheduler scheduler;
     scheduler.Configure(90.0);
+    const PresentationVsyncTiming timing = Timing(90.0);
+    const int64_t decodedAtNs = kStartNs + kMs;
 
-    const PresentationPlan first = scheduler.PlanFrame(0, kStartNs);
-    const PresentationPlan second = scheduler.PlanFrame(11111, kStartNs);
-    const PresentationPlan third = scheduler.PlanFrame(22222, kStartNs + kMs);
+    const PresentationPlan first = scheduler.PlanFrame(0, decodedAtNs, timing);
+    const PresentationPlan second = scheduler.PlanFrame(11111, decodedAtNs, timing);
+    const PresentationPlan third = scheduler.PlanFrame(22222, decodedAtNs, timing);
 
-    assert(first.action == PresentationAction::SCHEDULE);
-    assert(second.action == PresentationAction::SCHEDULE);
-    assert(third.action == PresentationAction::SCHEDULE);
-    assert(second.event == PresentationEvent::NONE);
-    assert(third.event == PresentationEvent::CATCH_UP);
+    AssertOnVsyncSlot(first, timing);
+    AssertOnVsyncSlot(second, timing);
+    assert(second.targetTimeNs - first.targetTimeNs == timing.periodNs);
+    assert(third.action == PresentationAction::DROP);
+    assert(third.event == PresentationEvent::QUEUE_FULL);
 }
 
-void AssertLowRefreshBurstCatchesUp(double fps, int64_t framePtsUs) {
+void Test60FpsDoesNotGrowPresentationQueue() {
     PtsPresentationScheduler scheduler;
-    scheduler.Configure(fps);
+    scheduler.Configure(60.0);
+    const PresentationVsyncTiming timing = Timing(60.0);
+    const int64_t decodedAtNs = kStartNs + kMs;
 
-    const PresentationPlan first = scheduler.PlanFrame(0, kStartNs);
-    const PresentationPlan burst = scheduler.PlanFrame(framePtsUs, kStartNs);
+    const PresentationPlan first = scheduler.PlanFrame(0, decodedAtNs, timing);
+    const PresentationPlan burst = scheduler.PlanFrame(16667, decodedAtNs, timing);
+    const PresentationPlan recovered = scheduler.PlanFrame(
+        33333, first.targetTimeNs + kMs, timing);
 
-    assert(first.action == PresentationAction::SCHEDULE);
-    assert(burst.action == PresentationAction::SCHEDULE);
-    assert(burst.event == PresentationEvent::CATCH_UP);
-    assert(burst.targetTimeNs - kStartNs == scheduler.GetInitialLeadNs());
-}
-
-void TestLowRefreshBurstKeepsHalfFrameBudget() {
-    AssertLowRefreshBurstCatchesUp(30.0, 33333);
-    AssertLowRefreshBurstCatchesUp(60.0, 16667);
+    AssertOnVsyncSlot(first, timing);
+    assert(burst.action == PresentationAction::DROP);
+    assert(burst.event == PresentationEvent::QUEUE_FULL);
+    assert(recovered.action == PresentationAction::SCHEDULE);
+    assert(recovered.event == PresentationEvent::CATCH_UP);
+    assert(recovered.targetTimeNs == first.targetTimeNs + timing.periodNs);
 }
 
 void TestSmallLateFrameShiftsWholeTimeline() {
     PtsPresentationScheduler scheduler;
     scheduler.Configure(60.0);
+    const PresentationVsyncTiming timing = Timing(60.0);
 
-    const PresentationPlan first = scheduler.PlanFrame(0, kStartNs);
-    const PresentationPlan shifted = scheduler.PlanFrame(16667, 1018 * kMs);
-    const PresentationPlan next = scheduler.PlanFrame(33333, 1034 * kMs);
+    const PresentationPlan first = scheduler.PlanFrame(
+        0, kStartNs + kMs, timing);
+    const PresentationPlan shifted = scheduler.PlanFrame(
+        16667, kStartNs + 18 * kMs, timing);
+    const PresentationPlan next = scheduler.PlanFrame(
+        33333, kStartNs + 34 * kMs, timing);
 
     assert(shifted.action == PresentationAction::SCHEDULE);
     assert(shifted.event == PresentationEvent::PHASE_SHIFT);
     assert(next.action == PresentationAction::SCHEDULE);
-    assert(next.targetTimeNs - shifted.targetTimeNs == 16666000LL);
-    assert(shifted.targetTimeNs >= 1020 * kMs);
     assert(first.targetTimeNs < shifted.targetTimeNs);
+    assert(next.targetTimeNs - shifted.targetTimeNs == timing.periodNs);
 }
 
-void TestSevereLateDropThenRebuffer() {
+void TestSevereLateFrameRebuffersAfterDrain() {
     PtsPresentationScheduler scheduler;
     scheduler.Configure(60.0);
+    const PresentationVsyncTiming timing = Timing(60.0);
 
-    scheduler.PlanFrame(0, kStartNs);
-    const PresentationPlan dropped = scheduler.PlanFrame(16667, 1100 * kMs);
-    const PresentationPlan rebuffered = scheduler.PlanFrame(33333, 1101 * kMs);
+    scheduler.PlanFrame(0, kStartNs + kMs, timing);
+    const PresentationPlan rebuffered = scheduler.PlanFrame(
+        16667, kStartNs + 100 * kMs, timing);
 
-    assert(dropped.action == PresentationAction::DROP);
-    assert(dropped.event == PresentationEvent::LATE_DROP);
     assert(rebuffered.action == PresentationAction::SCHEDULE);
     assert(rebuffered.event == PresentationEvent::REBUFFER);
-    assert(rebuffered.targetTimeNs > 1101 * kMs);
+    assert(rebuffered.targetTimeNs > kStartNs + 100 * kMs);
 }
 
-void TestAccumulatedPhaseShiftRecoversQuickly() {
+void TestDiscontinuityWaitsForQueuedSlot() {
+    PtsPresentationScheduler scheduler;
+    scheduler.Configure(120.0);
+    const PresentationVsyncTiming timing = Timing(120.0);
+    const int64_t decodedAtNs = kStartNs + kMs;
+
+    const PresentationPlan first = scheduler.PlanFrame(1000000, decodedAtNs, timing);
+    const PresentationPlan waiting = scheduler.PlanFrame(500000, decodedAtNs, timing);
+    const PresentationPlan reanchored = scheduler.PlanFrame(
+        500001, first.targetTimeNs + kMs, timing);
+
+    assert(waiting.action == PresentationAction::DROP);
+    assert(waiting.event == PresentationEvent::WAIT_FOR_DRAIN);
+    assert(reanchored.action == PresentationAction::SCHEDULE);
+    assert(reanchored.event == PresentationEvent::DISCONTINUITY);
+    assert(reanchored.targetTimeNs == first.targetTimeNs + timing.periodNs);
+}
+
+void TestDuplicatePtsRecoversAfterQueuedSlot() {
     PtsPresentationScheduler scheduler;
     scheduler.Configure(60.0);
+    const PresentationVsyncTiming timing = Timing(60.0);
+    const int64_t decodedAtNs = kStartNs + kMs;
 
-    constexpr int64_t kFrameUs = 16667;
-    scheduler.PlanFrame(0, kStartNs);
+    const PresentationPlan first = scheduler.PlanFrame(1000, decodedAtNs, timing);
+    const PresentationPlan waiting = scheduler.PlanFrame(1000, decodedAtNs, timing);
+    const PresentationPlan reanchored = scheduler.PlanFrame(
+        1000, first.targetTimeNs + kMs, timing);
 
-    int phaseShiftCount = 0;
-    for (int i = 1; i <= 12; ++i) {
-        const int64_t ptsUs = i * kFrameUs;
-        const int64_t nominalDecodeNs =
-            kStartNs + ptsUs * kNanosecondsPerMicrosecond;
-        const int64_t rampDelayNs = (3 + (i - 1) * 6) * kMs;
-        const PresentationPlan delayed = scheduler.PlanFrame(
-            ptsUs, nominalDecodeNs + rampDelayNs);
-        assert(delayed.action == PresentationAction::SCHEDULE);
-        if (delayed.event == PresentationEvent::PHASE_SHIFT) {
-            phaseShiftCount++;
-        }
+    assert(waiting.action == PresentationAction::DROP);
+    assert(waiting.event == PresentationEvent::WAIT_FOR_DRAIN);
+    assert(reanchored.action == PresentationAction::SCHEDULE);
+    assert(reanchored.event == PresentationEvent::DUPLICATE_PTS);
+}
+
+void TestNtscCadenceSkipsARealSlotWithoutRegression() {
+    PtsPresentationScheduler scheduler;
+    scheduler.Configure(119.88);
+    const PresentationVsyncTiming timing = Timing(120.0);
+    constexpr double kPtsIntervalUs = 1000000.0 / 119.88;
+    const int64_t firstDecodedAtNs = kStartNs + kMs;
+
+    PresentationPlan previous = scheduler.PlanFrame(
+        0, firstDecodedAtNs, timing);
+    bool skippedSlot = false;
+    for (int i = 1; i <= 2500; ++i) {
+        const int64_t ptsUs = static_cast<int64_t>(
+            std::llround(i * kPtsIntervalUs));
+        const int64_t decodedAtNs =
+            firstDecodedAtNs + ptsUs * kNanosecondsPerMicrosecond;
+        const PresentationPlan current = scheduler.PlanFrame(
+            ptsUs, decodedAtNs, timing);
+
+        AssertOnVsyncSlot(current, timing);
+        assert(current.targetTimeNs > previous.targetTimeNs);
+        const int64_t slotDelta =
+            (current.targetTimeNs - previous.targetTimeNs) / timing.periodNs;
+        assert(slotDelta == 1 || slotDelta == 2);
+        skippedSlot = skippedSlot || slotDelta == 2;
+        previous = current;
     }
-    assert(phaseShiftCount >= 10);
-
-    const int64_t recoveredPtsUs = 13 * kFrameUs;
-    const int64_t recoveredDecodeNs =
-        kStartNs + recoveredPtsUs * kNanosecondsPerMicrosecond;
-    const PresentationPlan recovered = scheduler.PlanFrame(
-        recoveredPtsUs, recoveredDecodeNs);
-
-    assert(recovered.action == PresentationAction::SCHEDULE);
-    assert(recovered.event == PresentationEvent::PHASE_SHIFT);
-    assert(recovered.latenessNs < 0);
-    assert(std::llabs((recovered.targetTimeNs - recoveredDecodeNs) -
-                      scheduler.GetInitialLeadNs()) < kMs);
-
-    const int64_t nextPtsUs = 14 * kFrameUs;
-    const int64_t nextDecodeNs =
-        kStartNs + nextPtsUs * kNanosecondsPerMicrosecond;
-    const PresentationPlan next = scheduler.PlanFrame(nextPtsUs, nextDecodeNs);
-    assert(next.action == PresentationAction::SCHEDULE);
-    assert(std::llabs((next.targetTimeNs - recovered.targetTimeNs) -
-                      kFrameUs * kNanosecondsPerMicrosecond) < kMs);
+    assert(skippedSlot);
 }
 
-void TestBurstCatchesUpAfterPartialPhaseDebtRepayment() {
+void TestObservedVsyncPhaseCannotReuseFallbackSlot() {
+    PtsPresentationScheduler scheduler;
+    scheduler.Configure(120.0);
+    const int64_t decodedAtNs = kStartNs + kMs;
+
+    const PresentationPlan fallback = scheduler.PlanFrame(0, decodedAtNs);
+    const PresentationVsyncTiming observed = {
+        kStartNs + 3 * kMs, FrameIntervalNs(120.0)};
+    const PresentationPlan phased = scheduler.PlanFrame(
+        8334, decodedAtNs, observed);
+
+    AssertOnVsyncSlot(phased, observed);
+    const int64_t fallbackOccupiedSlot = observed.timestampNs +
+        static_cast<int64_t>(std::ceil(
+            static_cast<double>(fallback.targetTimeNs - observed.timestampNs) /
+            static_cast<double>(observed.periodNs))) * observed.periodNs;
+    assert(phased.targetTimeNs > fallbackOccupiedSlot);
+}
+
+void TestInvalidPtsDropsWithoutScheduling() {
     PtsPresentationScheduler scheduler;
     scheduler.Configure(60.0);
 
-    scheduler.PlanFrame(0, kStartNs);
-    const PresentationPlan shifted = scheduler.PlanFrame(16667, 1022 * kMs);
-    const PresentationPlan burst = scheduler.PlanFrame(50000, 1023 * kMs);
-
-    assert(shifted.event == PresentationEvent::PHASE_SHIFT);
-    assert(burst.action == PresentationAction::SCHEDULE);
-    assert(burst.event == PresentationEvent::CATCH_UP);
-    assert(burst.targetTimeNs - 1023 * kMs == scheduler.GetInitialLeadNs());
-}
-
-void TestDuplicatePtsReanchorsInsteadOfFreezing() {
-    PtsPresentationScheduler scheduler;
-    scheduler.Configure(60.0);
-
-    scheduler.PlanFrame(1000, 1000 * kMs);
-    const PresentationPlan firstDuplicate = scheduler.PlanFrame(1000, 1017 * kMs);
-    const PresentationPlan secondDuplicate = scheduler.PlanFrame(1000, 1034 * kMs);
-
-    assert(firstDuplicate.action == PresentationAction::SCHEDULE);
-    assert(firstDuplicate.event == PresentationEvent::DUPLICATE_PTS);
-    assert(secondDuplicate.action == PresentationAction::SCHEDULE);
-    assert(secondDuplicate.event == PresentationEvent::DUPLICATE_PTS);
-    assert(secondDuplicate.targetTimeNs > firstDuplicate.targetTimeNs);
-}
-
-void TestDiscontinuityReanchors() {
-    PtsPresentationScheduler scheduler;
-    scheduler.Configure(59.94);
-
-    scheduler.PlanFrame(1000000, 2000 * kMs);
-    const PresentationPlan discontinuity = scheduler.PlanFrame(500000, 2010 * kMs);
-
-    assert(discontinuity.action == PresentationAction::SCHEDULE);
-    assert(discontinuity.event == PresentationEvent::DISCONTINUITY);
-}
-
-void TestSlowClockDriftStaysBounded() {
-    PtsPresentationScheduler scheduler;
-    scheduler.Configure(60.0);
-
-    constexpr double kPtsIntervalUs = 1000000.0 / 60.0;
-    constexpr double kFastLocalIntervalNs = 1000000000.0 / 60.0 * (1.0 - 0.0001);
-    scheduler.PlanFrame(0, kStartNs);
-
-    PresentationPlan plan;
-    int64_t decodedAtNs = kStartNs;
-    for (int i = 1; i <= 20000; ++i) {
-        const int64_t ptsUs = static_cast<int64_t>(std::llround(i * kPtsIntervalUs));
-        decodedAtNs = kStartNs + static_cast<int64_t>(std::llround(i * kFastLocalIntervalNs));
-        plan = scheduler.PlanFrame(ptsUs, decodedAtNs);
-        assert(plan.action == PresentationAction::SCHEDULE);
-    }
-
-    const int64_t finalLeadNs = plan.targetTimeNs - decodedAtNs;
-    const int64_t expectedLeadNs = scheduler.GetInitialLeadNs();
-    assert(std::llabs(finalLeadNs - expectedLeadNs) < 5 * kMs);
+    const PresentationPlan invalid = scheduler.PlanFrame(-1, kStartNs);
+    assert(invalid.action == PresentationAction::DROP);
+    assert(invalid.event == PresentationEvent::INVALID_PTS);
 }
 } // namespace
 
 int main() {
     TestRefreshRateTierBudgets();
-    Test120FpsTripleBurstKeepsPtsCadence();
-    Test90FpsPairBurstKeepsSingleFrameBudget();
-    TestLowRefreshBurstKeepsHalfFrameBudget();
+    Test120FpsBurstUsesThreeUniqueSlots();
+    TestQueueFullWaitsForDrainBeforeReanchor();
+    Test90FpsPairBurstUsesTwoSlots();
+    Test60FpsDoesNotGrowPresentationQueue();
     TestSmallLateFrameShiftsWholeTimeline();
-    TestSevereLateDropThenRebuffer();
-    TestAccumulatedPhaseShiftRecoversQuickly();
-    TestBurstCatchesUpAfterPartialPhaseDebtRepayment();
-    TestDuplicatePtsReanchorsInsteadOfFreezing();
-    TestDiscontinuityReanchors();
-    TestSlowClockDriftStaysBounded();
+    TestSevereLateFrameRebuffersAfterDrain();
+    TestDiscontinuityWaitsForQueuedSlot();
+    TestDuplicatePtsRecoversAfterQueuedSlot();
+    TestNtscCadenceSkipsARealSlotWithoutRegression();
+    TestObservedVsyncPhaseCannotReuseFallbackSlot();
+    TestInvalidPtsDropsWithoutScheduling();
     std::cout << "presentation scheduler tests passed\n";
     return 0;
 }

--- a/nativelib/src/test/cpp/presentation_scheduler_test.cpp
+++ b/nativelib/src/test/cpp/presentation_scheduler_test.cpp
@@ -150,15 +150,19 @@ void TestSmallLateFrameShiftsWholeTimeline() {
     assert(next.targetTimeNs - shifted.targetTimeNs == timing.periodNs);
 }
 
-void TestSevereLateFrameRebuffersAfterDrain() {
+void TestSevereLateFrameDropsBeforeRebuffer() {
     PtsPresentationScheduler scheduler;
     scheduler.Configure(60.0);
     const PresentationVsyncTiming timing = Timing(60.0);
 
     scheduler.PlanFrame(0, kStartNs + kMs, timing);
-    const PresentationPlan rebuffered = scheduler.PlanFrame(
+    const PresentationPlan dropped = scheduler.PlanFrame(
         16667, kStartNs + 100 * kMs, timing);
+    const PresentationPlan rebuffered = scheduler.PlanFrame(
+        33333, kStartNs + 101 * kMs, timing);
 
+    assert(dropped.action == PresentationAction::DROP);
+    assert(dropped.event == PresentationEvent::LATE_DROP);
     assert(rebuffered.action == PresentationAction::SCHEDULE);
     assert(rebuffered.event == PresentationEvent::REBUFFER);
     assert(rebuffered.targetTimeNs > kStartNs + 100 * kMs);
@@ -264,7 +268,7 @@ int main() {
     Test90FpsPairBurstUsesTwoSlots();
     Test60FpsDoesNotGrowPresentationQueue();
     TestSmallLateFrameShiftsWholeTimeline();
-    TestSevereLateFrameRebuffersAfterDrain();
+    TestSevereLateFrameDropsBeforeRebuffer();
     TestDiscontinuityWaitsForQueuedSlot();
     TestDuplicatePtsRecoversAfterQueuedSlot();
     TestNtscCadenceSkipsARealSlotWithoutRegression();


### PR DESCRIPTION
## 改了啥呀

- 将 host PTS 理想时间映射到 NativeVSync 的真实槽位
- 保证每个已提交帧占用唯一槽位，目标时间严格单调
- 解码突发超出既有余量时在进入 Surface 前丢弃，并等队列排空后再重锚
- 串行化计划与 `RenderOutputBufferAtTime`，避免并发回调颠倒提交顺序
- 增加 `queueFull` / `waitDrain` 观测以及 60/90/120 Hz、119.88 NTSC 测试

## 为啥要改

以前 `CATCH_UP` 会在 Surface 里已有未来帧时生成更早的目标时间。Surface 又不能倒车，于是这些杂鱼式倒退时间戳会变成同槽覆盖、排队和粘滞。现在只在已提交槽位排空后重锚，不扩大原有节拍余量。

这是基于 #66 的堆叠 PR；#66 继续保持纯观测，方便分别 review。

## 验证

- `presentation_scheduler_test`（含 120 Hz 三帧突发、排空重锚、119.88 NTSC）
- `presentation_observability_test`
- `npm run check`
- `node hvigorw.js assembleApp --mode project -p product=default -p buildMode=debug --no-daemon --stacktrace`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 优化了视频帧呈现调度，更准确地结合实际 VSync 时序，提升不同刷新率下的播放稳定性与帧间一致性。
  - 改善了队列繁忙、等待排空、时间不连续及重复时间戳等场景的处理，减少卡顿、异常丢帧和时序偏移。
  - 增强了追帧、重新同步及无效时间戳处理，提升长时间播放的可靠性。

- **测试**
  - 扩展了多种刷新率、队列状态和异常播放场景的验证覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->