### PR TITLE
fix(render): avoid PTS pacing drop cascades

### DIFF
--- a/nativelib/src/main/cpp/native_render.cpp
+++ b/nativelib/src/main/cpp/native_render.cpp
@@ -439,7 +439,6 @@ void NativeRender::ResetPresentationStatsLocked() {
     preciseRebufferCount_ = 0;
     preciseResyncCount_ = 0;
     preciseQueueFullCount_ = 0;
-    preciseWaitForDrainCount_ = 0;
     preciseApiFailureCount_ = 0;
     preciseMaxTargetLeadNs_ = 0;
     presentationDiagnostics_.Reset();
@@ -579,9 +578,6 @@ NativeRender::FrameSubmitResult NativeRender::SubmitFrame(const DecodedFrame& fr
                 preciseResyncCount_++;
             }
             if (plan.event == PresentationEvent::QUEUE_FULL) preciseQueueFullCount_++;
-            if (plan.event == PresentationEvent::WAIT_FOR_DRAIN) {
-                preciseWaitForDrainCount_++;
-            }
             if (plan.action == PresentationAction::SCHEDULE) {
                 preciseMaxTargetLeadNs_ = std::max(
                     preciseMaxTargetLeadNs_, plan.targetTimeNs - decodedAtNs);
@@ -595,7 +591,7 @@ NativeRender::FrameSubmitResult NativeRender::SubmitFrame(const DecodedFrame& fr
                 const PresentationTimingStats& timing =
                     presentationDiagnostics_.GetStats();
                 OH_LOG_INFO(LOG_APP,
-                    "Host-paced stats: frames=%{public}lld, scheduled=%{public}lld, dropped=%{public}lld, late=%{public}lld, catchUp=%{public}lld, phaseShift=%{public}lld, rebuffer=%{public}lld, resync=%{public}lld, queueFull=%{public}lld, waitDrain=%{public}lld, apiFailure=%{public}lld, lead=%{public}lldus, maxLead=%{public}lldus, sameSlot=%{public}lld, slotRegression=%{public}lld, targetRegression=%{public}lld, maxRegression=%{public}lldus, maxQueueSlots=%{public}lld, vsyncPeriod=%{public}lldus, vsyncAge=%{public}lldus, vsyncSampleFailure=%{public}lld",
+                    "Host-paced stats: frames=%{public}lld, scheduled=%{public}lld, dropped=%{public}lld, late=%{public}lld, catchUp=%{public}lld, phaseShift=%{public}lld, rebuffer=%{public}lld, resync=%{public}lld, queueFull=%{public}lld, apiFailure=%{public}lld, lead=%{public}lldus, maxLead=%{public}lldus, sameSlot=%{public}lld, slotRegression=%{public}lld, targetRegression=%{public}lld, maxRegression=%{public}lldus, maxQueueSlots=%{public}lld, vsyncPeriod=%{public}lldus, vsyncAge=%{public}lldus, vsyncSampleFailure=%{public}lld",
                     static_cast<long long>(totalFrames),
                     static_cast<long long>(preciseScheduledCount_),
                     static_cast<long long>(preciseDroppedCount_),
@@ -605,7 +601,6 @@ NativeRender::FrameSubmitResult NativeRender::SubmitFrame(const DecodedFrame& fr
                     static_cast<long long>(preciseRebufferCount_),
                     static_cast<long long>(preciseResyncCount_),
                     static_cast<long long>(preciseQueueFullCount_),
-                    static_cast<long long>(preciseWaitForDrainCount_),
                     static_cast<long long>(preciseApiFailureCount_),
                     static_cast<long long>(ptsScheduler_.GetInitialLeadNs() / 1000),
                     static_cast<long long>(preciseMaxTargetLeadNs_ / 1000),

--- a/nativelib/src/main/cpp/native_render.h
+++ b/nativelib/src/main/cpp/native_render.h
@@ -186,7 +186,6 @@ private:
     int64_t preciseRebufferCount_ = 0;
     int64_t preciseResyncCount_ = 0;
     int64_t preciseQueueFullCount_ = 0;
-    int64_t preciseWaitForDrainCount_ = 0;
     int64_t preciseApiFailureCount_ = 0;
     int64_t preciseMaxTargetLeadNs_ = 0;
     

--- a/nativelib/src/main/cpp/presentation_scheduler.cpp
+++ b/nativelib/src/main/cpp/presentation_scheduler.cpp
@@ -24,7 +24,15 @@ constexpr double kHighRefreshFps = kDefaultFps;
 constexpr double kNtscTripleBurstFps = 119.88;
 constexpr int64_t kDriftDeadbandNs = 2 * kNanosecondsPerMillisecond;
 constexpr int64_t kMaxDriftCorrectionPerFrameNs = 20 * kNanosecondsPerMicrosecond;
-constexpr int kSevereLateFramesBeforeRebuffer = 2;
+
+PresentationEvent ReanchorEventForRetry(PresentationEvent event) {
+    if (event == PresentationEvent::DISCONTINUITY ||
+        event == PresentationEvent::REBUFFER ||
+        event == PresentationEvent::DUPLICATE_PTS) {
+        return event;
+    }
+    return PresentationEvent::CATCH_UP;
+}
 
 int64_t FloorDiv(int64_t value, int64_t divisor) {
     int64_t quotient = value / divisor;
@@ -67,11 +75,10 @@ void PtsPresentationScheduler::Configure(double fps) {
         std::llround(static_cast<double>(kNanosecondsPerSecond) / safeFps));
     frameIntervalNs_ = std::max<int64_t>(frameIntervalNs_, 1000000LL);
     // RenderService needs an absolute latch margin that does not shrink with
-    // the stream frame interval. Host-paced presentation also keeps one full
-    // stream frame decoded ahead so normal decoder jitter does not immediately
-    // miss a VSync slot.
+    // the stream frame interval. Keep steady-state lead small, but large enough
+    // for 120 Hz submission overhead.
     submitLeadNs_ = kSubmitLeadNs;
-    initialLeadNs_ = submitLeadNs_ + frameIntervalNs_;
+    initialLeadNs_ = submitLeadNs_;
     maxFutureLeadNs_ = initialLeadNs_ +
         CalculateFutureCadenceBudgetNs(safeFps, frameIntervalNs_) +
         kPtsQuantizationSlackNs;
@@ -88,25 +95,24 @@ void PtsPresentationScheduler::Reset() {
     driftErrorEmaNs_ = 0;
     phaseShiftDebtNs_ = 0;
     lastScheduledTargetNs_ = 0;
-    consecutiveSevereLateFrames_ = 0;
-    reanchorPending_ = false;
+    reanchorRetryPending_ = false;
     pendingReanchorEvent_ = PresentationEvent::CATCH_UP;
 }
 
 PresentationPlan PtsPresentationScheduler::AnchorFrame(
         int64_t ptsUs, int64_t decodedAtNs, PresentationEvent event,
-        const SlotClock& slotClock) {
+        const SlotClock& slotClock, int64_t latenessNs) {
     initialized_ = true;
     anchorPtsUs_ = ptsUs;
     anchorTargetNs_ = decodedAtNs + initialLeadNs_;
     lastPtsUs_ = ptsUs;
     driftErrorEmaNs_ = 0;
     phaseShiftDebtNs_ = 0;
-    consecutiveSevereLateFrames_ = 0;
-    reanchorPending_ = false;
+    reanchorRetryPending_ = false;
     pendingReanchorEvent_ = PresentationEvent::CATCH_UP;
 
-    return ScheduleTarget(anchorTargetNs_, decodedAtNs, event, 0, slotClock);
+    return ScheduleTarget(
+        anchorTargetNs_, decodedAtNs, event, latenessNs, slotClock);
 }
 
 PresentationPlan PtsPresentationScheduler::ScheduleTarget(
@@ -128,15 +134,15 @@ PresentationPlan PtsPresentationScheduler::ScheduleTarget(
         }
     }
 
-    // Start the queue budget at the first slot that still has the submit
-    // margin. Being close to a VSync must not reduce burst capacity.
+    // Start the existing cadence budget at the first slot that still has the
+    // submit margin. Being close to a VSync must not reduce burst capacity.
     const int64_t firstEligibleSlotNs = CeilToSlot(
         requiredTargetNs, slotClock.anchorNs, slotClock.periodNs);
     const int64_t maxScheduledSlotNs = firstEligibleSlotNs +
         GetAdditionalQueueSlots(slotClock.periodNs) * slotClock.periodNs;
     if (scheduledSlotNs > maxScheduledSlotNs) {
-        reanchorPending_ = true;
-        pendingReanchorEvent_ = PresentationEvent::CATCH_UP;
+        reanchorRetryPending_ = true;
+        pendingReanchorEvent_ = ReanchorEventForRetry(event);
         PresentationPlan plan;
         plan.event = PresentationEvent::QUEUE_FULL;
         plan.latenessNs = latenessNs;
@@ -180,12 +186,9 @@ bool PtsPresentationScheduler::IsPresentationQueueEmpty(
 
 int64_t PtsPresentationScheduler::GetAdditionalQueueSlots(
         int64_t vsyncPeriodNs) const {
-    // Count from the first slot that satisfies the RenderService submit margin.
-    // This includes the one-frame playout reserve plus the existing burst
-    // budget, so adding the reserve does not reduce burst capacity.
-    const int64_t queueLeadNs = std::max<int64_t>(
-        0, maxFutureLeadNs_ - submitLeadNs_);
-    return queueLeadNs / vsyncPeriodNs;
+    const int64_t cadenceBudgetNs = std::max<int64_t>(
+        0, maxFutureLeadNs_ - initialLeadNs_);
+    return cadenceBudgetNs / vsyncPeriodNs;
 }
 
 void PtsPresentationScheduler::ApplySlowDriftCorrection(
@@ -226,14 +229,9 @@ PresentationPlan PtsPresentationScheduler::PlanFrame(
     const SlotClock slotClock = ResolveSlotClock(decodedAtNs, vsyncTiming);
     const bool queueEmpty = IsPresentationQueueEmpty(slotClock);
 
-    if (reanchorPending_) {
-        if (queueEmpty) {
-            return AnchorFrame(
-                ptsUs, decodedAtNs, pendingReanchorEvent_, slotClock);
-        }
-        PresentationPlan plan;
-        plan.event = PresentationEvent::WAIT_FOR_DRAIN;
-        return plan;
+    if (reanchorRetryPending_) {
+        return AnchorFrame(
+            ptsUs, decodedAtNs, pendingReanchorEvent_, slotClock);
     }
 
     if (!initialized_) {
@@ -245,28 +243,14 @@ PresentationPlan PtsPresentationScheduler::PlanFrame(
         // A permanently repeated timestamp must not become a permanent DROP
         // state. Treat it as a broken host timeline and fall back to a fresh
         // local anchor until valid PTS progression resumes.
-        if (queueEmpty) {
-            return AnchorFrame(
-                ptsUs, decodedAtNs, PresentationEvent::DUPLICATE_PTS, slotClock);
-        }
-        reanchorPending_ = true;
-        pendingReanchorEvent_ = PresentationEvent::DUPLICATE_PTS;
-        PresentationPlan plan;
-        plan.event = PresentationEvent::WAIT_FOR_DRAIN;
-        return plan;
+        return AnchorFrame(
+            ptsUs, decodedAtNs, PresentationEvent::DUPLICATE_PTS, slotClock);
     }
 
     const int64_t ptsDeltaUs = ptsUs - lastPtsUs_;
     if (ptsDeltaUs < 0 || ptsDeltaUs > discontinuityNs_ / kNanosecondsPerMicrosecond) {
-        if (queueEmpty) {
-            return AnchorFrame(
-                ptsUs, decodedAtNs, PresentationEvent::DISCONTINUITY, slotClock);
-        }
-        reanchorPending_ = true;
-        pendingReanchorEvent_ = PresentationEvent::DISCONTINUITY;
-        PresentationPlan plan;
-        plan.event = PresentationEvent::WAIT_FOR_DRAIN;
-        return plan;
+        return AnchorFrame(
+            ptsUs, decodedAtNs, PresentationEvent::DISCONTINUITY, slotClock);
     }
     lastPtsUs_ = ptsUs;
 
@@ -304,32 +288,23 @@ PresentationPlan PtsPresentationScheduler::PlanFrame(
     const int64_t requiredTargetNs = decodedAtNs + submitLeadNs_;
     if (queueEmpty && targetTimeNs < requiredTargetNs) {
         const int64_t latenessNs = requiredTargetNs - targetTimeNs;
-        if (latenessNs <= frameIntervalNs_ / 2) {
+        if (latenessNs <= frameIntervalNs_) {
             // Move the complete timeline forward. This keeps all following PTS
             // intervals intact instead of switching this frame to immediate mode.
             anchorTargetNs_ += latenessNs;
             phaseShiftDebtNs_ += latenessNs;
             driftErrorEmaNs_ = 0;
-            consecutiveSevereLateFrames_ = 0;
             event = PresentationEvent::PHASE_SHIFT;
             targetTimeNs = requiredTargetNs;
             return ScheduleTarget(
                 targetTimeNs, decodedAtNs, event, latenessNs, slotClock);
         }
 
-        consecutiveSevereLateFrames_++;
-        if (consecutiveSevereLateFrames_ >= kSevereLateFramesBeforeRebuffer) {
-            return AnchorFrame(
-                ptsUs, decodedAtNs, PresentationEvent::REBUFFER, slotClock);
-        }
-
-        PresentationPlan plan;
-        plan.event = PresentationEvent::LATE_DROP;
-        plan.latenessNs = latenessNs;
-        return plan;
+        return AnchorFrame(
+            ptsUs, decodedAtNs, PresentationEvent::REBUFFER,
+            slotClock, latenessNs);
     }
 
-    consecutiveSevereLateFrames_ = 0;
     return ScheduleTarget(
         targetTimeNs, decodedAtNs, event, latenessNs, slotClock);
 }

--- a/nativelib/src/main/cpp/presentation_scheduler.h
+++ b/nativelib/src/main/cpp/presentation_scheduler.h
@@ -27,9 +27,7 @@ enum class PresentationEvent {
     REBUFFER,
     DUPLICATE_PTS,
     INVALID_PTS,
-    LATE_DROP,
     QUEUE_FULL,
-    WAIT_FOR_DRAIN,
 };
 
 struct PresentationVsyncTiming {
@@ -66,7 +64,8 @@ private:
 
     PresentationPlan AnchorFrame(int64_t ptsUs, int64_t decodedAtNs,
                                  PresentationEvent event,
-                                 const SlotClock& slotClock);
+                                 const SlotClock& slotClock,
+                                 int64_t latenessNs = 0);
     PresentationPlan ScheduleTarget(int64_t targetTimeNs, int64_t decodedAtNs,
                                     PresentationEvent event, int64_t latenessNs,
                                     const SlotClock& slotClock);
@@ -78,9 +77,9 @@ private:
     int64_t GetAdditionalQueueSlots(int64_t vsyncPeriodNs) const;
 
     int64_t frameIntervalNs_ = 16666667LL;
-    int64_t initialLeadNs_ = 18666667LL;
+    int64_t initialLeadNs_ = 2000000LL;
     int64_t submitLeadNs_ = 2000000LL;
-    int64_t maxFutureLeadNs_ = 27001000LL;
+    int64_t maxFutureLeadNs_ = 10334333LL;
     int64_t discontinuityNs_ = 250000000LL;
 
     bool initialized_ = false;
@@ -90,8 +89,7 @@ private:
     int64_t driftErrorEmaNs_ = 0;
     int64_t phaseShiftDebtNs_ = 0;
     int64_t lastScheduledTargetNs_ = 0;
-    int consecutiveSevereLateFrames_ = 0;
-    bool reanchorPending_ = false;
+    bool reanchorRetryPending_ = false;
     PresentationEvent pendingReanchorEvent_ = PresentationEvent::CATCH_UP;
 };
 

--- a/nativelib/src/test/cpp/presentation_scheduler_test.cpp
+++ b/nativelib/src/test/cpp/presentation_scheduler_test.cpp
@@ -35,11 +35,9 @@ void AssertFutureCadenceBudget(double fps, int numerator, int denominator) {
     const int64_t expectedCadenceBudgetNs =
         FrameIntervalNs(fps) * numerator / denominator;
 
-    const int64_t expectedInitialLeadNs =
-        kExpectedSubmitLeadNs + FrameIntervalNs(fps);
-    assert(scheduler.GetInitialLeadNs() == expectedInitialLeadNs);
+    assert(scheduler.GetInitialLeadNs() == kExpectedSubmitLeadNs);
     assert(scheduler.GetMaxFutureLeadNs() ==
-        expectedInitialLeadNs + expectedCadenceBudgetNs +
+        kExpectedSubmitLeadNs + expectedCadenceBudgetNs +
         kNanosecondsPerMicrosecond);
 }
 
@@ -54,7 +52,7 @@ void TestRefreshRateTierBudgets() {
     AssertFutureCadenceBudget(144.0, 2, 1);
 }
 
-void TestOneFrameReserveAbsorbsSubFrameDecodeJitter() {
+void TestTransient120FpsJitterUsesTemporaryPhaseShift() {
     PtsPresentationScheduler scheduler;
     scheduler.Configure(120.0);
     const PresentationVsyncTiming timing = Timing(120.0);
@@ -64,13 +62,48 @@ void TestOneFrameReserveAbsorbsSubFrameDecodeJitter() {
         0, firstDecodedAtNs, timing);
     const PresentationPlan jittered = scheduler.PlanFrame(
         8334, firstDecodedAtNs + timing.periodNs + 5 * kMs, timing);
-    const int64_t firstEligibleSlotNs = kStartNs + timing.periodNs;
+    const PresentationPlan recovered = scheduler.PlanFrame(
+        16667, firstDecodedAtNs + 2 * timing.periodNs, timing);
 
     AssertOnVsyncSlot(first, timing);
     AssertOnVsyncSlot(jittered, timing);
-    assert(first.targetTimeNs == firstEligibleSlotNs + timing.periodNs);
-    assert(jittered.event == PresentationEvent::NONE);
+    AssertOnVsyncSlot(recovered, timing);
+    assert(jittered.event == PresentationEvent::PHASE_SHIFT);
+    assert(jittered.latenessNs > timing.periodNs / 2);
+    assert(jittered.latenessNs <= timing.periodNs);
+    assert(recovered.event == PresentationEvent::PHASE_SHIFT);
+    assert(recovered.latenessNs < 0);
     assert(jittered.targetTimeNs == first.targetTimeNs + timing.periodNs);
+    assert(recovered.targetTimeNs == jittered.targetTimeNs + timing.periodNs);
+}
+
+void TestSustained120FpsPeriodicJitterDoesNotDrop() {
+    PtsPresentationScheduler scheduler;
+    scheduler.Configure(120.0);
+    const PresentationVsyncTiming timing = Timing(120.0);
+    constexpr double kPtsIntervalUs = 1000000.0 / 120.0;
+    const int64_t firstDecodedAtNs = kStartNs + kMs;
+
+    PresentationPlan previous = scheduler.PlanFrame(
+        0, firstDecodedAtNs, timing);
+    int phaseShiftCount = 0;
+    for (int i = 1; i <= 1201; ++i) {
+        const int64_t ptsUs = static_cast<int64_t>(
+            std::llround(i * kPtsIntervalUs));
+        const int64_t jitterNs = i % 120 == 0 ? 5 * kMs : 0;
+        const int64_t decodedAtNs =
+            firstDecodedAtNs + i * timing.periodNs + jitterNs;
+        const PresentationPlan current = scheduler.PlanFrame(
+            ptsUs, decodedAtNs, timing);
+
+        AssertOnVsyncSlot(current, timing);
+        assert(current.targetTimeNs > previous.targetTimeNs);
+        if (current.event == PresentationEvent::PHASE_SHIFT) {
+            phaseShiftCount++;
+        }
+        previous = current;
+    }
+    assert(phaseShiftCount >= 20);
 }
 
 void Test120FpsBurstUsesThreeUniqueSlots() {
@@ -93,7 +126,7 @@ void Test120FpsBurstUsesThreeUniqueSlots() {
     assert(fourth.event == PresentationEvent::QUEUE_FULL);
 }
 
-void TestQueueFullWaitsForDrainBeforeReanchor() {
+void TestQueueFullRetriesAtNextAvailableSlot() {
     PtsPresentationScheduler scheduler;
     scheduler.Configure(120.0);
     const PresentationVsyncTiming timing = Timing(120.0);
@@ -103,17 +136,21 @@ void TestQueueFullWaitsForDrainBeforeReanchor() {
     scheduler.PlanFrame(8334, burstTimeNs, timing);
     const PresentationPlan third = scheduler.PlanFrame(16667, burstTimeNs, timing);
     const PresentationPlan full = scheduler.PlanFrame(25000, burstTimeNs, timing);
-    const PresentationPlan waiting = scheduler.PlanFrame(
-        33333, first.targetTimeNs + kMs, timing);
+    const PresentationPlan stillFull = scheduler.PlanFrame(
+        33333, burstTimeNs, timing);
     const PresentationPlan recovered = scheduler.PlanFrame(
-        41667, third.targetTimeNs + kMs, timing);
+        41667, first.targetTimeNs + kMs, timing);
+    const PresentationPlan next = scheduler.PlanFrame(
+        50000, first.targetTimeNs + timing.periodNs + kMs, timing);
 
     assert(full.event == PresentationEvent::QUEUE_FULL);
-    assert(waiting.action == PresentationAction::DROP);
-    assert(waiting.event == PresentationEvent::WAIT_FOR_DRAIN);
+    assert(stillFull.action == PresentationAction::DROP);
+    assert(stillFull.event == PresentationEvent::QUEUE_FULL);
     assert(recovered.action == PresentationAction::SCHEDULE);
     assert(recovered.event == PresentationEvent::CATCH_UP);
-    assert(recovered.targetTimeNs == third.targetTimeNs + 2 * timing.periodNs);
+    assert(recovered.targetTimeNs == third.targetTimeNs + timing.periodNs);
+    assert(next.action == PresentationAction::SCHEDULE);
+    assert(next.targetTimeNs == recovered.targetTimeNs + timing.periodNs);
 }
 
 void Test90FpsPairBurstUsesTwoSlots() {
@@ -149,7 +186,7 @@ void Test60FpsDoesNotGrowPresentationQueue() {
     assert(burst.event == PresentationEvent::QUEUE_FULL);
     assert(recovered.action == PresentationAction::SCHEDULE);
     assert(recovered.event == PresentationEvent::CATCH_UP);
-    assert(recovered.targetTimeNs == first.targetTimeNs + 2 * timing.periodNs);
+    assert(recovered.targetTimeNs == first.targetTimeNs + timing.periodNs);
 }
 
 void TestSmallLateFrameShiftsWholeTimeline() {
@@ -160,9 +197,9 @@ void TestSmallLateFrameShiftsWholeTimeline() {
     const PresentationPlan first = scheduler.PlanFrame(
         0, kStartNs + kMs, timing);
     const PresentationPlan shifted = scheduler.PlanFrame(
-        16667, kStartNs + 35 * kMs, timing);
+        16667, kStartNs + 18 * kMs, timing);
     const PresentationPlan next = scheduler.PlanFrame(
-        33333, kStartNs + 51 * kMs, timing);
+        33333, kStartNs + 34 * kMs, timing);
 
     assert(shifted.action == PresentationAction::SCHEDULE);
     assert(shifted.event == PresentationEvent::PHASE_SHIFT);
@@ -171,40 +208,34 @@ void TestSmallLateFrameShiftsWholeTimeline() {
     assert(next.targetTimeNs - shifted.targetTimeNs == timing.periodNs);
 }
 
-void TestSevereLateFrameDropsBeforeRebuffer() {
+void TestSevereLateFrameReanchorsImmediately() {
     PtsPresentationScheduler scheduler;
     scheduler.Configure(60.0);
     const PresentationVsyncTiming timing = Timing(60.0);
 
     scheduler.PlanFrame(0, kStartNs + kMs, timing);
-    const PresentationPlan dropped = scheduler.PlanFrame(
-        16667, kStartNs + 100 * kMs, timing);
     const PresentationPlan rebuffered = scheduler.PlanFrame(
-        33333, kStartNs + 101 * kMs, timing);
+        16667, kStartNs + 100 * kMs, timing);
 
-    assert(dropped.action == PresentationAction::DROP);
-    assert(dropped.event == PresentationEvent::LATE_DROP);
     assert(rebuffered.action == PresentationAction::SCHEDULE);
     assert(rebuffered.event == PresentationEvent::REBUFFER);
+    assert(rebuffered.latenessNs > timing.periodNs);
     assert(rebuffered.targetTimeNs > kStartNs + 100 * kMs);
 }
 
-void TestDiscontinuityWaitsForQueuedSlot() {
+void TestDiscontinuityUsesNextAvailableSlot() {
     PtsPresentationScheduler scheduler;
     scheduler.Configure(120.0);
     const PresentationVsyncTiming timing = Timing(120.0);
     const int64_t decodedAtNs = kStartNs + kMs;
 
     const PresentationPlan first = scheduler.PlanFrame(1000000, decodedAtNs, timing);
-    const PresentationPlan waiting = scheduler.PlanFrame(500000, decodedAtNs, timing);
     const PresentationPlan reanchored = scheduler.PlanFrame(
-        500001, first.targetTimeNs + kMs, timing);
+        500000, decodedAtNs, timing);
 
-    assert(waiting.action == PresentationAction::DROP);
-    assert(waiting.event == PresentationEvent::WAIT_FOR_DRAIN);
     assert(reanchored.action == PresentationAction::SCHEDULE);
     assert(reanchored.event == PresentationEvent::DISCONTINUITY);
-    assert(reanchored.targetTimeNs == first.targetTimeNs + 2 * timing.periodNs);
+    assert(reanchored.targetTimeNs == first.targetTimeNs + timing.periodNs);
 }
 
 void TestDuplicatePtsRecoversAfterQueuedSlot() {
@@ -214,14 +245,15 @@ void TestDuplicatePtsRecoversAfterQueuedSlot() {
     const int64_t decodedAtNs = kStartNs + kMs;
 
     const PresentationPlan first = scheduler.PlanFrame(1000, decodedAtNs, timing);
-    const PresentationPlan waiting = scheduler.PlanFrame(1000, decodedAtNs, timing);
+    const PresentationPlan full = scheduler.PlanFrame(1000, decodedAtNs, timing);
     const PresentationPlan reanchored = scheduler.PlanFrame(
         1000, first.targetTimeNs + kMs, timing);
 
-    assert(waiting.action == PresentationAction::DROP);
-    assert(waiting.event == PresentationEvent::WAIT_FOR_DRAIN);
+    assert(full.action == PresentationAction::DROP);
+    assert(full.event == PresentationEvent::QUEUE_FULL);
     assert(reanchored.action == PresentationAction::SCHEDULE);
     assert(reanchored.event == PresentationEvent::DUPLICATE_PTS);
+    assert(reanchored.targetTimeNs == first.targetTimeNs + timing.periodNs);
 }
 
 void TestNtscCadenceSkipsARealSlotWithoutRegression() {
@@ -284,14 +316,15 @@ void TestInvalidPtsDropsWithoutScheduling() {
 
 int main() {
     TestRefreshRateTierBudgets();
-    TestOneFrameReserveAbsorbsSubFrameDecodeJitter();
+    TestTransient120FpsJitterUsesTemporaryPhaseShift();
+    TestSustained120FpsPeriodicJitterDoesNotDrop();
     Test120FpsBurstUsesThreeUniqueSlots();
-    TestQueueFullWaitsForDrainBeforeReanchor();
+    TestQueueFullRetriesAtNextAvailableSlot();
     Test90FpsPairBurstUsesTwoSlots();
     Test60FpsDoesNotGrowPresentationQueue();
     TestSmallLateFrameShiftsWholeTimeline();
-    TestSevereLateFrameDropsBeforeRebuffer();
-    TestDiscontinuityWaitsForQueuedSlot();
+    TestSevereLateFrameReanchorsImmediately();
+    TestDiscontinuityUsesNextAvailableSlot();
     TestDuplicatePtsRecoversAfterQueuedSlot();
     TestNtscCadenceSkipsARealSlotWithoutRegression();
     TestObservedVsyncPhaseCannotReuseFallbackSlot();


### PR DESCRIPTION
## 改了啥呀

- 保持 2 ms 的稳定提交余量，不再长期预占一整帧的 Surface 队列
- 删除会主动制造丢帧级联的 `LATE_DROP` 和粘滞 `WAIT_FOR_DRAIN` 状态
- `QUEUE_FULL` 只在当前确实没有可用 VSync 槽时丢帧；下一次回调立即用最新帧重锚并重试
- 重复 PTS、时间戳跳变和严重晚到帧直接从下一个可用槽重锚，不等整条队列排空
- 清理对应的无效统计字段，补齐高刷、NTSC、队列恢复和相移偿还回归测试

## 为啥要改

旧状态机遇到一次瞬时队列满，会先丢掉无处可放的帧，再把后续帧锁进 `WAIT_FOR_DRAIN`。这个杂鱼链路会额外空掉 VSync，放大成连续掉帧和粘滞感。现在保留真实容量边界，但不再人为等待或牺牲恢复帧；平稳路径仍按 PTS 节奏排槽，晚到只做一次可偿还的相移。

## 验证

- `c++ -std=c++17 -Wall -Wextra -Werror -I nativelib/src/main/cpp nativelib/src/main/cpp/presentation_scheduler.cpp nativelib/src/test/cpp/presentation_scheduler_test.cpp -o /tmp/moonlight-presentation-scheduler-test && /tmp/moonlight-presentation-scheduler-test`: passed
- `c++ -std=c++17 -Wall -Wextra -Werror -I nativelib/src/main/cpp nativelib/src/main/cpp/presentation_diagnostics.cpp nativelib/src/main/cpp/rolling_frame_rate.cpp nativelib/src/test/cpp/presentation_observability_test.cpp -o /tmp/moonlight-presentation-observability-test && /tmp/moonlight-presentation-observability-test`: passed
- `DEVECO_SDK_HOME=/Users/mac/ohos-sdk-cache/6.1-Release-mac/sdk-ci-shape JAVA_HOME=/Applications/DevEco-Studio.app/Contents/jbr/Contents/Home PATH=/Applications/DevEco-Studio.app/Contents/jbr/Contents/Home/bin:$PATH node hvigorw.js assembleApp --mode project -p product=default -p buildMode=debug --no-daemon`: BUILD SUCCESSFUL
- `git diff --check`: passed