### PR TITLE
fix(render): preserve PTS burst frames

### DIFF
--- a/nativelib/src/main/cpp/native_render.cpp
+++ b/nativelib/src/main/cpp/native_render.cpp
@@ -438,7 +438,6 @@ void NativeRender::ResetPresentationStatsLocked() {
     precisePhaseShiftCount_ = 0;
     preciseRebufferCount_ = 0;
     preciseResyncCount_ = 0;
-    preciseQueueFullCount_ = 0;
     preciseApiFailureCount_ = 0;
     preciseMaxTargetLeadNs_ = 0;
     presentationDiagnostics_.Reset();
@@ -577,7 +576,6 @@ NativeRender::FrameSubmitResult NativeRender::SubmitFrame(const DecodedFrame& fr
                 plan.event == PresentationEvent::DUPLICATE_PTS) {
                 preciseResyncCount_++;
             }
-            if (plan.event == PresentationEvent::QUEUE_FULL) preciseQueueFullCount_++;
             if (plan.action == PresentationAction::SCHEDULE) {
                 preciseMaxTargetLeadNs_ = std::max(
                     preciseMaxTargetLeadNs_, plan.targetTimeNs - decodedAtNs);
@@ -591,7 +589,7 @@ NativeRender::FrameSubmitResult NativeRender::SubmitFrame(const DecodedFrame& fr
                 const PresentationTimingStats& timing =
                     presentationDiagnostics_.GetStats();
                 OH_LOG_INFO(LOG_APP,
-                    "Host-paced stats: frames=%{public}lld, scheduled=%{public}lld, dropped=%{public}lld, late=%{public}lld, catchUp=%{public}lld, phaseShift=%{public}lld, rebuffer=%{public}lld, resync=%{public}lld, queueFull=%{public}lld, apiFailure=%{public}lld, lead=%{public}lldus, maxLead=%{public}lldus, sameSlot=%{public}lld, slotRegression=%{public}lld, targetRegression=%{public}lld, maxRegression=%{public}lldus, maxQueueSlots=%{public}lld, vsyncPeriod=%{public}lldus, vsyncAge=%{public}lldus, vsyncSampleFailure=%{public}lld",
+                    "Host-paced stats: frames=%{public}lld, scheduled=%{public}lld, dropped=%{public}lld, late=%{public}lld, catchUp=%{public}lld, phaseShift=%{public}lld, rebuffer=%{public}lld, resync=%{public}lld, apiFailure=%{public}lld, lead=%{public}lldus, maxLead=%{public}lldus, sameSlot=%{public}lld, slotRegression=%{public}lld, targetRegression=%{public}lld, maxRegression=%{public}lldus, maxQueueSlots=%{public}lld, vsyncPeriod=%{public}lldus, vsyncAge=%{public}lldus, vsyncSampleFailure=%{public}lld",
                     static_cast<long long>(totalFrames),
                     static_cast<long long>(preciseScheduledCount_),
                     static_cast<long long>(preciseDroppedCount_),
@@ -600,7 +598,6 @@ NativeRender::FrameSubmitResult NativeRender::SubmitFrame(const DecodedFrame& fr
                     static_cast<long long>(precisePhaseShiftCount_),
                     static_cast<long long>(preciseRebufferCount_),
                     static_cast<long long>(preciseResyncCount_),
-                    static_cast<long long>(preciseQueueFullCount_),
                     static_cast<long long>(preciseApiFailureCount_),
                     static_cast<long long>(ptsScheduler_.GetInitialLeadNs() / 1000),
                     static_cast<long long>(preciseMaxTargetLeadNs_ / 1000),

--- a/nativelib/src/main/cpp/native_render.h
+++ b/nativelib/src/main/cpp/native_render.h
@@ -185,7 +185,6 @@ private:
     int64_t precisePhaseShiftCount_ = 0;
     int64_t preciseRebufferCount_ = 0;
     int64_t preciseResyncCount_ = 0;
-    int64_t preciseQueueFullCount_ = 0;
     int64_t preciseApiFailureCount_ = 0;
     int64_t preciseMaxTargetLeadNs_ = 0;
     

--- a/nativelib/src/main/cpp/presentation_scheduler.cpp
+++ b/nativelib/src/main/cpp/presentation_scheduler.cpp
@@ -25,15 +25,6 @@ constexpr double kNtscTripleBurstFps = 119.88;
 constexpr int64_t kDriftDeadbandNs = 2 * kNanosecondsPerMillisecond;
 constexpr int64_t kMaxDriftCorrectionPerFrameNs = 20 * kNanosecondsPerMicrosecond;
 
-PresentationEvent ReanchorEventForRetry(PresentationEvent event) {
-    if (event == PresentationEvent::DISCONTINUITY ||
-        event == PresentationEvent::REBUFFER ||
-        event == PresentationEvent::DUPLICATE_PTS) {
-        return event;
-    }
-    return PresentationEvent::CATCH_UP;
-}
-
 int64_t FloorDiv(int64_t value, int64_t divisor) {
     int64_t quotient = value / divisor;
     if (value % divisor < 0) {
@@ -95,8 +86,6 @@ void PtsPresentationScheduler::Reset() {
     driftErrorEmaNs_ = 0;
     phaseShiftDebtNs_ = 0;
     lastScheduledTargetNs_ = 0;
-    reanchorRetryPending_ = false;
-    pendingReanchorEvent_ = PresentationEvent::CATCH_UP;
 }
 
 PresentationPlan PtsPresentationScheduler::AnchorFrame(
@@ -108,8 +97,6 @@ PresentationPlan PtsPresentationScheduler::AnchorFrame(
     lastPtsUs_ = ptsUs;
     driftErrorEmaNs_ = 0;
     phaseShiftDebtNs_ = 0;
-    reanchorRetryPending_ = false;
-    pendingReanchorEvent_ = PresentationEvent::CATCH_UP;
 
     return ScheduleTarget(
         anchorTargetNs_, decodedAtNs, event, latenessNs, slotClock);
@@ -132,21 +119,6 @@ PresentationPlan PtsPresentationScheduler::ScheduleTarget(
         if (scheduledSlotNs <= lastOccupiedSlotNs) {
             scheduledSlotNs = lastOccupiedSlotNs + slotClock.periodNs;
         }
-    }
-
-    // Start the existing cadence budget at the first slot that still has the
-    // submit margin. Being close to a VSync must not reduce burst capacity.
-    const int64_t firstEligibleSlotNs = CeilToSlot(
-        requiredTargetNs, slotClock.anchorNs, slotClock.periodNs);
-    const int64_t maxScheduledSlotNs = firstEligibleSlotNs +
-        GetAdditionalQueueSlots(slotClock.periodNs) * slotClock.periodNs;
-    if (scheduledSlotNs > maxScheduledSlotNs) {
-        reanchorRetryPending_ = true;
-        pendingReanchorEvent_ = ReanchorEventForRetry(event);
-        PresentationPlan plan;
-        plan.event = PresentationEvent::QUEUE_FULL;
-        plan.latenessNs = latenessNs;
-        return plan;
     }
 
     lastScheduledTargetNs_ = scheduledSlotNs;
@@ -182,13 +154,6 @@ bool PtsPresentationScheduler::IsPresentationQueueEmpty(
     const int64_t lastOccupiedSlotNs = CeilToSlot(
         lastScheduledTargetNs_, slotClock.anchorNs, slotClock.periodNs);
     return lastOccupiedSlotNs <= slotClock.currentSlotNs;
-}
-
-int64_t PtsPresentationScheduler::GetAdditionalQueueSlots(
-        int64_t vsyncPeriodNs) const {
-    const int64_t cadenceBudgetNs = std::max<int64_t>(
-        0, maxFutureLeadNs_ - initialLeadNs_);
-    return cadenceBudgetNs / vsyncPeriodNs;
 }
 
 void PtsPresentationScheduler::ApplySlowDriftCorrection(
@@ -228,11 +193,6 @@ PresentationPlan PtsPresentationScheduler::PlanFrame(
 
     const SlotClock slotClock = ResolveSlotClock(decodedAtNs, vsyncTiming);
     const bool queueEmpty = IsPresentationQueueEmpty(slotClock);
-
-    if (reanchorRetryPending_) {
-        return AnchorFrame(
-            ptsUs, decodedAtNs, pendingReanchorEvent_, slotClock);
-    }
 
     if (!initialized_) {
         return AnchorFrame(

--- a/nativelib/src/main/cpp/presentation_scheduler.h
+++ b/nativelib/src/main/cpp/presentation_scheduler.h
@@ -27,7 +27,6 @@ enum class PresentationEvent {
     REBUFFER,
     DUPLICATE_PTS,
     INVALID_PTS,
-    QUEUE_FULL,
 };
 
 struct PresentationVsyncTiming {
@@ -74,7 +73,6 @@ private:
         int64_t decodedAtNs,
         const PresentationVsyncTiming& vsyncTiming) const;
     bool IsPresentationQueueEmpty(const SlotClock& slotClock) const;
-    int64_t GetAdditionalQueueSlots(int64_t vsyncPeriodNs) const;
 
     int64_t frameIntervalNs_ = 16666667LL;
     int64_t initialLeadNs_ = 2000000LL;
@@ -89,8 +87,6 @@ private:
     int64_t driftErrorEmaNs_ = 0;
     int64_t phaseShiftDebtNs_ = 0;
     int64_t lastScheduledTargetNs_ = 0;
-    bool reanchorRetryPending_ = false;
-    PresentationEvent pendingReanchorEvent_ = PresentationEvent::CATCH_UP;
 };
 
 #endif // PRESENTATION_SCHEDULER_H

--- a/nativelib/src/test/cpp/presentation_scheduler_test.cpp
+++ b/nativelib/src/test/cpp/presentation_scheduler_test.cpp
@@ -106,7 +106,7 @@ void TestSustained120FpsPeriodicJitterDoesNotDrop() {
     assert(phaseShiftCount >= 20);
 }
 
-void Test120FpsBurstUsesThreeUniqueSlots() {
+void Test120FpsBurstPreservesAllFrames() {
     PtsPresentationScheduler scheduler;
     scheduler.Configure(120.0);
     const PresentationVsyncTiming timing = Timing(120.0);
@@ -116,44 +116,55 @@ void Test120FpsBurstUsesThreeUniqueSlots() {
     const PresentationPlan second = scheduler.PlanFrame(8334, decodedAtNs, timing);
     const PresentationPlan third = scheduler.PlanFrame(16667, decodedAtNs, timing);
     const PresentationPlan fourth = scheduler.PlanFrame(25000, decodedAtNs, timing);
+    const PresentationPlan fifth = scheduler.PlanFrame(33333, decodedAtNs, timing);
 
     AssertOnVsyncSlot(first, timing);
     AssertOnVsyncSlot(second, timing);
     AssertOnVsyncSlot(third, timing);
+    AssertOnVsyncSlot(fourth, timing);
+    AssertOnVsyncSlot(fifth, timing);
     assert(second.targetTimeNs - first.targetTimeNs == timing.periodNs);
     assert(third.targetTimeNs - second.targetTimeNs == timing.periodNs);
-    assert(fourth.action == PresentationAction::DROP);
-    assert(fourth.event == PresentationEvent::QUEUE_FULL);
+    assert(fourth.targetTimeNs - third.targetTimeNs == timing.periodNs);
+    assert(fifth.targetTimeNs - fourth.targetTimeNs == timing.periodNs);
 }
 
-void TestQueueFullRetriesAtNextAvailableSlot() {
+void TestRepeated120FpsBurstsDrainBetweenCallbacks() {
     PtsPresentationScheduler scheduler;
     scheduler.Configure(120.0);
     const PresentationVsyncTiming timing = Timing(120.0);
-    const int64_t burstTimeNs = kStartNs + kMs;
+    const int64_t firstDecodedAtNs = kStartNs + kMs;
+    constexpr double kPtsIntervalUs = 1000000.0 / 120.0;
+    constexpr int kBurstSize = 5;
 
-    const PresentationPlan first = scheduler.PlanFrame(0, burstTimeNs, timing);
-    scheduler.PlanFrame(8334, burstTimeNs, timing);
-    const PresentationPlan third = scheduler.PlanFrame(16667, burstTimeNs, timing);
-    const PresentationPlan full = scheduler.PlanFrame(25000, burstTimeNs, timing);
-    const PresentationPlan stillFull = scheduler.PlanFrame(
-        33333, burstTimeNs, timing);
-    const PresentationPlan recovered = scheduler.PlanFrame(
-        41667, first.targetTimeNs + kMs, timing);
-    const PresentationPlan next = scheduler.PlanFrame(
-        50000, first.targetTimeNs + timing.periodNs + kMs, timing);
+    PresentationPlan previous;
+    for (int burst = 0; burst < 120; ++burst) {
+        const int firstFrame = burst * kBurstSize;
+        const int64_t decodedAtNs =
+            firstDecodedAtNs + firstFrame * timing.periodNs;
+        for (int offset = 0; offset < kBurstSize; ++offset) {
+            const int frame = firstFrame + offset;
+            const int64_t ptsUs = static_cast<int64_t>(
+                std::llround(frame * kPtsIntervalUs));
+            const PresentationPlan current = scheduler.PlanFrame(
+                ptsUs, decodedAtNs, timing);
 
-    assert(full.event == PresentationEvent::QUEUE_FULL);
-    assert(stillFull.action == PresentationAction::DROP);
-    assert(stillFull.event == PresentationEvent::QUEUE_FULL);
-    assert(recovered.action == PresentationAction::SCHEDULE);
-    assert(recovered.event == PresentationEvent::CATCH_UP);
-    assert(recovered.targetTimeNs == third.targetTimeNs + timing.periodNs);
-    assert(next.action == PresentationAction::SCHEDULE);
-    assert(next.targetTimeNs == recovered.targetTimeNs + timing.periodNs);
+            AssertOnVsyncSlot(current, timing);
+            if (frame > 0) {
+                assert(current.targetTimeNs ==
+                    previous.targetTimeNs + timing.periodNs);
+            }
+            previous = current;
+        }
+    }
+
+    const int64_t lastDecodedAtNs = firstDecodedAtNs +
+        (120 - 1) * kBurstSize * timing.periodNs;
+    assert(previous.targetTimeNs - lastDecodedAtNs <=
+        kBurstSize * timing.periodNs);
 }
 
-void Test90FpsPairBurstUsesTwoSlots() {
+void Test90FpsBurstPreservesAllFrames() {
     PtsPresentationScheduler scheduler;
     scheduler.Configure(90.0);
     const PresentationVsyncTiming timing = Timing(90.0);
@@ -165,12 +176,12 @@ void Test90FpsPairBurstUsesTwoSlots() {
 
     AssertOnVsyncSlot(first, timing);
     AssertOnVsyncSlot(second, timing);
+    AssertOnVsyncSlot(third, timing);
     assert(second.targetTimeNs - first.targetTimeNs == timing.periodNs);
-    assert(third.action == PresentationAction::DROP);
-    assert(third.event == PresentationEvent::QUEUE_FULL);
+    assert(third.targetTimeNs - second.targetTimeNs == timing.periodNs);
 }
 
-void Test60FpsDoesNotGrowPresentationQueue() {
+void Test60FpsBurstPreservesAllFrames() {
     PtsPresentationScheduler scheduler;
     scheduler.Configure(60.0);
     const PresentationVsyncTiming timing = Timing(60.0);
@@ -182,11 +193,10 @@ void Test60FpsDoesNotGrowPresentationQueue() {
         33333, first.targetTimeNs + kMs, timing);
 
     AssertOnVsyncSlot(first, timing);
-    assert(burst.action == PresentationAction::DROP);
-    assert(burst.event == PresentationEvent::QUEUE_FULL);
-    assert(recovered.action == PresentationAction::SCHEDULE);
-    assert(recovered.event == PresentationEvent::CATCH_UP);
-    assert(recovered.targetTimeNs == first.targetTimeNs + timing.periodNs);
+    AssertOnVsyncSlot(burst, timing);
+    AssertOnVsyncSlot(recovered, timing);
+    assert(burst.targetTimeNs == first.targetTimeNs + timing.periodNs);
+    assert(recovered.targetTimeNs == burst.targetTimeNs + timing.periodNs);
 }
 
 void TestSmallLateFrameShiftsWholeTimeline() {
@@ -238,22 +248,23 @@ void TestDiscontinuityUsesNextAvailableSlot() {
     assert(reanchored.targetTimeNs == first.targetTimeNs + timing.periodNs);
 }
 
-void TestDuplicatePtsRecoversAfterQueuedSlot() {
+void TestDuplicatePtsReanchorsWithoutDropping() {
     PtsPresentationScheduler scheduler;
     scheduler.Configure(60.0);
     const PresentationVsyncTiming timing = Timing(60.0);
     const int64_t decodedAtNs = kStartNs + kMs;
 
     const PresentationPlan first = scheduler.PlanFrame(1000, decodedAtNs, timing);
-    const PresentationPlan full = scheduler.PlanFrame(1000, decodedAtNs, timing);
+    const PresentationPlan duplicate = scheduler.PlanFrame(1000, decodedAtNs, timing);
     const PresentationPlan reanchored = scheduler.PlanFrame(
         1000, first.targetTimeNs + kMs, timing);
 
-    assert(full.action == PresentationAction::DROP);
-    assert(full.event == PresentationEvent::QUEUE_FULL);
+    assert(duplicate.action == PresentationAction::SCHEDULE);
+    assert(duplicate.event == PresentationEvent::DUPLICATE_PTS);
     assert(reanchored.action == PresentationAction::SCHEDULE);
     assert(reanchored.event == PresentationEvent::DUPLICATE_PTS);
-    assert(reanchored.targetTimeNs == first.targetTimeNs + timing.periodNs);
+    assert(duplicate.targetTimeNs == first.targetTimeNs + timing.periodNs);
+    assert(reanchored.targetTimeNs == duplicate.targetTimeNs + timing.periodNs);
 }
 
 void TestNtscCadenceSkipsARealSlotWithoutRegression() {
@@ -318,14 +329,14 @@ int main() {
     TestRefreshRateTierBudgets();
     TestTransient120FpsJitterUsesTemporaryPhaseShift();
     TestSustained120FpsPeriodicJitterDoesNotDrop();
-    Test120FpsBurstUsesThreeUniqueSlots();
-    TestQueueFullRetriesAtNextAvailableSlot();
-    Test90FpsPairBurstUsesTwoSlots();
-    Test60FpsDoesNotGrowPresentationQueue();
+    Test120FpsBurstPreservesAllFrames();
+    TestRepeated120FpsBurstsDrainBetweenCallbacks();
+    Test90FpsBurstPreservesAllFrames();
+    Test60FpsBurstPreservesAllFrames();
     TestSmallLateFrameShiftsWholeTimeline();
     TestSevereLateFrameReanchorsImmediately();
     TestDiscontinuityUsesNextAvailableSlot();
-    TestDuplicatePtsRecoversAfterQueuedSlot();
+    TestDuplicatePtsReanchorsWithoutDropping();
     TestNtscCadenceSkipsARealSlotWithoutRegression();
     TestObservedVsyncPhaseCannotReuseFallbackSlot();
     TestInvalidPtsDropsWithoutScheduling();


### PR DESCRIPTION
## 改了啥呀

- 删除 PTS 调度器的固定未来槽位上限，不再因为第 4 个或第 5 个 burst 帧超出软件预算就主动释放
- 保留一帧一个 VSync 槽的节奏整形，短时硬解 burst 会排进连续槽位，平均输出恢复后自然排空
- 删除 `QUEUE_FULL`、重锚重试状态和对应统计；有效 PTS 只调度，只有无效 PTS 才由调度器拒绝
- 保留 2 ms 常态提交余量、晚到相移、严重晚到重锚，以及 `maxLead` / `maxQueueSlots` 积压观测
- 新增 60/90/120 FPS burst 和连续 120 轮五帧 burst 回归，确认不丢帧且队列不会逐轮增长

## 为啥要改

硬解输出经常成批回调，但平均帧率仍与显示刷新率一致。旧的三槽上限会把第 4 帧直接变成 `QUEUE_FULL`，这个杂鱼容量判断把可自然排空的瞬时 burst 误判成持续积压，所以清掉等待状态后用户仍能看到同样的基础掉帧。现在让 RenderService 接收完整的连续 PTS 槽位，客户端不再抢着替系统丢有效帧。

这版刻意保留槽位整形，只移除硬容量丢帧，便于设备侧单独验证根因。若生产速率长期高于显示速率，`maxLead` 和 `maxQueueSlots` 会直接暴露积压，而不是被主动丢帧掩盖。

## 验证

- `c++ -std=c++17 -Wall -Wextra -Werror -I nativelib/src/main/cpp nativelib/src/main/cpp/presentation_scheduler.cpp nativelib/src/test/cpp/presentation_scheduler_test.cpp -o /tmp/moonlight-presentation-scheduler-test && /tmp/moonlight-presentation-scheduler-test`: passed
- `c++ -std=c++17 -Wall -Wextra -Werror -I nativelib/src/main/cpp nativelib/src/main/cpp/presentation_diagnostics.cpp nativelib/src/main/cpp/rolling_frame_rate.cpp nativelib/src/test/cpp/presentation_observability_test.cpp -o /tmp/moonlight-presentation-observability-test && /tmp/moonlight-presentation-observability-test`: passed
- `DEVECO_SDK_HOME=/Users/mac/ohos-sdk-cache/6.1-Release-mac/sdk-ci-shape JAVA_HOME=/Applications/DevEco-Studio.app/Contents/jbr/Contents/Home PATH=/Applications/DevEco-Studio.app/Contents/jbr/Contents/Home/bin:$PATH node hvigorw.js assembleApp --mode project -p product=default -p buildMode=debug --no-daemon`: BUILD SUCCESSFUL
- `git diff --check`: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化帧呈现调度，减少突发帧场景下的不必要丢帧。
  * 改善 60fps、90fps 和 120fps 内容的目标时间连续性与调度稳定性。
  * 优化重复时间戳帧的重新锚定处理，提升后续帧恢复效果。
  * 精简呈现统计信息，改进主机节奏模式下的性能日志。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->