### PR TITLE
fix(render): keep one frame of PTS headroom

### DIFF
--- a/nativelib/src/main/cpp/presentation_scheduler.cpp
+++ b/nativelib/src/main/cpp/presentation_scheduler.cpp
@@ -67,10 +67,11 @@ void PtsPresentationScheduler::Configure(double fps) {
         std::llround(static_cast<double>(kNanosecondsPerSecond) / safeFps));
     frameIntervalNs_ = std::max<int64_t>(frameIntervalNs_, 1000000LL);
     // RenderService needs an absolute latch margin that does not shrink with
-    // the stream frame interval. Keep steady-state lead small, but large enough
-    // for 120 Hz submission overhead.
+    // the stream frame interval. Host-paced presentation also keeps one full
+    // stream frame decoded ahead so normal decoder jitter does not immediately
+    // miss a VSync slot.
     submitLeadNs_ = kSubmitLeadNs;
-    initialLeadNs_ = submitLeadNs_;
+    initialLeadNs_ = submitLeadNs_ + frameIntervalNs_;
     maxFutureLeadNs_ = initialLeadNs_ +
         CalculateFutureCadenceBudgetNs(safeFps, frameIntervalNs_) +
         kPtsQuantizationSlackNs;
@@ -127,8 +128,8 @@ PresentationPlan PtsPresentationScheduler::ScheduleTarget(
         }
     }
 
-    // Start the existing cadence budget at the first slot that still has the
-    // submit margin. Being close to a VSync must not reduce burst capacity.
+    // Start the queue budget at the first slot that still has the submit
+    // margin. Being close to a VSync must not reduce burst capacity.
     const int64_t firstEligibleSlotNs = CeilToSlot(
         requiredTargetNs, slotClock.anchorNs, slotClock.periodNs);
     const int64_t maxScheduledSlotNs = firstEligibleSlotNs +
@@ -179,9 +180,12 @@ bool PtsPresentationScheduler::IsPresentationQueueEmpty(
 
 int64_t PtsPresentationScheduler::GetAdditionalQueueSlots(
         int64_t vsyncPeriodNs) const {
-    const int64_t cadenceBudgetNs = std::max<int64_t>(
-        0, maxFutureLeadNs_ - initialLeadNs_);
-    return cadenceBudgetNs / vsyncPeriodNs;
+    // Count from the first slot that satisfies the RenderService submit margin.
+    // This includes the one-frame playout reserve plus the existing burst
+    // budget, so adding the reserve does not reduce burst capacity.
+    const int64_t queueLeadNs = std::max<int64_t>(
+        0, maxFutureLeadNs_ - submitLeadNs_);
+    return queueLeadNs / vsyncPeriodNs;
 }
 
 void PtsPresentationScheduler::ApplySlowDriftCorrection(

--- a/nativelib/src/main/cpp/presentation_scheduler.h
+++ b/nativelib/src/main/cpp/presentation_scheduler.h
@@ -78,9 +78,9 @@ private:
     int64_t GetAdditionalQueueSlots(int64_t vsyncPeriodNs) const;
 
     int64_t frameIntervalNs_ = 16666667LL;
-    int64_t initialLeadNs_ = 2000000LL;
+    int64_t initialLeadNs_ = 18666667LL;
     int64_t submitLeadNs_ = 2000000LL;
-    int64_t maxFutureLeadNs_ = 10334333LL;
+    int64_t maxFutureLeadNs_ = 27001000LL;
     int64_t discontinuityNs_ = 250000000LL;
 
     bool initialized_ = false;

--- a/nativelib/src/test/cpp/presentation_scheduler_test.cpp
+++ b/nativelib/src/test/cpp/presentation_scheduler_test.cpp
@@ -35,9 +35,11 @@ void AssertFutureCadenceBudget(double fps, int numerator, int denominator) {
     const int64_t expectedCadenceBudgetNs =
         FrameIntervalNs(fps) * numerator / denominator;
 
-    assert(scheduler.GetInitialLeadNs() == kExpectedSubmitLeadNs);
+    const int64_t expectedInitialLeadNs =
+        kExpectedSubmitLeadNs + FrameIntervalNs(fps);
+    assert(scheduler.GetInitialLeadNs() == expectedInitialLeadNs);
     assert(scheduler.GetMaxFutureLeadNs() ==
-        kExpectedSubmitLeadNs + expectedCadenceBudgetNs +
+        expectedInitialLeadNs + expectedCadenceBudgetNs +
         kNanosecondsPerMicrosecond);
 }
 
@@ -50,6 +52,25 @@ void TestRefreshRateTierBudgets() {
     AssertFutureCadenceBudget(119.88, 2, 1);
     AssertFutureCadenceBudget(120.0, 2, 1);
     AssertFutureCadenceBudget(144.0, 2, 1);
+}
+
+void TestOneFrameReserveAbsorbsSubFrameDecodeJitter() {
+    PtsPresentationScheduler scheduler;
+    scheduler.Configure(120.0);
+    const PresentationVsyncTiming timing = Timing(120.0);
+    const int64_t firstDecodedAtNs = kStartNs + kMs;
+
+    const PresentationPlan first = scheduler.PlanFrame(
+        0, firstDecodedAtNs, timing);
+    const PresentationPlan jittered = scheduler.PlanFrame(
+        8334, firstDecodedAtNs + timing.periodNs + 5 * kMs, timing);
+    const int64_t firstEligibleSlotNs = kStartNs + timing.periodNs;
+
+    AssertOnVsyncSlot(first, timing);
+    AssertOnVsyncSlot(jittered, timing);
+    assert(first.targetTimeNs == firstEligibleSlotNs + timing.periodNs);
+    assert(jittered.event == PresentationEvent::NONE);
+    assert(jittered.targetTimeNs == first.targetTimeNs + timing.periodNs);
 }
 
 void Test120FpsBurstUsesThreeUniqueSlots() {
@@ -92,7 +113,7 @@ void TestQueueFullWaitsForDrainBeforeReanchor() {
     assert(waiting.event == PresentationEvent::WAIT_FOR_DRAIN);
     assert(recovered.action == PresentationAction::SCHEDULE);
     assert(recovered.event == PresentationEvent::CATCH_UP);
-    assert(recovered.targetTimeNs == third.targetTimeNs + timing.periodNs);
+    assert(recovered.targetTimeNs == third.targetTimeNs + 2 * timing.periodNs);
 }
 
 void Test90FpsPairBurstUsesTwoSlots() {
@@ -128,7 +149,7 @@ void Test60FpsDoesNotGrowPresentationQueue() {
     assert(burst.event == PresentationEvent::QUEUE_FULL);
     assert(recovered.action == PresentationAction::SCHEDULE);
     assert(recovered.event == PresentationEvent::CATCH_UP);
-    assert(recovered.targetTimeNs == first.targetTimeNs + timing.periodNs);
+    assert(recovered.targetTimeNs == first.targetTimeNs + 2 * timing.periodNs);
 }
 
 void TestSmallLateFrameShiftsWholeTimeline() {
@@ -139,9 +160,9 @@ void TestSmallLateFrameShiftsWholeTimeline() {
     const PresentationPlan first = scheduler.PlanFrame(
         0, kStartNs + kMs, timing);
     const PresentationPlan shifted = scheduler.PlanFrame(
-        16667, kStartNs + 18 * kMs, timing);
+        16667, kStartNs + 35 * kMs, timing);
     const PresentationPlan next = scheduler.PlanFrame(
-        33333, kStartNs + 34 * kMs, timing);
+        33333, kStartNs + 51 * kMs, timing);
 
     assert(shifted.action == PresentationAction::SCHEDULE);
     assert(shifted.event == PresentationEvent::PHASE_SHIFT);
@@ -183,7 +204,7 @@ void TestDiscontinuityWaitsForQueuedSlot() {
     assert(waiting.event == PresentationEvent::WAIT_FOR_DRAIN);
     assert(reanchored.action == PresentationAction::SCHEDULE);
     assert(reanchored.event == PresentationEvent::DISCONTINUITY);
-    assert(reanchored.targetTimeNs == first.targetTimeNs + timing.periodNs);
+    assert(reanchored.targetTimeNs == first.targetTimeNs + 2 * timing.periodNs);
 }
 
 void TestDuplicatePtsRecoversAfterQueuedSlot() {
@@ -263,6 +284,7 @@ void TestInvalidPtsDropsWithoutScheduling() {
 
 int main() {
     TestRefreshRateTierBudgets();
+    TestOneFrameReserveAbsorbsSubFrameDecodeJitter();
     Test120FpsBurstUsesThreeUniqueSlots();
     TestQueueFullWaitsForDrainBeforeReanchor();
     Test90FpsPairBurstUsesTwoSlots();


### PR DESCRIPTION
## 改了啥呀

- PTS 调度初始 lead 明确保留一个完整流帧，再叠加 2 ms 的 RenderService 提交余量
- 队列容量从提交余量起算，保留原有突发容纳能力，不让一帧储备偷偷吃掉 burst budget
- 补上 120 FPS 解码抖动、刷新率分档和重锚行为测试

## 为啥要改

解码后的短时抖动会让帧错过 VSync 槽，表现成偶发粘滞。现在先准备一帧，让这点杂鱼抖动在上屏前被吸收，同时无 PTS 路径完全不动。

## 验证

- `presentation_scheduler_test`: passed
- `presentation_observability_test`: passed
- `hvigor assembleApp --mode project -p product=default -p buildMode=debug --no-daemon`: BUILD SUCCESSFUL