### PR TITLE
feat(render): add true two-step PTS pacing experiment

### DIFF
--- a/entry/src/main/ets/components/StreamSessionReport.ets
+++ b/entry/src/main/ets/components/StreamSessionReport.ets
@@ -14,7 +14,8 @@
  * 轻量分析本次串流统计，展示可爱的结论、改进建议，并生成可分享 PNG 卡片。
  */
 import { componentSnapshot, display } from '@kit.ArkUI';
-import { common } from '@kit.AbilityKit';
+import { common, bundleManager } from '@kit.AbilityKit';
+import { deviceInfo, pasteboard } from '@kit.BasicServicesKit';
 import { fileIo, fileUri } from '@kit.CoreFileKit';
 import { image } from '@kit.ImageKit';
 import { systemShare } from '@kit.ShareKit';
@@ -37,6 +38,7 @@ const REPORT_MIN_FIT_SCALE = 0.82;
 
 export class StreamReportStats {
   fps: number = 0;
+  codecOutputFps: number = 0;
   renderedFps: number = 0;
   bitrate: number = 0;
   latency: number = 0;
@@ -44,7 +46,10 @@ export class StreamReportStats {
   networkLatency: number = 0;
   packetLoss: number = 0;
   decodedFrames: number = 0;
+  codecOutputFrames: number = 0;
   droppedFrames: number = 0;
+  framesLost: number = 0;
+  totalFrames: number = 0;
   globalAvgDecodeLatency: number = 0;
   globalAvgHostLatency: number = 0;
   globalAvgFps: number = 0;
@@ -53,6 +58,25 @@ export class StreamReportStats {
   droppedByL3: number = 0;
   droppedByL4: number = 0;
   droppedByL5: number = 0;
+  droppedByQueueOverflow: number = 0;
+  droppedByTimeout: number = 0;
+  syncDrainEvents: number = 0;
+  syncDrainFrames: number = 0;
+  syncDecode: boolean = false;
+  hostPacedPresentationActive: boolean = false;
+  presentationPrepared: number = 0;
+  presentationScheduled: number = 0;
+  presentationExpired: number = 0;
+  presentationMissing: number = 0;
+  presentationFuture: number = 0;
+  presentationNonMonotonicDrops: number = 0;
+  presentationRenderFallbacks: number = 0;
+  presentationLeadUnder1Ms: number = 0;
+  presentationLead1To2Ms: number = 0;
+  presentationLead2To4Ms: number = 0;
+  presentationLead4To8Ms: number = 0;
+  presentationLeadAtLeast8Ms: number = 0;
+  presentationPendingHighWater: number = 0;
 }
 
 export interface StreamReportMetric {
@@ -76,6 +100,12 @@ export class StreamReportConfigSnapshot {
   bitrate: number = 0;
   codec: string = 'Auto';
   hdr: boolean = false;
+  clientRefreshRateX100: number = 0;
+  decoderBufferCount: number = 0;
+  syncDecode: boolean = false;
+  vsync: boolean = false;
+  hostPacedPresentation: boolean = false;
+  vrr: boolean = false;
 }
 
 export interface StreamReportData {
@@ -108,6 +138,12 @@ export function createStreamReportConfigSnapshot(config: StreamConfig | null | u
   snapshot.bitrate = config.bitrate;
   snapshot.codec = config.codec;
   snapshot.hdr = config.hdr;
+  snapshot.clientRefreshRateX100 = config.clientRefreshRateX100;
+  snapshot.decoderBufferCount = config.decoderBufferCount;
+  snapshot.syncDecode = config.enableSyncDecode;
+  snapshot.vsync = config.enableVsync;
+  snapshot.hostPacedPresentation = config.enableHostPacedPresentation;
+  snapshot.vrr = config.enableVrr;
   return snapshot;
 }
 
@@ -238,6 +274,94 @@ function getNowText(): string {
   const hour = now.getHours().toString().padStart(2, '0');
   const minute = now.getMinutes().toString().padStart(2, '0');
   return `${month}-${day} ${hour}:${minute}`;
+}
+
+function formatDiagnosticFps(value: number): string {
+  return Math.max(0, safeNumber(value, 0)).toFixed(1);
+}
+
+function formatDiagnosticCount(value: number): string {
+  return Math.max(0, Math.round(safeNumber(value, 0))).toString();
+}
+
+function getDiagnosticBuildText(): string {
+  try {
+    const bundleInfo = bundleManager.getBundleInfoForSelfSync(
+      bundleManager.BundleFlag.GET_BUNDLE_INFO_DEFAULT);
+    return bundleInfo.versionName + ' (' + bundleInfo.versionCode.toString() + ')';
+  } catch (_) {
+    return 'unknown';
+  }
+}
+
+export function buildStreamDiagnosticsText(stats: StreamReportStats,
+  config: StreamReportConfigSnapshot | null | undefined, appName: string, durationMs: number): string {
+  const durationSeconds = Math.max(0, durationMs) / 1000;
+  const receivedAvgFps = durationSeconds > 0 ? stats.totalFrames / durationSeconds : stats.fps;
+  const outputAvgFps = durationSeconds > 0 ? stats.codecOutputFrames / durationSeconds : stats.codecOutputFps;
+  const submittedAvgFps = stats.globalAvgFps > 0 ? stats.globalAvgFps : stats.renderedFps;
+  const deviceName = deviceInfo.marketName || deviceInfo.productModel || 'unknown';
+  const streamText = config
+    ? config.width.toString() + 'x' + config.height.toString() + '@' + config.fps.toString() + ' ' + config.codec
+    : 'unknown';
+  const refreshText = config && config.clientRefreshRateX100 > 0
+    ? (config.clientRefreshRateX100 / 100).toFixed(2) + 'Hz'
+    : 'unknown';
+  const bufferText = config
+    ? (config.decoderBufferCount > 0 ? config.decoderBufferCount.toString() : 'auto')
+    : 'unknown';
+  const decodeMode = stats.syncDecode ? 'sync' : 'async';
+  const ptsMode = stats.hostPacedPresentationActive
+    ? 'active'
+    : (config && config.hostPacedPresentation ? 'configured-unavailable' : 'off');
+  const vsyncMode = config && config.vsync ? 'on' : 'off';
+  const vrrMode = config && config.vrr ? 'on' : 'off';
+  const lines: string[] = [];
+
+  lines.push('Moonlight Harmony Diagnostics');
+  lines.push('build: ' + getDiagnosticBuildText());
+  lines.push('device: ' + deviceName);
+  lines.push('os: ' + deviceInfo.osFullName + ' / API ' + deviceInfo.sdkApiVersion.toString());
+  lines.push('app: ' + (appName || 'unknown'));
+  lines.push('stream: ' + streamText + ' / display ' + refreshText);
+  lines.push('mode: decode=' + decodeMode + ', pts=' + ptsMode + ', vsync=' + vsyncMode +
+    ', vrr=' + vrrMode + ', buffers=' + bufferText);
+  lines.push('duration: ' + formatDuration(durationMs));
+  lines.push('');
+  lines.push('fps-avg: rx=' + formatDiagnosticFps(receivedAvgFps) +
+    ', output=' + formatDiagnosticFps(outputAvgFps) +
+    ', submit=' + formatDiagnosticFps(submittedAvgFps));
+  lines.push('fps-window: rx=' + formatDiagnosticFps(stats.fps) +
+    ', output=' + formatDiagnosticFps(stats.codecOutputFps) +
+    ', submit=' + formatDiagnosticFps(stats.renderedFps));
+  lines.push('frames: rx=' + formatDiagnosticCount(stats.totalFrames) +
+    ', output=' + formatDiagnosticCount(stats.codecOutputFrames) +
+    ', submit=' + formatDiagnosticCount(stats.decodedFrames) +
+    ', network-lost=' + formatDiagnosticCount(stats.framesLost));
+  lines.push('drops: total=' + formatDiagnosticCount(stats.droppedFrames) +
+    ', L1=' + formatDiagnosticCount(stats.droppedByL1) +
+    ', L2=' + formatDiagnosticCount(stats.droppedByL2) +
+    ', L3=' + formatDiagnosticCount(stats.droppedByL3) +
+    ', L4=' + formatDiagnosticCount(stats.droppedByL4) +
+    ', L5=' + formatDiagnosticCount(stats.droppedByL5) +
+    ', queue=' + formatDiagnosticCount(stats.droppedByQueueOverflow) +
+    ', timeout=' + formatDiagnosticCount(stats.droppedByTimeout));
+  lines.push('pacing: prepared=' + formatDiagnosticCount(stats.presentationPrepared) +
+    ', scheduled=' + formatDiagnosticCount(stats.presentationScheduled) +
+    ', expired=' + formatDiagnosticCount(stats.presentationExpired) +
+    ', missing=' + formatDiagnosticCount(stats.presentationMissing) +
+    ', future=' + formatDiagnosticCount(stats.presentationFuture) +
+    ', non-monotonic-drop=' + formatDiagnosticCount(stats.presentationNonMonotonicDrops) +
+    ', render-fallback=' + formatDiagnosticCount(stats.presentationRenderFallbacks));
+  lines.push('target-lead: <1ms=' + formatDiagnosticCount(stats.presentationLeadUnder1Ms) +
+    ', 1-2ms=' + formatDiagnosticCount(stats.presentationLead1To2Ms) +
+    ', 2-4ms=' + formatDiagnosticCount(stats.presentationLead2To4Ms) +
+    ', 4-8ms=' + formatDiagnosticCount(stats.presentationLead4To8Ms) +
+    ', >=8ms=' + formatDiagnosticCount(stats.presentationLeadAtLeast8Ms));
+  lines.push('sync-drain: events=' + formatDiagnosticCount(stats.syncDrainEvents) +
+    ', frames=' + formatDiagnosticCount(stats.syncDrainFrames) +
+    ', pending-high-water=' + formatDiagnosticCount(stats.presentationPendingHighWater));
+  return lines.join('\n');
 }
 
 function buildSuggestions(score: number, networkLatency: number, decodeLatency: number, hostLatency: number,
@@ -423,6 +547,7 @@ export function buildStreamReportDataFromSnapshot(stats: StreamReportStats,
 @Component
 export struct StreamSessionReport {
   @Prop data: StreamReportData = createEmptyStreamReport();
+  @Prop diagnosticsText: string = '';
   onClose?: () => void;
 
   @State private overlayOpacity: number = 0;
@@ -517,6 +642,22 @@ export struct StreamSessionReport {
       ToastQueue.show({ message: '分享图片生成失败', duration: 1600 });
     } finally {
       this.isSharing = false;
+    }
+  }
+
+  private copyDiagnostics(): void {
+    if (this.diagnosticsText.length === 0) {
+      ToastQueue.show({ message: '暂无诊断数据', duration: 1500 });
+      return;
+    }
+    try {
+      const pasteData = pasteboard.createData(
+        pasteboard.MIMETYPE_TEXT_PLAIN, this.diagnosticsText);
+      pasteboard.getSystemPasteboard().setDataSync(pasteData);
+      ToastQueue.show({ message: '诊断数据已复制', duration: 1500 });
+    } catch (err) {
+      console.error('[StreamSessionReport] 复制诊断数据失败:', JSON.stringify(err));
+      ToastQueue.show({ message: '复制诊断数据失败', duration: 1600 });
     }
   }
 
@@ -874,6 +1015,25 @@ export struct StreamSessionReport {
             .enabled(!this.isSharing)
             .onClick(() => {
               this.shareReportImage();
+            })
+
+            Button() {
+              Text('复制诊断')
+                .fontSize(13)
+                .maxLines(1)
+                .textOverflow({ overflow: TextOverflow.Ellipsis })
+                .textAlign(TextAlign.Center)
+                .width('100%')
+            }
+            .layoutWeight(1)
+            .constraintSize({ minWidth: 0 })
+            .height(40)
+            .borderRadius(22)
+            .fontColor('#E8FFFFFF')
+            .backgroundColor('#22FFFFFF')
+            .clip(true)
+            .onClick(() => {
+              this.copyDiagnostics();
             })
 
             Button() {

--- a/entry/src/main/ets/pages/SettingsPageV2.ets
+++ b/entry/src/main/ets/pages/SettingsPageV2.ets
@@ -2354,6 +2354,14 @@ struct SettingsPageV2 {
                 }
               },
               {
+                title: '上次串流诊断',
+                subtitle: '复制最近一次串流的帧率与 PTS 调度数据',
+                type: 'action',
+                action: async () => {
+                  await this.copyLastStreamDiagnostics();
+                }
+              },
+              {
                 title: '更新日志',
                 subtitle: '查看版本更新历史',
                 type: 'action',
@@ -4051,6 +4059,24 @@ struct SettingsPageV2 {
   private async failDeveloperUnlockVerification(message: string): Promise<void> {
     this.developerMode = false;
     ToastQueue.show({ message: `开发者模式验证失败: ${message}`, duration: 3000 });
+  }
+
+  private async copyLastStreamDiagnostics(): Promise<void> {
+    try {
+      const diagnostics = await PreferencesUtil.get<string>(
+        SettingsKeys.LAST_STREAM_DIAGNOSTICS, '');
+      if (diagnostics.length === 0) {
+        this.showToast('暂无串流诊断数据');
+        return;
+      }
+      const pasteData = pasteboard.createData(
+        pasteboard.MIMETYPE_TEXT_PLAIN, diagnostics);
+      pasteboard.getSystemPasteboard().setDataSync(pasteData);
+      this.showToast('上次串流诊断已复制');
+    } catch (err) {
+      console.error('[SettingsPage] 复制串流诊断失败:', JSON.stringify(err));
+      this.showToast('复制串流诊断失败');
+    }
   }
 
   /**

--- a/entry/src/main/ets/pages/StreamPage.ets
+++ b/entry/src/main/ets/pages/StreamPage.ets
@@ -44,7 +44,7 @@ import { StreamLifecycleManager } from '../service/streaming/StreamLifecycleMana
 import { StreamIMEManager } from '../service/streaming/StreamIMEManager';
 import { VirtualKeyboard } from '../components/virtual/VirtualKeyboard';
 import { CustomKeyOverlay } from '../components/CustomKeyOverlay';
-import { StreamSessionReport, StreamReportData, StreamReportStats, StreamReportConfigSnapshot, createEmptyStreamReport, createStreamReportConfigSnapshot, buildStreamReportDataFromSnapshot, markStreamReportAiLoading } from '../components/StreamSessionReport';
+import { StreamSessionReport, StreamReportData, StreamReportStats, StreamReportConfigSnapshot, createEmptyStreamReport, createStreamReportConfigSnapshot, buildStreamReportDataFromSnapshot, buildStreamDiagnosticsText, markStreamReportAiLoading } from '../components/StreamSessionReport';
 import { CustomKeyManager, CustomKeyManagerHost, SessionLike } from '../service/customkey/CustomKeyManager';
 import { CustomKeyStore } from '../service/customkey/CustomKeyStore';
 import { PanZoomHandler, PanZoomState, PointXY } from '../service/input/PanZoomHandler';
@@ -98,6 +98,7 @@ class BuiltStreamReport {
   stats: StreamReportStats = new StreamReportStats();
   config: StreamReportConfigSnapshot | null = null;
   durationMs: number = 0;
+  diagnosticsText: string = '';
 }
 
 /** StreamPage 对 CustomKeyManager 的宿主回调实现 */
@@ -188,6 +189,7 @@ struct StreamPage {
   /** 串流结束后的可分享战报 */
   @State private showStreamReport: boolean = false;
   @State private streamReportData: StreamReportData = createEmptyStreamReport();
+  @State private streamDiagnosticsText: string = '';
   /** 用户设置：优先使用虚拟键盘 */
   private useVirtualKeyboard: boolean = false;
   /** 待对话框关闭后显示 IME */
@@ -1496,7 +1498,8 @@ struct StreamPage {
    */
   private buildCurrentStreamReport(): BuiltStreamReport {
     const session = this.viewModel.getSession();
-    const stats = session ? session.getSummaryStats() : this.viewModel.performanceStats;
+    const sessionStats = session ? session.getSummaryStats() : null;
+    const stats = sessionStats || this.viewModel.performanceStats;
     const durationMs = this.streamStartedAtMs > 0 ? Date.now() - this.streamStartedAtMs : 0;
     const snapshot = new StreamReportStats();
     snapshot.fps = stats.fps;
@@ -1516,12 +1519,50 @@ struct StreamPage {
     snapshot.droppedByL3 = stats.droppedByL3;
     snapshot.droppedByL4 = stats.droppedByL4;
     snapshot.droppedByL5 = stats.droppedByL5;
+    if (sessionStats) {
+      snapshot.codecOutputFps = sessionStats.codecOutputFps;
+      snapshot.codecOutputFrames = sessionStats.codecOutputFrames;
+      snapshot.framesLost = sessionStats.framesLost;
+      snapshot.totalFrames = sessionStats.totalFrames;
+      snapshot.droppedByQueueOverflow = sessionStats.droppedByQueueOverflow;
+      snapshot.droppedByTimeout = sessionStats.droppedByTimeout;
+      snapshot.syncDrainEvents = sessionStats.syncDrainEvents;
+      snapshot.syncDrainFrames = sessionStats.syncDrainFrames;
+      snapshot.syncDecode = sessionStats.syncDecode;
+      snapshot.hostPacedPresentationActive = sessionStats.hostPacedPresentationActive;
+      snapshot.presentationPrepared = sessionStats.presentationPrepared;
+      snapshot.presentationScheduled = sessionStats.presentationScheduled;
+      snapshot.presentationExpired = sessionStats.presentationExpired;
+      snapshot.presentationMissing = sessionStats.presentationMissing;
+      snapshot.presentationFuture = sessionStats.presentationFuture;
+      snapshot.presentationNonMonotonicDrops = sessionStats.presentationNonMonotonicDrops;
+      snapshot.presentationRenderFallbacks = sessionStats.presentationRenderFallbacks;
+      snapshot.presentationLeadUnder1Ms = sessionStats.presentationLeadUnder1Ms;
+      snapshot.presentationLead1To2Ms = sessionStats.presentationLead1To2Ms;
+      snapshot.presentationLead2To4Ms = sessionStats.presentationLead2To4Ms;
+      snapshot.presentationLead4To8Ms = sessionStats.presentationLead4To8Ms;
+      snapshot.presentationLeadAtLeast8Ms = sessionStats.presentationLeadAtLeast8Ms;
+      snapshot.presentationPendingHighWater = sessionStats.presentationPendingHighWater;
+    }
     const result = new BuiltStreamReport();
     result.stats = snapshot;
     result.config = createStreamReportConfigSnapshot(this.viewModel.streamConfig);
     result.durationMs = durationMs;
     result.data = buildStreamReportDataFromSnapshot(snapshot, result.config, this.appName || '远程游戏', durationMs);
+    result.diagnosticsText = buildStreamDiagnosticsText(
+      snapshot, result.config, this.appName || '远程游戏', durationMs);
     return result;
+  }
+
+  private async saveStreamDiagnostics(text: string): Promise<void> {
+    if (text.length === 0) {
+      return;
+    }
+    try {
+      await PreferencesUtil.put(SettingsKeys.LAST_STREAM_DIAGNOSTICS, text);
+    } catch (err) {
+      console.warn('[StreamPage] 保存串流诊断失败:', JSON.stringify(err));
+    }
   }
 
   private enrichStreamReportWithAi(report: BuiltStreamReport): void {
@@ -1731,6 +1772,9 @@ struct StreamPage {
 
     this.stopClipboardSync();
 
+    const report = this.buildCurrentStreamReport();
+    await this.saveStreamDiagnostics(report.diagnosticsText);
+
     if (!this.endStreamReportEnabled) {
       await this.prepareStreamEndUi();
       await this.exitStreamAndReturn();
@@ -1738,9 +1782,9 @@ struct StreamPage {
       return;
     }
 
-    const report = this.buildCurrentStreamReport();
     this.prepareStreamEndUiImmediate();
     this.streamReportData = report.data;
+    this.streamDiagnosticsText = report.diagnosticsText;
     this.showStreamReport = true;
     this.enrichStreamReportWithAi(report);
     this.runStreamShutdownInBackground('正在断开串流', async (): Promise<void> => {
@@ -1762,10 +1806,11 @@ struct StreamPage {
 
     this.stopClipboardSync();
 
-    const report = this.endStreamReportEnabled ? this.buildCurrentStreamReport() : null;
+    const report = this.buildCurrentStreamReport();
+    await this.saveStreamDiagnostics(report.diagnosticsText);
     this.prepareStreamEndUiImmediate();
 
-    if (!this.endStreamReportEnabled || !report) {
+    if (!this.endStreamReportEnabled) {
       await this.lifecycleManager.stopBackgroundTask();
       await this.sendLockScreenShortcutBeforeDisconnect();
       await this.exitStreamAndReturn();
@@ -1774,6 +1819,7 @@ struct StreamPage {
     }
 
     this.streamReportData = report.data;
+    this.streamDiagnosticsText = report.diagnosticsText;
     this.showStreamReport = true;
     this.enrichStreamReportWithAi(report);
     this.runStreamShutdownInBackground('正在退出游戏', async (): Promise<void> => {
@@ -2132,6 +2178,7 @@ struct StreamPage {
       if (this.showStreamReport) {
         StreamSessionReport({
           data: this.streamReportData,
+          diagnosticsText: this.streamDiagnosticsText,
           onClose: (): void => {
             this.closeStreamReportAndReturn();
           }

--- a/entry/src/main/ets/service/SettingsService.ets
+++ b/entry/src/main/ets/service/SettingsService.ets
@@ -154,6 +154,7 @@ export class SettingsKeys {
   static readonly PERF_OVERLAY_BG_OPACITY: string = 'settings_perf_overlay_bg_opacity';
   static readonly PERF_OVERLAY_GUIDE_SHOWN: string = 'settings_perf_overlay_guide_shown';
   static readonly LATENCY_TOAST: string = 'settings_latency_toast';
+  static readonly LAST_STREAM_DIAGNOSTICS: string = 'last_stream_diagnostics';
   static readonly DISABLE_WARNINGS: string = 'settings_disable_warnings';
   static readonly ENABLE_STUN: string = 'settings_enable_stun';
   static readonly ENABLE_ESC_MENU: string = 'settings_enable_esc_menu';

--- a/entry/src/main/ets/service/streaming/StreamingSession.ets
+++ b/entry/src/main/ets/service/streaming/StreamingSession.ets
@@ -55,6 +55,7 @@ import nativeLib from 'libmoonlight_nativelib.so';
  */
 export interface StreamStats {
   fps: number;             // 接收帧率 (Rx)
+  codecOutputFps: number;  // 解码器输出帧率
   renderedFps: number;     // 渲染帧率 (Rd)
   bitrate: number;         // Kbps
   latency: number;         // 解码延迟 ms (EMA 瞬时值)
@@ -62,7 +63,10 @@ export interface StreamStats {
   networkLatency: number;  // 网络延迟（RTT）ms
   packetLoss: number;      // %
   decodedFrames: number;
+  codecOutputFrames: number;
   droppedFrames: number;
+  framesLost: number;
+  totalFrames: number;
   globalAvgDecodeLatency: number;  // 全局平均解码延迟 ms
   globalAvgHostLatency: number;    // 全局平均主机延迟 ms
   globalAvgFps: number;            // 全局平均帧率
@@ -72,6 +76,25 @@ export interface StreamStats {
   droppedByL3: number;     // L3: 临界延迟 IDR 恢复
   droppedByL4: number;     // L4: 网络突发检测
   droppedByL5: number;     // L5: async 渲染跳帧
+  droppedByQueueOverflow: number;
+  droppedByTimeout: number;
+  syncDrainEvents: number;
+  syncDrainFrames: number;
+  syncDecode: boolean;
+  hostPacedPresentationActive: boolean;
+  presentationPrepared: number;
+  presentationScheduled: number;
+  presentationExpired: number;
+  presentationMissing: number;
+  presentationFuture: number;
+  presentationNonMonotonicDrops: number;
+  presentationRenderFallbacks: number;
+  presentationLeadUnder1Ms: number;
+  presentationLead1To2Ms: number;
+  presentationLead2To4Ms: number;
+  presentationLead4To8Ms: number;
+  presentationLeadAtLeast8Ms: number;
+  presentationPendingHighWater: number;
 }
 
 /**
@@ -197,9 +220,11 @@ interface StreamCallbacks {
 
 interface VideoStats {
   framesDecoded: number;
+  codecOutputFrames: number;
   framesDropped: number;
   avgDecodeTimeMs: number;
   fps: number;
+  codecOutputFps: number;
   renderedFps: number;
   bitrate: number;
   hostLatency: number;
@@ -219,6 +244,23 @@ interface VideoStats {
   droppedByL5: number;
   droppedByQueueOverflow: number;
   droppedByTimeout: number;
+  syncDrainEvents: number;
+  syncDrainFrames: number;
+  syncDecode: boolean;
+  hostPacedPresentationActive: boolean;
+  presentationPrepared: number;
+  presentationScheduled: number;
+  presentationExpired: number;
+  presentationMissing: number;
+  presentationFuture: number;
+  presentationNonMonotonicDrops: number;
+  presentationRenderFallbacks: number;
+  presentationLeadUnder1Ms: number;
+  presentationLead1To2Ms: number;
+  presentationLead2To4Ms: number;
+  presentationLead4To8Ms: number;
+  presentationLeadAtLeast8Ms: number;
+  presentationPendingHighWater: number;
 }
 
 interface ControllerState {
@@ -393,11 +435,21 @@ export class StreamingSession {
   // ---------------------------------------------------------------------------
 
   private stats: StreamStats = {
-    fps: 0, renderedFps: 0, bitrate: 0, latency: 0,
+    fps: 0, codecOutputFps: 0, renderedFps: 0, bitrate: 0, latency: 0,
     hostLatency: 0, networkLatency: 0, packetLoss: 0,
-    decodedFrames: 0, droppedFrames: 0,
+    decodedFrames: 0, codecOutputFrames: 0, droppedFrames: 0,
+    framesLost: 0, totalFrames: 0,
     globalAvgDecodeLatency: 0, globalAvgHostLatency: 0, globalAvgFps: 0,
-    droppedByL1: 0, droppedByL2: 0, droppedByL3: 0, droppedByL4: 0, droppedByL5: 0
+    droppedByL1: 0, droppedByL2: 0, droppedByL3: 0, droppedByL4: 0, droppedByL5: 0,
+    droppedByQueueOverflow: 0, droppedByTimeout: 0,
+    syncDrainEvents: 0, syncDrainFrames: 0,
+    syncDecode: false, hostPacedPresentationActive: false,
+    presentationPrepared: 0, presentationScheduled: 0,
+    presentationExpired: 0, presentationMissing: 0, presentationFuture: 0,
+    presentationNonMonotonicDrops: 0, presentationRenderFallbacks: 0,
+    presentationLeadUnder1Ms: 0, presentationLead1To2Ms: 0,
+    presentationLead2To4Ms: 0, presentationLead4To8Ms: 0,
+    presentationLeadAtLeast8Ms: 0, presentationPendingHighWater: 0
   };
   private lastValidStats: StreamStats | null = null;
 
@@ -826,8 +878,10 @@ export class StreamingSession {
     try {
       const vs = this.nativeModule.getVideoStats();
       this.stats.decodedFrames = vs.framesDecoded;
+      this.stats.codecOutputFrames = vs.codecOutputFrames || 0;
       this.stats.droppedFrames = vs.framesDropped;
       this.stats.fps = vs.fps || 0;
+      this.stats.codecOutputFps = vs.codecOutputFps || 0;
       this.stats.renderedFps = vs.renderedFps || 0;
       this.stats.bitrate = vs.bitrate || 0;
       this.stats.latency = vs.avgDecodeTimeMs || 0;
@@ -836,6 +890,8 @@ export class StreamingSession {
       // 滑动窗口丢包率（对齐 Android: ~2秒窗口 = lastWindow + activeWindow）
       const totalFrames = vs.totalFrames || 0;
       const framesLost = vs.framesLost || 0;
+      this.stats.totalFrames = totalFrames;
+      this.stats.framesLost = framesLost;
       const now = Date.now();
       if (this.lastWindowFlipTime === 0) {
         // 首次调用：初始化窗口
@@ -863,6 +919,25 @@ export class StreamingSession {
       this.stats.droppedByL3 = vs.droppedByL3 || 0;
       this.stats.droppedByL4 = vs.droppedByL4 || 0;
       this.stats.droppedByL5 = vs.droppedByL5 || 0;
+      this.stats.droppedByQueueOverflow = vs.droppedByQueueOverflow || 0;
+      this.stats.droppedByTimeout = vs.droppedByTimeout || 0;
+      this.stats.syncDrainEvents = vs.syncDrainEvents || 0;
+      this.stats.syncDrainFrames = vs.syncDrainFrames || 0;
+      this.stats.syncDecode = vs.syncDecode || false;
+      this.stats.hostPacedPresentationActive = vs.hostPacedPresentationActive || false;
+      this.stats.presentationPrepared = vs.presentationPrepared || 0;
+      this.stats.presentationScheduled = vs.presentationScheduled || 0;
+      this.stats.presentationExpired = vs.presentationExpired || 0;
+      this.stats.presentationMissing = vs.presentationMissing || 0;
+      this.stats.presentationFuture = vs.presentationFuture || 0;
+      this.stats.presentationNonMonotonicDrops = vs.presentationNonMonotonicDrops || 0;
+      this.stats.presentationRenderFallbacks = vs.presentationRenderFallbacks || 0;
+      this.stats.presentationLeadUnder1Ms = vs.presentationLeadUnder1Ms || 0;
+      this.stats.presentationLead1To2Ms = vs.presentationLead1To2Ms || 0;
+      this.stats.presentationLead2To4Ms = vs.presentationLead2To4Ms || 0;
+      this.stats.presentationLead4To8Ms = vs.presentationLead4To8Ms || 0;
+      this.stats.presentationLeadAtLeast8Ms = vs.presentationLeadAtLeast8Ms || 0;
+      this.stats.presentationPendingHighWater = vs.presentationPendingHighWater || 0;
 
       if ((vs.validDecodeFrames || 0) > 0) {
         this.stats.globalAvgDecodeLatency = (vs.totalDecodeTimeMs || 0) / vs.validDecodeFrames;
@@ -882,6 +957,7 @@ export class StreamingSession {
 
     const copy: StreamStats = {
       fps: this.stats.fps,
+      codecOutputFps: this.stats.codecOutputFps,
       renderedFps: this.stats.renderedFps,
       bitrate: this.stats.bitrate,
       latency: this.stats.latency,
@@ -889,7 +965,10 @@ export class StreamingSession {
       networkLatency: this.stats.networkLatency,
       packetLoss: this.stats.packetLoss,
       decodedFrames: this.stats.decodedFrames,
+      codecOutputFrames: this.stats.codecOutputFrames,
       droppedFrames: this.stats.droppedFrames,
+      framesLost: this.stats.framesLost,
+      totalFrames: this.stats.totalFrames,
       globalAvgDecodeLatency: this.stats.globalAvgDecodeLatency,
       globalAvgHostLatency: this.stats.globalAvgHostLatency,
       globalAvgFps: this.stats.globalAvgFps,
@@ -898,8 +977,28 @@ export class StreamingSession {
       droppedByL3: this.stats.droppedByL3,
       droppedByL4: this.stats.droppedByL4,
       droppedByL5: this.stats.droppedByL5,
+      droppedByQueueOverflow: this.stats.droppedByQueueOverflow,
+      droppedByTimeout: this.stats.droppedByTimeout,
+      syncDrainEvents: this.stats.syncDrainEvents,
+      syncDrainFrames: this.stats.syncDrainFrames,
+      syncDecode: this.stats.syncDecode,
+      hostPacedPresentationActive: this.stats.hostPacedPresentationActive,
+      presentationPrepared: this.stats.presentationPrepared,
+      presentationScheduled: this.stats.presentationScheduled,
+      presentationExpired: this.stats.presentationExpired,
+      presentationMissing: this.stats.presentationMissing,
+      presentationFuture: this.stats.presentationFuture,
+      presentationNonMonotonicDrops: this.stats.presentationNonMonotonicDrops,
+      presentationRenderFallbacks: this.stats.presentationRenderFallbacks,
+      presentationLeadUnder1Ms: this.stats.presentationLeadUnder1Ms,
+      presentationLead1To2Ms: this.stats.presentationLead1To2Ms,
+      presentationLead2To4Ms: this.stats.presentationLead2To4Ms,
+      presentationLead4To8Ms: this.stats.presentationLead4To8Ms,
+      presentationLeadAtLeast8Ms: this.stats.presentationLeadAtLeast8Ms,
+      presentationPendingHighWater: this.stats.presentationPendingHighWater,
     };
     copy.fps = Math.round(copy.fps);
+    copy.codecOutputFps = Math.round(copy.codecOutputFps);
     copy.renderedFps = Math.round(copy.renderedFps);
     copy.bitrate = Math.round(copy.bitrate);
 

--- a/nativelib/src/main/cpp/CMakeLists.txt
+++ b/nativelib/src/main/cpp/CMakeLists.txt
@@ -86,6 +86,7 @@ set(SOURCE_FILES
     usb_ddk_poller.cpp
     native_render.cpp
     presentation_scheduler.cpp
+    two_step_presentation_scheduler.cpp
     rolling_frame_rate.cpp
     gl_post_processor.cpp
     sdl_gamecontrollerdb.cpp

--- a/nativelib/src/main/cpp/moonlight_bridge.cpp
+++ b/nativelib/src/main/cpp/moonlight_bridge.cpp
@@ -1724,74 +1724,15 @@ napi_value MoonBridge_ReleaseVideoSurface(napi_env env, napi_callback_info info)
 napi_value MoonBridge_GetVideoStats(napi_env env, napi_callback_info info) {
     napi_value result;
     napi_create_object(env, &result);
-    
-    auto stats = VideoDecoderInstance::GetStats();
-    
-    napi_value framesDecoded, framesDropped, avgDecodeTime;
-    napi_value fps, codecOutputFps, renderedFps, bitrate, hostLatency;
-    napi_value totalDecodeTime, validDecodeFrames, totalHostLatency, framesWithHostLat;
-    
-    napi_create_uint32(env, static_cast<uint32_t>(stats.decodedFrames), &framesDecoded);
-    napi_create_uint32(env, static_cast<uint32_t>(stats.droppedFrames), &framesDropped);
-    napi_create_double(env, stats.averageDecodeTimeMs, &avgDecodeTime);
-    napi_create_double(env, stats.currentFps, &fps);          // 接收帧率 (Rx)
-    napi_create_double(env, stats.codecOutputFps, &codecOutputFps);
-    napi_create_double(env, stats.renderedFps, &renderedFps); // 渲染帧率 (Rd)
-    napi_create_double(env, stats.currentBitrate, &bitrate);
-    napi_create_double(env, stats.recentHostProcessingLatency, &hostLatency);  // 最近 1 秒主机处理延迟
-    
-    // 网络丢帧统计
-    napi_value framesLost, totalFrames;
-    napi_create_uint32(env, static_cast<uint32_t>(stats.framesLost), &framesLost);
-    napi_create_uint32(env, static_cast<uint32_t>(stats.totalFrames), &totalFrames);
-    
-    // 累积值（用于串流结束后计算全局平均）
-    napi_value globalAvgFps;
-    napi_create_double(env, stats.totalDecodeTimeMs, &totalDecodeTime);
-    napi_create_uint32(env, static_cast<uint32_t>(stats.validDecodeFrames), &validDecodeFrames);
-    napi_create_double(env, stats.totalHostProcessingLatency, &totalHostLatency);
-    napi_create_uint32(env, static_cast<uint32_t>(stats.framesWithHostLatency), &framesWithHostLat);
-    napi_create_double(env, stats.globalAvgFps, &globalAvgFps);
-    
-    napi_set_named_property(env, result, "framesDecoded", framesDecoded);
-    napi_set_named_property(env, result, "framesDropped", framesDropped);
-    napi_set_named_property(env, result, "avgDecodeTimeMs", avgDecodeTime);
-    napi_set_named_property(env, result, "fps", fps);             // 接收帧率 (Rx)
-    napi_set_named_property(env, result, "codecOutputFps", codecOutputFps);
-    napi_set_named_property(env, result, "renderedFps", renderedFps); // 渲染帧率 (Rd)
-    napi_set_named_property(env, result, "bitrate", bitrate);
-    napi_set_named_property(env, result, "hostLatency", hostLatency);  // 最近 1 秒主机处理延迟（编码时间）
-    napi_set_named_property(env, result, "framesLost", framesLost);
-    napi_set_named_property(env, result, "totalFrames", totalFrames);
-    
-    // 累积值
-    napi_set_named_property(env, result, "totalDecodeTimeMs", totalDecodeTime);
-    napi_set_named_property(env, result, "validDecodeFrames", validDecodeFrames);
-    napi_set_named_property(env, result, "totalHostLatencyMs", totalHostLatency);
-    napi_set_named_property(env, result, "framesWithHostLatency", framesWithHostLat);
-    napi_set_named_property(env, result, "globalAvgFps", globalAvgFps);
-    
-    // 分类丢帧统计（用于诊断性能问题）
-    napi_value dropL1, dropL2, dropL3, dropL4, dropL5, dropQueue, dropTimeout;
-    napi_create_uint32(env, static_cast<uint32_t>(stats.droppedByL1), &dropL1);
-    napi_create_uint32(env, static_cast<uint32_t>(stats.droppedByL2), &dropL2);
-    napi_create_uint32(env, static_cast<uint32_t>(stats.droppedByL3), &dropL3);
-    napi_create_uint32(env, static_cast<uint32_t>(stats.droppedByL4), &dropL4);
-    napi_create_uint32(env, static_cast<uint32_t>(stats.droppedByL5), &dropL5);
-    napi_create_uint32(env, static_cast<uint32_t>(stats.droppedByQueueOverflow), &dropQueue);
-    napi_create_uint32(env, static_cast<uint32_t>(stats.droppedByTimeout), &dropTimeout);
-    napi_set_named_property(env, result, "droppedByL1", dropL1);
-    napi_set_named_property(env, result, "droppedByL2", dropL2);
-    napi_set_named_property(env, result, "droppedByL3", dropL3);
-    napi_set_named_property(env, result, "droppedByL4", dropL4);
-    napi_set_named_property(env, result, "droppedByL5", dropL5);
-    napi_set_named_property(env, result, "droppedByQueueOverflow", dropQueue);
-    napi_set_named_property(env, result, "droppedByTimeout", dropTimeout);
 
-    auto setCounter = [env, result](const char* name, uint64_t value) {
+    const VideoDecoderStats stats = VideoDecoderInstance::GetStats();
+    auto setNumber = [env, result](const char* name, double value) {
         napi_value jsValue;
-        napi_create_double(env, static_cast<double>(value), &jsValue);
+        napi_create_double(env, value, &jsValue);
         napi_set_named_property(env, result, name, jsValue);
+    };
+    auto setCounter = [&setNumber](const char* name, uint64_t value) {
+        setNumber(name, static_cast<double>(value));
     };
     auto setBoolean = [env, result](const char* name, bool value) {
         napi_value jsValue;
@@ -1799,24 +1740,46 @@ napi_value MoonBridge_GetVideoStats(napi_env env, napi_callback_info info) {
         napi_set_named_property(env, result, name, jsValue);
     };
 
+    setCounter("framesDecoded", stats.decodedFrames);
     setCounter("codecOutputFrames", stats.codecOutputFrames);
+    setCounter("framesDropped", stats.droppedFrames);
+    setNumber("avgDecodeTimeMs", stats.averageDecodeTimeMs);
+    setNumber("fps", stats.currentFps);
+    setNumber("codecOutputFps", stats.codecOutputFps);
+    setNumber("renderedFps", stats.renderedFps);
+    setNumber("bitrate", stats.currentBitrate);
+    setNumber("hostLatency", stats.recentHostProcessingLatency);
+    setCounter("framesLost", stats.framesLost);
+    setCounter("totalFrames", stats.totalFrames);
+    setNumber("totalDecodeTimeMs", stats.totalDecodeTimeMs);
+    setCounter("validDecodeFrames", stats.validDecodeFrames);
+    setNumber("totalHostLatencyMs", stats.totalHostProcessingLatency);
+    setCounter("framesWithHostLatency", stats.framesWithHostLatency);
+    setNumber("globalAvgFps", stats.globalAvgFps);
+    setCounter("droppedByL1", stats.droppedByL1);
+    setCounter("droppedByL2", stats.droppedByL2);
+    setCounter("droppedByL3", stats.droppedByL3);
+    setCounter("droppedByL4", stats.droppedByL4);
+    setCounter("droppedByL5", stats.droppedByL5);
+    setCounter("droppedByQueueOverflow", stats.droppedByQueueOverflow);
+    setCounter("droppedByTimeout", stats.droppedByTimeout);
     setCounter("syncDrainEvents", stats.syncDrainEvents);
     setCounter("syncDrainFrames", stats.syncDrainFrames);
     setBoolean("syncDecode", stats.syncDecode);
     setBoolean("hostPacedPresentationActive", stats.hostPacedPresentationActive);
-    setCounter("presentationPrepared", stats.presentationPrepared);
-    setCounter("presentationScheduled", stats.presentationScheduled);
-    setCounter("presentationExpired", stats.presentationExpired);
-    setCounter("presentationMissing", stats.presentationMissing);
-    setCounter("presentationFuture", stats.presentationFuture);
-    setCounter("presentationNonMonotonicDrops", stats.presentationNonMonotonicDrops);
-    setCounter("presentationRenderFallbacks", stats.presentationRenderFallbacks);
-    setCounter("presentationLeadUnder1Ms", stats.presentationLeadUnder1Ms);
-    setCounter("presentationLead1To2Ms", stats.presentationLead1To2Ms);
-    setCounter("presentationLead2To4Ms", stats.presentationLead2To4Ms);
-    setCounter("presentationLead4To8Ms", stats.presentationLead4To8Ms);
-    setCounter("presentationLeadAtLeast8Ms", stats.presentationLeadAtLeast8Ms);
-    setCounter("presentationPendingHighWater", stats.presentationPendingHighWater);
+    setCounter("presentationPrepared", stats.presentation.preparedTargets);
+    setCounter("presentationScheduled", stats.presentation.scheduledFrames);
+    setCounter("presentationExpired", stats.presentation.expiredTargets);
+    setCounter("presentationMissing", stats.presentation.missingTargets);
+    setCounter("presentationFuture", stats.presentation.futureTargets);
+    setCounter("presentationNonMonotonicDrops", stats.presentation.nonMonotonicDrops);
+    setCounter("presentationRenderFallbacks", stats.presentation.renderAtTimeFallbacks);
+    setCounter("presentationLeadUnder1Ms", stats.presentation.leadUnder1Ms);
+    setCounter("presentationLead1To2Ms", stats.presentation.lead1To2Ms);
+    setCounter("presentationLead2To4Ms", stats.presentation.lead2To4Ms);
+    setCounter("presentationLead4To8Ms", stats.presentation.lead4To8Ms);
+    setCounter("presentationLeadAtLeast8Ms", stats.presentation.leadAtLeast8Ms);
+    setCounter("presentationPendingHighWater", stats.presentation.pendingHighWater);
     
     return result;
 }

--- a/nativelib/src/main/cpp/moonlight_bridge.cpp
+++ b/nativelib/src/main/cpp/moonlight_bridge.cpp
@@ -1728,13 +1728,14 @@ napi_value MoonBridge_GetVideoStats(napi_env env, napi_callback_info info) {
     auto stats = VideoDecoderInstance::GetStats();
     
     napi_value framesDecoded, framesDropped, avgDecodeTime;
-    napi_value fps, renderedFps, bitrate, hostLatency;
+    napi_value fps, codecOutputFps, renderedFps, bitrate, hostLatency;
     napi_value totalDecodeTime, validDecodeFrames, totalHostLatency, framesWithHostLat;
     
     napi_create_uint32(env, static_cast<uint32_t>(stats.decodedFrames), &framesDecoded);
     napi_create_uint32(env, static_cast<uint32_t>(stats.droppedFrames), &framesDropped);
     napi_create_double(env, stats.averageDecodeTimeMs, &avgDecodeTime);
     napi_create_double(env, stats.currentFps, &fps);          // 接收帧率 (Rx)
+    napi_create_double(env, stats.codecOutputFps, &codecOutputFps);
     napi_create_double(env, stats.renderedFps, &renderedFps); // 渲染帧率 (Rd)
     napi_create_double(env, stats.currentBitrate, &bitrate);
     napi_create_double(env, stats.recentHostProcessingLatency, &hostLatency);  // 最近 1 秒主机处理延迟
@@ -1756,6 +1757,7 @@ napi_value MoonBridge_GetVideoStats(napi_env env, napi_callback_info info) {
     napi_set_named_property(env, result, "framesDropped", framesDropped);
     napi_set_named_property(env, result, "avgDecodeTimeMs", avgDecodeTime);
     napi_set_named_property(env, result, "fps", fps);             // 接收帧率 (Rx)
+    napi_set_named_property(env, result, "codecOutputFps", codecOutputFps);
     napi_set_named_property(env, result, "renderedFps", renderedFps); // 渲染帧率 (Rd)
     napi_set_named_property(env, result, "bitrate", bitrate);
     napi_set_named_property(env, result, "hostLatency", hostLatency);  // 最近 1 秒主机处理延迟（编码时间）
@@ -1785,6 +1787,36 @@ napi_value MoonBridge_GetVideoStats(napi_env env, napi_callback_info info) {
     napi_set_named_property(env, result, "droppedByL5", dropL5);
     napi_set_named_property(env, result, "droppedByQueueOverflow", dropQueue);
     napi_set_named_property(env, result, "droppedByTimeout", dropTimeout);
+
+    auto setCounter = [env, result](const char* name, uint64_t value) {
+        napi_value jsValue;
+        napi_create_double(env, static_cast<double>(value), &jsValue);
+        napi_set_named_property(env, result, name, jsValue);
+    };
+    auto setBoolean = [env, result](const char* name, bool value) {
+        napi_value jsValue;
+        napi_get_boolean(env, value, &jsValue);
+        napi_set_named_property(env, result, name, jsValue);
+    };
+
+    setCounter("codecOutputFrames", stats.codecOutputFrames);
+    setCounter("syncDrainEvents", stats.syncDrainEvents);
+    setCounter("syncDrainFrames", stats.syncDrainFrames);
+    setBoolean("syncDecode", stats.syncDecode);
+    setBoolean("hostPacedPresentationActive", stats.hostPacedPresentationActive);
+    setCounter("presentationPrepared", stats.presentationPrepared);
+    setCounter("presentationScheduled", stats.presentationScheduled);
+    setCounter("presentationExpired", stats.presentationExpired);
+    setCounter("presentationMissing", stats.presentationMissing);
+    setCounter("presentationFuture", stats.presentationFuture);
+    setCounter("presentationNonMonotonicDrops", stats.presentationNonMonotonicDrops);
+    setCounter("presentationRenderFallbacks", stats.presentationRenderFallbacks);
+    setCounter("presentationLeadUnder1Ms", stats.presentationLeadUnder1Ms);
+    setCounter("presentationLead1To2Ms", stats.presentationLead1To2Ms);
+    setCounter("presentationLead2To4Ms", stats.presentationLead2To4Ms);
+    setCounter("presentationLead4To8Ms", stats.presentationLead4To8Ms);
+    setCounter("presentationLeadAtLeast8Ms", stats.presentationLeadAtLeast8Ms);
+    setCounter("presentationPendingHighWater", stats.presentationPendingHighWater);
     
     return result;
 }

--- a/nativelib/src/main/cpp/native_render.cpp
+++ b/nativelib/src/main/cpp/native_render.cpp
@@ -246,6 +246,11 @@ bool NativeRender::IsHostPacedPresentationActive() const {
     return hostPacedPresentationEnabled_.load() && GetRenderAtTimeFunc() != nullptr;
 }
 
+TwoStepPresentationStats NativeRender::GetTwoStepPresentationStats() const {
+    std::lock_guard<std::mutex> lock(presentationMutex_);
+    return twoStepScheduler_.GetStats();
+}
+
 PresentationTargetHandle NativeRender::PreparePresentationFrame(int64_t ptsUs) {
     if (!IsHostPacedPresentationActive()) {
         return {};
@@ -397,6 +402,7 @@ void NativeRender::ResetPresentationStatsLocked() {
     vsyncFrameCount_ = 0;
     vsyncLateFrameCount_ = 0;
     vsyncResyncCount_ = 0;
+    twoStepScheduler_.ResetStats();
 }
 
 void NativeRender::ResetPresentationClock() {
@@ -524,6 +530,10 @@ NativeRender::FrameSubmitResult NativeRender::SubmitFrame(const DecodedFrame& fr
                     bufferConsumed = true;
                     framePresented = true;
                 } else {
+                    {
+                        std::lock_guard<std::mutex> lock(presentationMutex_);
+                        twoStepScheduler_.NoteRenderAtTimeFallback();
+                    }
                     OH_LOG_WARN(LOG_APP,
                         "Host-paced render failed: %{public}d, pts=%{public}lld, targetNs=%{public}lld; falling back",
                         renderResult, static_cast<long long>(frame.ptsUs),

--- a/nativelib/src/main/cpp/native_render.cpp
+++ b/nativelib/src/main/cpp/native_render.cpp
@@ -202,7 +202,7 @@ void NativeRender::SetConfiguredFps(double fps) {
     {
         std::lock_guard<std::mutex> lock(presentationMutex_);
         configuredFps_.store(fps);
-        ptsScheduler_.Configure(fps);
+        twoStepScheduler_.Configure(fps);
         ResetPresentationClockLocked();
     }
     OH_LOG_INFO(LOG_APP, "Configured FPS set to: %.3f", fps);
@@ -244,6 +244,25 @@ void NativeRender::SetHostPacedPresentationEnabled(bool enable) {
 
 bool NativeRender::IsHostPacedPresentationActive() const {
     return hostPacedPresentationEnabled_.load() && GetRenderAtTimeFunc() != nullptr;
+}
+
+bool NativeRender::PreparePresentationFrame(int64_t ptsUs) {
+    if (!IsHostPacedPresentationActive()) {
+        return false;
+    }
+
+    const int64_t preparedAtNs = GetMonotonicTimeNs();
+    std::lock_guard<std::mutex> lock(presentationMutex_);
+    return twoStepScheduler_.PrepareFrame(ptsUs, preparedAtNs);
+}
+
+void NativeRender::DiscardPresentationFrame(int64_t ptsUs) {
+    if (!hostPacedPresentationEnabled_.load()) {
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(presentationMutex_);
+    twoStepScheduler_.DiscardFrame(ptsUs);
 }
 
 void NativeRender::ConfigureNativeWindow() {
@@ -356,7 +375,7 @@ void NativeRender::ApplyFrameRateRange() {
 // =============================================================================
 
 void NativeRender::ResetPresentationClockLocked() {
-    ptsScheduler_.Reset();
+    twoStepScheduler_.Reset();
     timeBaseInitialized_ = false;
     estimatedOffsetNs_ = 0;
     skewNs_ = 0;
@@ -477,14 +496,17 @@ NativeRender::FrameSubmitResult NativeRender::SubmitFrame(const DecodedFrame& fr
             }
         } else {
             const int64_t decodedAtNs = GetMonotonicTimeNs();
-            PresentationPlan plan;
+            PreparedPresentationPlan plan;
             {
                 std::lock_guard<std::mutex> lock(presentationMutex_);
-                plan = ptsScheduler_.PlanFrame(frame.ptsUs, decodedAtNs);
+                plan = twoStepScheduler_.PlanDecodedFrame(
+                    frame.ptsUs, decodedAtNs);
             }
 
-            if (plan.action == PresentationAction::DROP) {
+            if (plan.action == PreparedPresentationAction::DROP) {
                 renderResult = freeFrame();
+            } else if (plan.action == PreparedPresentationAction::IMMEDIATE) {
+                renderResult = renderImmediately();
             } else {
                 renderResult = renderAtTime(
                     frame.codec, frame.bufferIndex, plan.targetTimeNs);

--- a/nativelib/src/main/cpp/native_render.cpp
+++ b/nativelib/src/main/cpp/native_render.cpp
@@ -246,14 +246,24 @@ bool NativeRender::IsHostPacedPresentationActive() const {
     return hostPacedPresentationEnabled_.load() && GetRenderAtTimeFunc() != nullptr;
 }
 
-bool NativeRender::PreparePresentationFrame(int64_t ptsUs) {
+PresentationTargetHandle NativeRender::PreparePresentationFrame(int64_t ptsUs) {
     if (!IsHostPacedPresentationActive()) {
-        return false;
+        return {};
     }
 
     const int64_t preparedAtNs = GetMonotonicTimeNs();
     std::lock_guard<std::mutex> lock(presentationMutex_);
     return twoStepScheduler_.PrepareFrame(ptsUs, preparedAtNs);
+}
+
+void NativeRender::DiscardPresentationFrame(
+        PresentationTargetHandle handle) {
+    if (!handle) {
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(presentationMutex_);
+    twoStepScheduler_.DiscardFrame(handle);
 }
 
 void NativeRender::DiscardPresentationFrame(int64_t ptsUs) {

--- a/nativelib/src/main/cpp/native_render.h
+++ b/nativelib/src/main/cpp/native_render.h
@@ -85,6 +85,7 @@ public:
     */
     void SetHostPacedPresentationEnabled(bool enable);
     bool IsHostPacedPresentationActive() const;
+    TwoStepPresentationStats GetTwoStepPresentationStats() const;
 
     // Step 1: reserve the host-PTS target before the frame enters the decoder.
     PresentationTargetHandle PreparePresentationFrame(int64_t ptsUs);

--- a/nativelib/src/main/cpp/native_render.h
+++ b/nativelib/src/main/cpp/native_render.h
@@ -30,7 +30,7 @@
 #include <multimedia/player_framework/native_avcodec_videodecoder.h>
 #include <hilog/log.h>
 
-#include "presentation_scheduler.h"
+#include "two_step_presentation_scheduler.h"
 
 #include <cstdint>
 #include <mutex>
@@ -85,6 +85,10 @@ public:
     */
     void SetHostPacedPresentationEnabled(bool enable);
     bool IsHostPacedPresentationActive() const;
+
+    // Step 1: reserve the host-PTS target before the frame enters the decoder.
+    bool PreparePresentationFrame(int64_t ptsUs);
+    void DiscardPresentationFrame(int64_t ptsUs);
     
     /**
      * 强制下一帧重新锚定（Flush/重连/Surface 切换）。
@@ -161,7 +165,7 @@ private:
     // Timed presentation state. Legacy VSync and host-paced presentation use
     // separate clocks so switching decoder modes cannot perturb PTS cadence.
     mutable std::mutex presentationMutex_;
-    PtsPresentationScheduler ptsScheduler_;
+    TwoStepPresentationScheduler twoStepScheduler_;
 
     // Legacy VSync clock, kept isolated from the host-paced scheduler.
     int64_t estimatedOffsetNs_ = 0;  // 平滑后的 (本地 - host) 偏移均值(纳秒)

--- a/nativelib/src/main/cpp/native_render.h
+++ b/nativelib/src/main/cpp/native_render.h
@@ -87,7 +87,8 @@ public:
     bool IsHostPacedPresentationActive() const;
 
     // Step 1: reserve the host-PTS target before the frame enters the decoder.
-    bool PreparePresentationFrame(int64_t ptsUs);
+    PresentationTargetHandle PreparePresentationFrame(int64_t ptsUs);
+    void DiscardPresentationFrame(PresentationTargetHandle handle);
     void DiscardPresentationFrame(int64_t ptsUs);
     
     /**

--- a/nativelib/src/main/cpp/presentation_scheduler.h
+++ b/nativelib/src/main/cpp/presentation_scheduler.h
@@ -45,6 +45,7 @@ public:
     PresentationPlan PlanFrame(int64_t ptsUs, int64_t decodedAtNs);
 
     int64_t GetInitialLeadNs() const { return initialLeadNs_; }
+    int64_t GetSubmitLeadNs() const { return submitLeadNs_; }
 
 private:
     PresentationPlan AnchorFrame(int64_t ptsUs, int64_t decodedAtNs,

--- a/nativelib/src/main/cpp/two_step_presentation_scheduler.cpp
+++ b/nativelib/src/main/cpp/two_step_presentation_scheduler.cpp
@@ -20,6 +20,7 @@ void TwoStepPresentationScheduler::Configure(double fps) {
     submitLeadNs_ = scheduler_.GetSubmitLeadNs();
     maxFutureLeadNs_ = frameIntervalNs * kMaxFutureIntervals;
     Reset();
+    ResetStats();
 }
 
 void TwoStepPresentationScheduler::Reset() {
@@ -48,6 +49,9 @@ PresentationTargetHandle TwoStepPresentationScheduler::StoreTarget(
     }
     target = {handle.id_, ptsUs, targetTimeNs, true};
     targetWriteIndex_ = (targetWriteIndex_ + 1) % targets_.size();
+    stats_.preparedTargets++;
+    stats_.pendingHighWater = std::max<uint64_t>(
+        stats_.pendingHighWater, pendingTargetCount_);
     return handle;
 }
 
@@ -106,12 +110,35 @@ void TwoStepPresentationScheduler::NoteSubmittedPts(int64_t ptsUs) {
     hasSubmittedPts_ = true;
 }
 
+void TwoStepPresentationScheduler::RecordTargetLead(int64_t targetLeadNs) {
+    if (targetLeadNs < kNanosecondsPerMillisecond) {
+        stats_.leadUnder1Ms++;
+    } else if (targetLeadNs < 2 * kNanosecondsPerMillisecond) {
+        stats_.lead1To2Ms++;
+    } else if (targetLeadNs < 4 * kNanosecondsPerMillisecond) {
+        stats_.lead2To4Ms++;
+    } else if (targetLeadNs < 8 * kNanosecondsPerMillisecond) {
+        stats_.lead4To8Ms++;
+    } else {
+        stats_.leadAtLeast8Ms++;
+    }
+}
+
+void TwoStepPresentationScheduler::NoteRenderAtTimeFallback() {
+    stats_.renderAtTimeFallbacks++;
+}
+
+void TwoStepPresentationScheduler::ResetStats() {
+    stats_ = {};
+}
+
 PreparedPresentationPlan TwoStepPresentationScheduler::PlanDecodedFrame(
         int64_t ptsUs, int64_t decodedAtNs) {
     PreparedPresentationPlan plan;
     if (hasSubmittedPts_ && ptsUs <= lastSubmittedPtsUs_) {
         plan.action = PreparedPresentationAction::DROP;
         plan.event = PreparedPresentationEvent::NON_MONOTONIC_PTS;
+        stats_.nonMonotonicDrops++;
         DiscardFrame(ptsUs);
         return plan;
     }
@@ -119,24 +146,29 @@ PreparedPresentationPlan TwoStepPresentationScheduler::PlanDecodedFrame(
     int64_t targetTimeNs = 0;
     if (!TakeTarget(ptsUs, targetTimeNs)) {
         plan.event = PreparedPresentationEvent::MISSING_TARGET;
+        stats_.missingTargets++;
         return plan;
     }
 
     const int64_t targetLeadNs = targetTimeNs - decodedAtNs;
     plan.targetLeadNs = targetLeadNs;
+    RecordTargetLead(targetLeadNs);
     if (targetLeadNs < submitLeadNs_) {
         plan.event = PreparedPresentationEvent::EXPIRED_TARGET;
+        stats_.expiredTargets++;
         NoteSubmittedPts(ptsUs);
         return plan;
     }
     if (targetLeadNs > maxFutureLeadNs_) {
         plan.event = PreparedPresentationEvent::FUTURE_TARGET;
+        stats_.futureTargets++;
         NoteSubmittedPts(ptsUs);
         return plan;
     }
 
     plan.action = PreparedPresentationAction::SCHEDULE;
     plan.targetTimeNs = targetTimeNs;
+    stats_.scheduledFrames++;
     NoteSubmittedPts(ptsUs);
     return plan;
 }

--- a/nativelib/src/main/cpp/two_step_presentation_scheduler.cpp
+++ b/nativelib/src/main/cpp/two_step_presentation_scheduler.cpp
@@ -1,0 +1,122 @@
+#include "two_step_presentation_scheduler.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace {
+constexpr int64_t kNanosecondsPerSecond = 1000000000LL;
+constexpr int64_t kNanosecondsPerMillisecond = 1000000LL;
+constexpr double kDefaultFps = 60.0;
+constexpr int64_t kMaxFutureIntervals = 3;
+} // namespace
+
+void TwoStepPresentationScheduler::Configure(double fps) {
+    const double safeFps = fps > 0.0 ? fps : kDefaultFps;
+    const int64_t frameIntervalNs = std::max<int64_t>(
+        static_cast<int64_t>(std::llround(
+            static_cast<double>(kNanosecondsPerSecond) / safeFps)),
+        kNanosecondsPerMillisecond);
+    scheduler_.Configure(safeFps);
+    submitLeadNs_ = scheduler_.GetSubmitLeadNs();
+    maxFutureLeadNs_ = frameIntervalNs * kMaxFutureIntervals;
+    Reset();
+}
+
+void TwoStepPresentationScheduler::Reset() {
+    scheduler_.Reset();
+    ClearTargets();
+    lastSubmittedPtsUs_ = 0;
+    hasSubmittedPts_ = false;
+}
+
+void TwoStepPresentationScheduler::ClearTargets() {
+    targets_.fill({});
+    targetWriteIndex_ = 0;
+    pendingTargetCount_ = 0;
+}
+
+void TwoStepPresentationScheduler::StoreTarget(
+        int64_t ptsUs, int64_t targetTimeNs) {
+    PreparedTarget& target = targets_[targetWriteIndex_];
+    if (!target.valid) {
+        pendingTargetCount_++;
+    }
+    target = {ptsUs, targetTimeNs, true};
+    targetWriteIndex_ = (targetWriteIndex_ + 1) % targets_.size();
+}
+
+bool TwoStepPresentationScheduler::TakeTarget(
+        int64_t ptsUs, int64_t& targetTimeNs) {
+    for (size_t offset = 0; offset < targets_.size(); ++offset) {
+        const size_t index =
+            (targetWriteIndex_ + targets_.size() - 1 - offset) % targets_.size();
+        PreparedTarget& target = targets_[index];
+        if (target.valid && target.ptsUs == ptsUs) {
+            target.valid = false;
+            pendingTargetCount_--;
+            targetTimeNs = target.targetTimeNs;
+            return true;
+        }
+    }
+    return false;
+}
+
+bool TwoStepPresentationScheduler::PrepareFrame(
+        int64_t ptsUs, int64_t preparedAtNs) {
+    const PresentationPlan plan = scheduler_.PlanFrame(ptsUs, preparedAtNs);
+    if (plan.action != PresentationAction::SCHEDULE) {
+        return false;
+    }
+
+    if (plan.event == PresentationEvent::DISCONTINUITY) {
+        ClearTargets();
+        hasSubmittedPts_ = false;
+    }
+    StoreTarget(ptsUs, plan.targetTimeNs);
+    return true;
+}
+
+void TwoStepPresentationScheduler::DiscardFrame(int64_t ptsUs) {
+    int64_t ignoredTargetNs = 0;
+    TakeTarget(ptsUs, ignoredTargetNs);
+}
+
+void TwoStepPresentationScheduler::NoteSubmittedPts(int64_t ptsUs) {
+    lastSubmittedPtsUs_ = ptsUs;
+    hasSubmittedPts_ = true;
+}
+
+PreparedPresentationPlan TwoStepPresentationScheduler::PlanDecodedFrame(
+        int64_t ptsUs, int64_t decodedAtNs) {
+    PreparedPresentationPlan plan;
+    if (hasSubmittedPts_ && ptsUs <= lastSubmittedPtsUs_) {
+        plan.action = PreparedPresentationAction::DROP;
+        plan.event = PreparedPresentationEvent::NON_MONOTONIC_PTS;
+        DiscardFrame(ptsUs);
+        return plan;
+    }
+
+    int64_t targetTimeNs = 0;
+    if (!TakeTarget(ptsUs, targetTimeNs)) {
+        plan.event = PreparedPresentationEvent::MISSING_TARGET;
+        return plan;
+    }
+
+    const int64_t targetLeadNs = targetTimeNs - decodedAtNs;
+    plan.targetLeadNs = targetLeadNs;
+    if (targetLeadNs < submitLeadNs_) {
+        plan.event = PreparedPresentationEvent::EXPIRED_TARGET;
+        NoteSubmittedPts(ptsUs);
+        return plan;
+    }
+    if (targetLeadNs > maxFutureLeadNs_) {
+        plan.event = PreparedPresentationEvent::FUTURE_TARGET;
+        NoteSubmittedPts(ptsUs);
+        return plan;
+    }
+
+    plan.action = PreparedPresentationAction::SCHEDULE;
+    plan.targetTimeNs = targetTimeNs;
+    NoteSubmittedPts(ptsUs);
+    return plan;
+}

--- a/nativelib/src/main/cpp/two_step_presentation_scheduler.cpp
+++ b/nativelib/src/main/cpp/two_step_presentation_scheduler.cpp
@@ -35,14 +35,20 @@ void TwoStepPresentationScheduler::ClearTargets() {
     pendingTargetCount_ = 0;
 }
 
-void TwoStepPresentationScheduler::StoreTarget(
+PresentationTargetHandle TwoStepPresentationScheduler::StoreTarget(
         int64_t ptsUs, int64_t targetTimeNs) {
+    const PresentationTargetHandle handle(nextTargetId_++);
+    if (nextTargetId_ == 0) {
+        nextTargetId_ = 1;
+    }
+
     PreparedTarget& target = targets_[targetWriteIndex_];
     if (!target.valid) {
         pendingTargetCount_++;
     }
-    target = {ptsUs, targetTimeNs, true};
+    target = {handle.id_, ptsUs, targetTimeNs, true};
     targetWriteIndex_ = (targetWriteIndex_ + 1) % targets_.size();
+    return handle;
 }
 
 bool TwoStepPresentationScheduler::TakeTarget(
@@ -61,19 +67,33 @@ bool TwoStepPresentationScheduler::TakeTarget(
     return false;
 }
 
-bool TwoStepPresentationScheduler::PrepareFrame(
+PresentationTargetHandle TwoStepPresentationScheduler::PrepareFrame(
         int64_t ptsUs, int64_t preparedAtNs) {
     const PresentationPlan plan = scheduler_.PlanFrame(ptsUs, preparedAtNs);
     if (plan.action != PresentationAction::SCHEDULE) {
-        return false;
+        return {};
     }
 
     if (plan.event == PresentationEvent::DISCONTINUITY) {
         ClearTargets();
         hasSubmittedPts_ = false;
     }
-    StoreTarget(ptsUs, plan.targetTimeNs);
-    return true;
+    return StoreTarget(ptsUs, plan.targetTimeNs);
+}
+
+void TwoStepPresentationScheduler::DiscardFrame(
+        PresentationTargetHandle handle) {
+    if (!handle) {
+        return;
+    }
+
+    for (PreparedTarget& target : targets_) {
+        if (target.valid && target.id == handle.id_) {
+            target.valid = false;
+            pendingTargetCount_--;
+            return;
+        }
+    }
 }
 
 void TwoStepPresentationScheduler::DiscardFrame(int64_t ptsUs) {

--- a/nativelib/src/main/cpp/two_step_presentation_scheduler.h
+++ b/nativelib/src/main/cpp/two_step_presentation_scheduler.h
@@ -1,0 +1,71 @@
+#ifndef TWO_STEP_PRESENTATION_SCHEDULER_H
+#define TWO_STEP_PRESENTATION_SCHEDULER_H
+
+#include "presentation_scheduler.h"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+enum class PreparedPresentationAction {
+    SCHEDULE,
+    IMMEDIATE,
+    DROP,
+};
+
+enum class PreparedPresentationEvent {
+    NONE,
+    MISSING_TARGET,
+    EXPIRED_TARGET,
+    FUTURE_TARGET,
+    NON_MONOTONIC_PTS,
+};
+
+struct PreparedPresentationPlan {
+    PreparedPresentationAction action = PreparedPresentationAction::IMMEDIATE;
+    PreparedPresentationEvent event = PreparedPresentationEvent::NONE;
+    int64_t targetTimeNs = 0;
+    int64_t targetLeadNs = 0;
+};
+
+// Computes targets before decode and validates them after decode. Targets are
+// keyed by PTS, so decoder buffer indices and output callback order are not
+// part of the association contract.
+class TwoStepPresentationScheduler {
+public:
+    void Configure(double fps);
+    void Reset();
+
+    bool PrepareFrame(int64_t ptsUs, int64_t preparedAtNs);
+    void DiscardFrame(int64_t ptsUs);
+    PreparedPresentationPlan PlanDecodedFrame(
+        int64_t ptsUs, int64_t decodedAtNs);
+
+    size_t GetPendingTargetCount() const { return pendingTargetCount_; }
+    int64_t GetInitialLeadNs() const { return scheduler_.GetInitialLeadNs(); }
+
+private:
+    struct PreparedTarget {
+        int64_t ptsUs = 0;
+        int64_t targetTimeNs = 0;
+        bool valid = false;
+    };
+
+    void ClearTargets();
+    void StoreTarget(int64_t ptsUs, int64_t targetTimeNs);
+    bool TakeTarget(int64_t ptsUs, int64_t& targetTimeNs);
+    void NoteSubmittedPts(int64_t ptsUs);
+
+    static constexpr size_t kTargetCapacity = 64;
+
+    PtsPresentationScheduler scheduler_;
+    std::array<PreparedTarget, kTargetCapacity> targets_{};
+    size_t targetWriteIndex_ = 0;
+    size_t pendingTargetCount_ = 0;
+    int64_t submitLeadNs_ = 2000000LL;
+    int64_t maxFutureLeadNs_ = 50000000LL;
+    int64_t lastSubmittedPtsUs_ = 0;
+    bool hasSubmittedPts_ = false;
+};
+
+#endif // TWO_STEP_PRESENTATION_SCHEDULER_H

--- a/nativelib/src/main/cpp/two_step_presentation_scheduler.h
+++ b/nativelib/src/main/cpp/two_step_presentation_scheduler.h
@@ -28,6 +28,22 @@ struct PreparedPresentationPlan {
     int64_t targetLeadNs = 0;
 };
 
+struct TwoStepPresentationStats {
+    uint64_t preparedTargets = 0;
+    uint64_t scheduledFrames = 0;
+    uint64_t expiredTargets = 0;
+    uint64_t missingTargets = 0;
+    uint64_t futureTargets = 0;
+    uint64_t nonMonotonicDrops = 0;
+    uint64_t renderAtTimeFallbacks = 0;
+    uint64_t leadUnder1Ms = 0;
+    uint64_t lead1To2Ms = 0;
+    uint64_t lead2To4Ms = 0;
+    uint64_t lead4To8Ms = 0;
+    uint64_t leadAtLeast8Ms = 0;
+    uint64_t pendingHighWater = 0;
+};
+
 class PresentationTargetHandle {
 public:
     PresentationTargetHandle() = default;
@@ -54,9 +70,12 @@ public:
     void DiscardFrame(int64_t ptsUs);
     PreparedPresentationPlan PlanDecodedFrame(
         int64_t ptsUs, int64_t decodedAtNs);
+    void NoteRenderAtTimeFallback();
+    void ResetStats();
 
     size_t GetPendingTargetCount() const { return pendingTargetCount_; }
     int64_t GetInitialLeadNs() const { return scheduler_.GetInitialLeadNs(); }
+    TwoStepPresentationStats GetStats() const { return stats_; }
 
 private:
     struct PreparedTarget {
@@ -70,6 +89,7 @@ private:
     PresentationTargetHandle StoreTarget(int64_t ptsUs, int64_t targetTimeNs);
     bool TakeTarget(int64_t ptsUs, int64_t& targetTimeNs);
     void NoteSubmittedPts(int64_t ptsUs);
+    void RecordTargetLead(int64_t targetLeadNs);
 
     static constexpr size_t kTargetCapacity = 64;
 
@@ -83,6 +103,7 @@ private:
     int64_t maxFutureLeadNs_ = 50000000LL;
     int64_t lastSubmittedPtsUs_ = 0;
     bool hasSubmittedPts_ = false;
+    TwoStepPresentationStats stats_{};
 };
 
 #endif // TWO_STEP_PRESENTATION_SCHEDULER_H

--- a/nativelib/src/main/cpp/two_step_presentation_scheduler.h
+++ b/nativelib/src/main/cpp/two_step_presentation_scheduler.h
@@ -28,6 +28,19 @@ struct PreparedPresentationPlan {
     int64_t targetLeadNs = 0;
 };
 
+class PresentationTargetHandle {
+public:
+    PresentationTargetHandle() = default;
+    explicit operator bool() const { return id_ != 0; }
+
+private:
+    explicit PresentationTargetHandle(uint64_t id) : id_(id) {}
+
+    uint64_t id_ = 0;
+
+    friend class TwoStepPresentationScheduler;
+};
+
 // Computes targets before decode and validates them after decode. Targets are
 // keyed by PTS, so decoder buffer indices and output callback order are not
 // part of the association contract.
@@ -36,7 +49,8 @@ public:
     void Configure(double fps);
     void Reset();
 
-    bool PrepareFrame(int64_t ptsUs, int64_t preparedAtNs);
+    PresentationTargetHandle PrepareFrame(int64_t ptsUs, int64_t preparedAtNs);
+    void DiscardFrame(PresentationTargetHandle handle);
     void DiscardFrame(int64_t ptsUs);
     PreparedPresentationPlan PlanDecodedFrame(
         int64_t ptsUs, int64_t decodedAtNs);
@@ -46,13 +60,14 @@ public:
 
 private:
     struct PreparedTarget {
+        uint64_t id = 0;
         int64_t ptsUs = 0;
         int64_t targetTimeNs = 0;
         bool valid = false;
     };
 
     void ClearTargets();
-    void StoreTarget(int64_t ptsUs, int64_t targetTimeNs);
+    PresentationTargetHandle StoreTarget(int64_t ptsUs, int64_t targetTimeNs);
     bool TakeTarget(int64_t ptsUs, int64_t& targetTimeNs);
     void NoteSubmittedPts(int64_t ptsUs);
 
@@ -62,6 +77,8 @@ private:
     std::array<PreparedTarget, kTargetCapacity> targets_{};
     size_t targetWriteIndex_ = 0;
     size_t pendingTargetCount_ = 0;
+    // Keep IDs monotonic across Reset so stale guards cannot match new targets.
+    uint64_t nextTargetId_ = 1;
     int64_t submitLeadNs_ = 2000000LL;
     int64_t maxFutureLeadNs_ = 50000000LL;
     int64_t lastSubmittedPtsUs_ = 0;

--- a/nativelib/src/main/cpp/video_decoder.cpp
+++ b/nativelib/src/main/cpp/video_decoder.cpp
@@ -450,9 +450,7 @@ static int ResolveEffectiveBufferCount(int requestedCount, DecoderMode mode) {
 // VideoDecoder 类实现
 // =============================================================================
 
-VideoDecoder::VideoDecoder() {
-    memset(&stats_, 0, sizeof(stats_));
-}
+VideoDecoder::VideoDecoder() = default;
 
 VideoDecoder::~VideoDecoder() {
     Cleanup();
@@ -1459,23 +1457,7 @@ VideoDecoderStats VideoDecoder::GetStats() const {
     if (render_ != nullptr) {
         snapshot.hostPacedPresentationActive =
             render_->IsHostPacedPresentationActive();
-        const TwoStepPresentationStats presentation =
-            render_->GetTwoStepPresentationStats();
-        snapshot.presentationPrepared = presentation.preparedTargets;
-        snapshot.presentationScheduled = presentation.scheduledFrames;
-        snapshot.presentationExpired = presentation.expiredTargets;
-        snapshot.presentationMissing = presentation.missingTargets;
-        snapshot.presentationFuture = presentation.futureTargets;
-        snapshot.presentationNonMonotonicDrops =
-            presentation.nonMonotonicDrops;
-        snapshot.presentationRenderFallbacks =
-            presentation.renderAtTimeFallbacks;
-        snapshot.presentationLeadUnder1Ms = presentation.leadUnder1Ms;
-        snapshot.presentationLead1To2Ms = presentation.lead1To2Ms;
-        snapshot.presentationLead2To4Ms = presentation.lead2To4Ms;
-        snapshot.presentationLead4To8Ms = presentation.lead4To8Ms;
-        snapshot.presentationLeadAtLeast8Ms = presentation.leadAtLeast8Ms;
-        snapshot.presentationPendingHighWater = presentation.pendingHighWater;
+        snapshot.presentation = render_->GetTwoStepPresentationStats();
     }
     if (snapshot.sessionStartTime > 0 &&
         currentTimeMs > snapshot.sessionStartTime) {

--- a/nativelib/src/main/cpp/video_decoder.cpp
+++ b/nativelib/src/main/cpp/video_decoder.cpp
@@ -1435,11 +1435,15 @@ VideoDecoderStats VideoDecoder::GetStats() const {
         std::lock_guard<std::mutex> lock(statsMutex_);
         snapshot = stats_;
         snapshot.currentFps = receivedFrameRate_.GetRate(currentTimeMs);
+        codecOutputFrameRate_.Record(
+            currentTimeMs, codecOutputFrames_.load(std::memory_order_relaxed));
+        snapshot.codecOutputFps = codecOutputFrameRate_.GetRate(currentTimeMs);
         renderedFrameRate_.Record(
             currentTimeMs, decodedFrames_.load(std::memory_order_relaxed));
         snapshot.renderedFps = renderedFrameRate_.GetRate(currentTimeMs);
     }
 
+    snapshot.codecOutputFrames = codecOutputFrames_.load(std::memory_order_relaxed);
     snapshot.decodedFrames = decodedFrames_.load(std::memory_order_relaxed);
     snapshot.droppedFrames = droppedFrames_.load(std::memory_order_relaxed);
     snapshot.droppedByL1 = droppedByL1_.load(std::memory_order_relaxed);
@@ -1449,6 +1453,30 @@ VideoDecoderStats VideoDecoder::GetStats() const {
     snapshot.droppedByL5 = droppedByL5_.load(std::memory_order_relaxed);
     snapshot.droppedByQueueOverflow = droppedByQueueOverflow_.load(std::memory_order_relaxed);
     snapshot.droppedByTimeout = droppedByTimeout_.load(std::memory_order_relaxed);
+    snapshot.syncDrainEvents = syncDrainEvents_.load(std::memory_order_relaxed);
+    snapshot.syncDrainFrames = syncDrainFrames_.load(std::memory_order_relaxed);
+    snapshot.syncDecode = config_.decoderMode == DecoderMode::SYNC;
+    if (render_ != nullptr) {
+        snapshot.hostPacedPresentationActive =
+            render_->IsHostPacedPresentationActive();
+        const TwoStepPresentationStats presentation =
+            render_->GetTwoStepPresentationStats();
+        snapshot.presentationPrepared = presentation.preparedTargets;
+        snapshot.presentationScheduled = presentation.scheduledFrames;
+        snapshot.presentationExpired = presentation.expiredTargets;
+        snapshot.presentationMissing = presentation.missingTargets;
+        snapshot.presentationFuture = presentation.futureTargets;
+        snapshot.presentationNonMonotonicDrops =
+            presentation.nonMonotonicDrops;
+        snapshot.presentationRenderFallbacks =
+            presentation.renderAtTimeFallbacks;
+        snapshot.presentationLeadUnder1Ms = presentation.leadUnder1Ms;
+        snapshot.presentationLead1To2Ms = presentation.lead1To2Ms;
+        snapshot.presentationLead2To4Ms = presentation.lead2To4Ms;
+        snapshot.presentationLead4To8Ms = presentation.lead4To8Ms;
+        snapshot.presentationLeadAtLeast8Ms = presentation.leadAtLeast8Ms;
+        snapshot.presentationPendingHighWater = presentation.pendingHighWater;
+    }
     if (snapshot.sessionStartTime > 0 &&
         currentTimeMs > snapshot.sessionStartTime) {
         snapshot.globalAvgFps =
@@ -2226,6 +2254,8 @@ int VideoDecoder::SyncProcessOutput(int64_t timeoutUs) {
         RecordDroppedFrames(DropReason::L1, drainedCount);
         syncDrainEventsSinceLog_++;
         syncDrainFramesSinceLog_ += drainedCount;
+        syncDrainEvents_.fetch_add(1, std::memory_order_relaxed);
+        syncDrainFrames_.fetch_add(drainedCount, std::memory_order_relaxed);
     }
 
     const QueuedFrame& latestFrame = outputFrames[totalFrames - 1];

--- a/nativelib/src/main/cpp/video_decoder.cpp
+++ b/nativelib/src/main/cpp/video_decoder.cpp
@@ -1057,6 +1057,34 @@ static OH_AVCodecBufferAttr MakeInputBufferAttr(int32_t size, int64_t pts, Video
     return attr;
 }
 
+class PresentationTargetGuard {
+public:
+    PresentationTargetGuard(NativeRender* render, int64_t pts, bool prepare)
+        : render_(render), pts_(pts), active_(
+            render_ != nullptr && render_->IsHostPacedPresentationActive()) {
+        if (active_ && prepare) {
+            render_->PreparePresentationFrame(pts_);
+        }
+    }
+
+    ~PresentationTargetGuard() {
+        if (active_ && !committed_) {
+            render_->DiscardPresentationFrame(pts_);
+        }
+    }
+
+    void Commit() { committed_ = true; }
+
+    PresentationTargetGuard(const PresentationTargetGuard&) = delete;
+    PresentationTargetGuard& operator=(const PresentationTargetGuard&) = delete;
+
+private:
+    NativeRender* render_ = nullptr;
+    int64_t pts_ = 0;
+    bool active_ = false;
+    bool committed_ = false;
+};
+
 void VideoDecoder::RecordEnqueueTimestamp(int64_t timestamp) {
     const int64_t enqueueTimeMs = GetSteadyTimeMs();
     std::lock_guard<std::mutex> lock(timestampMutex_);
@@ -1154,6 +1182,8 @@ int VideoDecoder::SubmitDecodeUnitScatter(const BufferSegment* segments, int seg
         return recoveryResult;  // -1 = DR_NEED_IDR
     }
 
+    PresentationTargetGuard presentationTarget(render_, timestamp, true);
+
     // 同步模式：直接提交到解码器（scatter-gather 直写 AVBuffer）
     if (config_.decoderMode == DecoderMode::SYNC) {
         UpdateReceivedStats(totalSize, frameNumber, hostProcessingLatency);
@@ -1194,6 +1224,7 @@ int VideoDecoder::SubmitDecodeUnitScatter(const BufferSegment* segments, int seg
                         if (ret == AV_ERR_OK) {
                             // 唤醒解码线程立即轮询输出，避免 wait_for(halfFrame) 空等
                             pendingFrameCond_.notify_one();
+                            presentationTarget.Commit();
                             return 0;  // 直接提交成功
                         }
                     }
@@ -1209,6 +1240,8 @@ int VideoDecoder::SubmitDecodeUnitScatter(const BufferSegment* segments, int seg
             uint64_t overflowCount = 0;
             std::lock_guard<std::mutex> lock(pendingFrameMutex_);
             while (pendingFrameQueue_.size() >= maxPendingFrames_) {
+                render_->DiscardPresentationFrame(
+                    pendingFrameQueue_.front().timestamp);
                 pendingFrameQueue_.pop();
                 overflowCount++;
             }
@@ -1226,6 +1259,7 @@ int VideoDecoder::SubmitDecodeUnitScatter(const BufferSegment* segments, int seg
             
             pendingFrameQueue_.push(std::move(frame));
             pendingFrameCond_.notify_one();
+            presentationTarget.Commit();
             
             // 队列溢出 = 丢弃了中间 P 帧 → 后续 P 帧缺少参考帧会损坏
             // 激活恢复模式：丢弃后续 P 帧，等待 IDR 重建参考链
@@ -1299,6 +1333,8 @@ int VideoDecoder::SubmitDecodeUnitScatter(const BufferSegment* segments, int seg
         OH_LOG_ERROR(LOG_APP, "Failed to push input buffer: %{public}d", ret);
         return -1;
     }
+
+    presentationTarget.Commit();
 
     UpdateReceivedStats(totalSize, frameNumber, hostProcessingLatency);
     
@@ -1502,6 +1538,7 @@ void VideoDecoder::OnOutputBufferAvailable(OH_AVCodec* codec, uint32_t index,
     const int64_t pts = attr.pts;
 
     if (attr.flags & AVCODEC_BUFFER_FLAGS_EOS) {
+        self->render_->DiscardPresentationFrame(pts);
         OH_VideoDecoder_FreeOutputBuffer(codec, index);
         return;
     }
@@ -2018,6 +2055,8 @@ int VideoDecoder::SyncProcessInput(int64_t timeoutUs) {
         frame = std::move(pendingFrameQueue_.front());
         pendingFrameQueue_.pop();
     }
+    PresentationTargetGuard presentationTarget(
+        render_, frame.timestamp, false);
     // 成功获得输入 buffer，继续处理帧
     static bool firstInputLog = true;
     if (firstInputLog) {
@@ -2061,6 +2100,8 @@ int VideoDecoder::SyncProcessInput(int64_t timeoutUs) {
         OH_LOG_ERROR(LOG_APP, "Sync PushInputBuffer failed: %{public}d", ret);
         return -1;  // API 错误
     }
+
+    presentationTarget.Commit();
 
     return 1;  // 成功处理了一帧
 }
@@ -2115,18 +2156,9 @@ int VideoDecoder::SyncProcessOutput(int64_t timeoutUs) {
     // 检查 EOS
     if (attr.flags & AVCODEC_BUFFER_FLAGS_EOS) {
         OH_LOG_INFO(LOG_APP, "Sync: received EOS");
+        render_->DiscardPresentationFrame(attr.pts);
         OH_VideoDecoder_FreeOutputBuffer(decoder_, outputIndex);
         return 0;  // EOS 不是错误
-    }
-
-    // Host-paced presentation must see every PTS. Do not apply the low-latency
-    // drain-to-latest policy before the shared presentation scheduler.
-    if (render_->IsHostPacedPresentationActive()) {
-        const int64_t pts = attr.pts;
-        const int64_t enqueueTimeMs = TakeEnqueueTimestamp(pts);
-        const int64_t outputTimeMs = GetSteadyTimeMs();
-        SubmitDecodedFrame(decoder_, outputIndex, attr, enqueueTimeMs, outputTimeMs);
-        return 1;
     }
     
     // ================================================================
@@ -2172,6 +2204,7 @@ int VideoDecoder::SyncProcessOutput(int64_t timeoutUs) {
         
         // EOS 帧不参与收集
         if (nextAttr.flags & AVCODEC_BUFFER_FLAGS_EOS) {
+            render_->DiscardPresentationFrame(nextAttr.pts);
             OH_VideoDecoder_FreeOutputBuffer(decoder_, nextOutputIndex);
             break;
         }
@@ -2183,6 +2216,7 @@ int VideoDecoder::SyncProcessOutput(int64_t timeoutUs) {
         const uint64_t drainedCount = totalFrames - 1;
         for (size_t i = 0; i < drainedCount; ++i) {
             TakeEnqueueTimestamp(outputFrames[i].attr.pts);
+            render_->DiscardPresentationFrame(outputFrames[i].attr.pts);
             OH_VideoDecoder_FreeOutputBuffer(decoder_, outputFrames[i].index);
         }
         RecordDroppedFrames(DropReason::L1, drainedCount);
@@ -2197,9 +2231,8 @@ int VideoDecoder::SyncProcessOutput(int64_t timeoutUs) {
     const int64_t enqueueTimeMs = TakeEnqueueTimestamp(pts);
     const int64_t outputTimeMs = GetSteadyTimeMs();
     
-    // Decoder output selection and presentation are separate policies: sync
-    // mode still drains to the latest frame, while the shared presenter uses
-    // that frame's PTS when legacy VSync is enabled.
+    // Step 2 consumes only the newest decoded frame and looks up the target
+    // prepared before decode. Drained targets are removed above.
     SubmitDecodedFrame(decoder_, latestIndex, latestAttr,
                        enqueueTimeMs, outputTimeMs);
 

--- a/nativelib/src/main/cpp/video_decoder.cpp
+++ b/nativelib/src/main/cpp/video_decoder.cpp
@@ -1059,29 +1059,32 @@ static OH_AVCodecBufferAttr MakeInputBufferAttr(int32_t size, int64_t pts, Video
 
 class PresentationTargetGuard {
 public:
-    PresentationTargetGuard(NativeRender* render, int64_t pts, bool prepare)
-        : render_(render), pts_(pts), active_(
-            render_ != nullptr && render_->IsHostPacedPresentationActive()) {
-        if (active_ && prepare) {
-            render_->PreparePresentationFrame(pts_);
+    PresentationTargetGuard(NativeRender* render, int64_t pts)
+        : render_(render) {
+        if (render_ != nullptr) {
+            target_ = render_->PreparePresentationFrame(pts);
         }
     }
 
+    PresentationTargetGuard(
+            NativeRender* render, PresentationTargetHandle target)
+        : render_(render), target_(target) {}
+
     ~PresentationTargetGuard() {
-        if (active_ && !committed_) {
-            render_->DiscardPresentationFrame(pts_);
+        if (render_ != nullptr && target_ && !committed_) {
+            render_->DiscardPresentationFrame(target_);
         }
     }
 
     void Commit() { committed_ = true; }
+    PresentationTargetHandle GetTarget() const { return target_; }
 
     PresentationTargetGuard(const PresentationTargetGuard&) = delete;
     PresentationTargetGuard& operator=(const PresentationTargetGuard&) = delete;
 
 private:
     NativeRender* render_ = nullptr;
-    int64_t pts_ = 0;
-    bool active_ = false;
+    PresentationTargetHandle target_;
     bool committed_ = false;
 };
 
@@ -1182,7 +1185,7 @@ int VideoDecoder::SubmitDecodeUnitScatter(const BufferSegment* segments, int seg
         return recoveryResult;  // -1 = DR_NEED_IDR
     }
 
-    PresentationTargetGuard presentationTarget(render_, timestamp, true);
+    PresentationTargetGuard presentationTarget(render_, timestamp);
 
     // 同步模式：直接提交到解码器（scatter-gather 直写 AVBuffer）
     if (config_.decoderMode == DecoderMode::SYNC) {
@@ -1241,7 +1244,7 @@ int VideoDecoder::SubmitDecodeUnitScatter(const BufferSegment* segments, int seg
             std::lock_guard<std::mutex> lock(pendingFrameMutex_);
             while (pendingFrameQueue_.size() >= maxPendingFrames_) {
                 render_->DiscardPresentationFrame(
-                    pendingFrameQueue_.front().timestamp);
+                    pendingFrameQueue_.front().presentationTarget);
                 pendingFrameQueue_.pop();
                 overflowCount++;
             }
@@ -1256,6 +1259,7 @@ int VideoDecoder::SubmitDecodeUnitScatter(const BufferSegment* segments, int seg
             frame.frameType = frameType;
             frame.timestamp = timestamp;
             frame.hostProcessingLatency = hostProcessingLatency;
+            frame.presentationTarget = presentationTarget.GetTarget();
             
             pendingFrameQueue_.push(std::move(frame));
             pendingFrameCond_.notify_one();
@@ -2056,7 +2060,7 @@ int VideoDecoder::SyncProcessInput(int64_t timeoutUs) {
         pendingFrameQueue_.pop();
     }
     PresentationTargetGuard presentationTarget(
-        render_, frame.timestamp, false);
+        render_, frame.presentationTarget);
     // 成功获得输入 buffer，继续处理帧
     static bool firstInputLog = true;
     if (firstInputLog) {

--- a/nativelib/src/main/cpp/video_decoder.h
+++ b/nativelib/src/main/cpp/video_decoder.h
@@ -183,19 +183,7 @@ struct VideoDecoderStats {
     uint64_t syncDrainFrames;             // sync drain-to-latest 累计跳过帧数
     bool syncDecode;                      // 实际解码模式
     bool hostPacedPresentationActive;     // 定时提交 API 实际可用且已启用
-    uint64_t presentationPrepared;
-    uint64_t presentationScheduled;
-    uint64_t presentationExpired;
-    uint64_t presentationMissing;
-    uint64_t presentationFuture;
-    uint64_t presentationNonMonotonicDrops;
-    uint64_t presentationRenderFallbacks;
-    uint64_t presentationLeadUnder1Ms;
-    uint64_t presentationLead1To2Ms;
-    uint64_t presentationLead2To4Ms;
-    uint64_t presentationLead4To8Ms;
-    uint64_t presentationLeadAtLeast8Ms;
-    uint64_t presentationPendingHighWater;
+    TwoStepPresentationStats presentation;
 };
 
 /**
@@ -407,7 +395,7 @@ private:
     
     // 统计信息
     mutable std::mutex statsMutex_;
-    VideoDecoderStats stats_;
+    VideoDecoderStats stats_{};
     uint64_t recentHostLatencyWindowFrames_{0};
     double recentHostLatencyWindowTotalMs_{0.0};
     int64_t recentHostLatencyWindowStartTimeMs_{0};

--- a/nativelib/src/main/cpp/video_decoder.h
+++ b/nativelib/src/main/cpp/video_decoder.h
@@ -37,6 +37,7 @@
 #include <native_buffer/native_buffer.h>
 
 #include "rolling_frame_rate.h"
+#include "two_step_presentation_scheduler.h"
 
 class NativeRender;
 #include <hilog/log.h>
@@ -361,6 +362,7 @@ private:
         VideoFrameType frameType;
         int64_t timestamp;
         uint16_t hostProcessingLatency;
+        PresentationTargetHandle presentationTarget;
     };
     std::mutex pendingFrameMutex_;
     std::condition_variable pendingFrameCond_;

--- a/nativelib/src/main/cpp/video_decoder.h
+++ b/nativelib/src/main/cpp/video_decoder.h
@@ -152,7 +152,9 @@ struct VideoDecoderStats {
     double maxDecodeTimeMs;
     int64_t lastStatsCalculationTime; // 周期统计更新时间（毫秒）
     double currentFps;           // 最近 3 秒接收帧率 (Rx)
+    double codecOutputFps;       // 最近 3 秒解码器输出帧率
     double renderedFps;          // 最近 3 秒成功提交帧率 (Rd)
+    uint64_t codecOutputFrames;  // 解码器累计输出帧数
     // 会话平均帧率（用于串流结束后的 toast）
     int64_t sessionStartTime;           // 会话开始时间（毫秒）
     double globalAvgFps;                // 全局平均渲染帧率
@@ -177,6 +179,23 @@ struct VideoDecoderStats {
     uint64_t droppedByL5;                // L5: async 渲染跳帧（输出间隔过短+延迟偏高）
     uint64_t droppedByQueueOverflow;     // pending queue 溢出丢弃
     uint64_t droppedByTimeout;           // 输入 buffer 超时丢弃
+    uint64_t syncDrainEvents;             // sync drain-to-latest 累计触发次数
+    uint64_t syncDrainFrames;             // sync drain-to-latest 累计跳过帧数
+    bool syncDecode;                      // 实际解码模式
+    bool hostPacedPresentationActive;     // 定时提交 API 实际可用且已启用
+    uint64_t presentationPrepared;
+    uint64_t presentationScheduled;
+    uint64_t presentationExpired;
+    uint64_t presentationMissing;
+    uint64_t presentationFuture;
+    uint64_t presentationNonMonotonicDrops;
+    uint64_t presentationRenderFallbacks;
+    uint64_t presentationLeadUnder1Ms;
+    uint64_t presentationLead1To2Ms;
+    uint64_t presentationLead2To4Ms;
+    uint64_t presentationLead4To8Ms;
+    uint64_t presentationLeadAtLeast8Ms;
+    uint64_t presentationPendingHighWater;
 };
 
 /**
@@ -393,6 +412,7 @@ private:
     double recentHostLatencyWindowTotalMs_{0.0};
     int64_t recentHostLatencyWindowStartTimeMs_{0};
     RollingFrameRateTracker receivedFrameRate_;
+    mutable RollingFrameRateTracker codecOutputFrameRate_;
     mutable RollingFrameRateTracker renderedFrameRate_;
 
     // Output/drop counters are updated atomically so decoder callbacks never
@@ -416,6 +436,8 @@ private:
     // Sync diagnostics are owned by syncDecodeThread_.
     uint64_t syncDrainEventsSinceLog_{0};
     uint64_t syncDrainFramesSinceLog_{0};
+    std::atomic<uint64_t> syncDrainEvents_{0};
+    std::atomic<uint64_t> syncDrainFrames_{0};
     
     // 运行状态
     std::atomic<bool> running_{false};

--- a/nativelib/src/test/cpp/two_step_presentation_scheduler_test.cpp
+++ b/nativelib/src/test/cpp/two_step_presentation_scheduler_test.cpp
@@ -1,10 +1,12 @@
 #include "presentation_scheduler.h"
 #include "two_step_presentation_scheduler.h"
 
+#include <algorithm>
 #include <cassert>
 #include <cmath>
 #include <cstdint>
 #include <iostream>
+#include <iterator>
 
 namespace {
 constexpr int64_t kMs = 1000000LL;
@@ -54,6 +56,42 @@ void TestMissingTargetDoesNotPoisonNewTimeline() {
     const PreparedPresentationPlan first = scheduler.PlanDecodedFrame(
         0, kStartNs + 3 * kMs);
     assert(first.action == PreparedPresentationAction::SCHEDULE);
+}
+
+void TestStaleHandleCannotDiscardTargetAfterReset() {
+    TwoStepPresentationScheduler scheduler;
+    scheduler.Configure(120.0);
+
+    const PresentationTargetHandle stale = scheduler.PrepareFrame(0, kStartNs);
+    scheduler.Reset();
+    const PresentationTargetHandle current = scheduler.PrepareFrame(
+        0, kStartNs + kMs);
+
+    assert(stale);
+    assert(current);
+    scheduler.DiscardFrame(stale);
+    assert(scheduler.GetPendingTargetCount() == 1);
+    const PreparedPresentationPlan plan = scheduler.PlanDecodedFrame(
+        0, kStartNs + 3 * kMs);
+    assert(plan.action == PreparedPresentationAction::SCHEDULE);
+}
+
+void TestHandleDiscardsExactDuplicateTarget() {
+    TwoStepPresentationScheduler scheduler;
+    scheduler.Configure(60.0);
+
+    const PresentationTargetHandle older = scheduler.PrepareFrame(
+        1000, kStartNs);
+    const PresentationTargetHandle newer = scheduler.PrepareFrame(
+        1000, kStartNs + 17 * kMs);
+
+    assert(older);
+    assert(newer);
+    scheduler.DiscardFrame(older);
+    assert(scheduler.GetPendingTargetCount() == 1);
+    const PreparedPresentationPlan plan = scheduler.PlanDecodedFrame(
+        1000, kStartNs + 18 * kMs);
+    assert(plan.action == PreparedPresentationAction::SCHEDULE);
 }
 
 void TestFarFutureTargetRendersImmediately() {
@@ -234,6 +272,8 @@ int main() {
     TestDecodeTimeConsumesPreparedLead();
     TestExpiredPreparedTargetRendersImmediately();
     TestMissingTargetDoesNotPoisonNewTimeline();
+    TestStaleHandleCannotDiscardTargetAfterReset();
+    TestHandleDiscardsExactDuplicateTarget();
     TestFarFutureTargetRendersImmediately();
     TestTargetsFollowPtsAcrossOutputLookup();
     TestSyncDrainKeepsOnlyLatestPreparedTarget();

--- a/nativelib/src/test/cpp/two_step_presentation_scheduler_test.cpp
+++ b/nativelib/src/test/cpp/two_step_presentation_scheduler_test.cpp
@@ -266,6 +266,56 @@ void TestDuplicateOutputIsDroppedOnce() {
     assert(duplicate.event == PreparedPresentationEvent::NON_MONOTONIC_PTS);
     assert(scheduler.GetPendingTargetCount() == 0);
 }
+
+void TestDiagnosticsCountWithoutChangingTimelineReset() {
+    TwoStepPresentationScheduler scheduler;
+    scheduler.Configure(120.0);
+
+    assert(scheduler.PrepareFrame(0, kStartNs));
+    assert(scheduler.PlanDecodedFrame(0, kStartNs + 3 * kMs).action ==
+        PreparedPresentationAction::SCHEDULE);
+    assert(scheduler.PlanDecodedFrame(8333, kStartNs + 8 * kMs).event ==
+        PreparedPresentationEvent::MISSING_TARGET);
+
+    scheduler.Reset();
+    assert(scheduler.PrepareFrame(0, kStartNs + 20 * kMs));
+    assert(scheduler.PlanDecodedFrame(0, kStartNs + 32 * kMs).event ==
+        PreparedPresentationEvent::EXPIRED_TARGET);
+
+    scheduler.Reset();
+    assert(scheduler.PrepareFrame(0, kStartNs));
+    assert(scheduler.PrepareFrame(33333, kStartNs));
+    assert(scheduler.PlanDecodedFrame(33333, kStartNs).event ==
+        PreparedPresentationEvent::FUTURE_TARGET);
+
+    scheduler.Reset();
+    assert(scheduler.PrepareFrame(1000, kStartNs));
+    assert(scheduler.PlanDecodedFrame(1000, kStartNs + 3 * kMs).action ==
+        PreparedPresentationAction::SCHEDULE);
+    assert(scheduler.PlanDecodedFrame(1000, kStartNs + 4 * kMs).event ==
+        PreparedPresentationEvent::NON_MONOTONIC_PTS);
+    scheduler.NoteRenderAtTimeFallback();
+
+    const TwoStepPresentationStats stats = scheduler.GetStats();
+    assert(stats.preparedTargets == 5);
+    assert(stats.scheduledFrames == 2);
+    assert(stats.expiredTargets == 1);
+    assert(stats.missingTargets == 1);
+    assert(stats.futureTargets == 1);
+    assert(stats.nonMonotonicDrops == 1);
+    assert(stats.renderAtTimeFallbacks == 1);
+    assert(stats.leadUnder1Ms == 1);
+    assert(stats.lead1To2Ms == 0);
+    assert(stats.lead2To4Ms == 0);
+    assert(stats.lead4To8Ms == 2);
+    assert(stats.leadAtLeast8Ms == 1);
+    assert(stats.pendingHighWater == 2);
+
+    scheduler.Reset();
+    assert(scheduler.GetStats().scheduledFrames == 2);
+    scheduler.ResetStats();
+    assert(scheduler.GetStats().preparedTargets == 0);
+}
 } // namespace
 
 int main() {
@@ -282,6 +332,7 @@ int main() {
     TestNtscCadencePreservesPreparedTargets();
     TestDiscontinuityClearsOldTargets();
     TestDuplicateOutputIsDroppedOnce();
+    TestDiagnosticsCountWithoutChangingTimelineReset();
     std::cout << "two-step presentation scheduler tests passed\n";
     return 0;
 }

--- a/nativelib/src/test/cpp/two_step_presentation_scheduler_test.cpp
+++ b/nativelib/src/test/cpp/two_step_presentation_scheduler_test.cpp
@@ -1,0 +1,247 @@
+#include "presentation_scheduler.h"
+#include "two_step_presentation_scheduler.h"
+
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+
+namespace {
+constexpr int64_t kMs = 1000000LL;
+constexpr int64_t kUsToNs = 1000LL;
+constexpr int64_t kStartNs = 1000 * kMs;
+
+void TestDecodeTimeConsumesPreparedLead() {
+    PtsPresentationScheduler postDecode;
+    TwoStepPresentationScheduler twoStep;
+    postDecode.Configure(120.0);
+    twoStep.Configure(120.0);
+
+    constexpr int64_t kDecodeNs = 4 * kMs;
+    assert(twoStep.PrepareFrame(0, kStartNs));
+    const PreparedPresentationPlan prepared = twoStep.PlanDecodedFrame(
+        0, kStartNs + kDecodeNs);
+    const PresentationPlan post = postDecode.PlanFrame(
+        0, kStartNs + kDecodeNs);
+
+    assert(prepared.action == PreparedPresentationAction::SCHEDULE);
+    assert(post.action == PresentationAction::SCHEDULE);
+    assert(post.targetTimeNs - prepared.targetTimeNs == kDecodeNs);
+}
+
+void TestExpiredPreparedTargetRendersImmediately() {
+    TwoStepPresentationScheduler scheduler;
+    scheduler.Configure(120.0);
+
+    assert(scheduler.PrepareFrame(0, kStartNs));
+    const PreparedPresentationPlan plan = scheduler.PlanDecodedFrame(
+        0, kStartNs + 12 * kMs);
+
+    assert(plan.action == PreparedPresentationAction::IMMEDIATE);
+    assert(plan.event == PreparedPresentationEvent::EXPIRED_TARGET);
+}
+
+void TestMissingTargetDoesNotPoisonNewTimeline() {
+    TwoStepPresentationScheduler scheduler;
+    scheduler.Configure(120.0);
+
+    const PreparedPresentationPlan stale = scheduler.PlanDecodedFrame(
+        1000000, kStartNs);
+    assert(stale.action == PreparedPresentationAction::IMMEDIATE);
+    assert(stale.event == PreparedPresentationEvent::MISSING_TARGET);
+
+    assert(scheduler.PrepareFrame(0, kStartNs + kMs));
+    const PreparedPresentationPlan first = scheduler.PlanDecodedFrame(
+        0, kStartNs + 3 * kMs);
+    assert(first.action == PreparedPresentationAction::SCHEDULE);
+}
+
+void TestFarFutureTargetRendersImmediately() {
+    TwoStepPresentationScheduler scheduler;
+    scheduler.Configure(120.0);
+
+    assert(scheduler.PrepareFrame(0, kStartNs));
+    assert(scheduler.PrepareFrame(33333, kStartNs));
+    const PreparedPresentationPlan plan = scheduler.PlanDecodedFrame(
+        33333, kStartNs);
+
+    assert(plan.action == PreparedPresentationAction::IMMEDIATE);
+    assert(plan.event == PreparedPresentationEvent::FUTURE_TARGET);
+}
+
+void TestTargetsFollowPtsAcrossOutputLookup() {
+    TwoStepPresentationScheduler scheduler;
+    scheduler.Configure(120.0);
+
+    assert(scheduler.PrepareFrame(0, kStartNs));
+    assert(scheduler.PrepareFrame(8333, kStartNs + 8 * kMs));
+
+    const PreparedPresentationPlan newer = scheduler.PlanDecodedFrame(
+        8333, kStartNs + 9 * kMs);
+    const PreparedPresentationPlan older = scheduler.PlanDecodedFrame(
+        0, kStartNs + 10 * kMs);
+
+    assert(newer.action == PreparedPresentationAction::SCHEDULE);
+    assert(older.action == PreparedPresentationAction::DROP);
+    assert(older.event == PreparedPresentationEvent::NON_MONOTONIC_PTS);
+}
+
+void TestSyncDrainKeepsOnlyLatestPreparedTarget() {
+    PtsPresentationScheduler postDecode;
+    TwoStepPresentationScheduler twoStep;
+    postDecode.Configure(120.0);
+    twoStep.Configure(120.0);
+
+    constexpr int64_t kPtsUs[] = {0, 8333, 16667, 25000, 33333};
+    for (int64_t ptsUs : kPtsUs) {
+        assert(twoStep.PrepareFrame(
+            ptsUs, kStartNs + ptsUs * kUsToNs));
+    }
+
+    const int64_t burstDecodedAtNs = kStartNs + 34 * kMs;
+    int64_t maxPostDecodeLeadNs = 0;
+    for (size_t index = 0; index < std::size(kPtsUs); ++index) {
+        const PresentationPlan post = postDecode.PlanFrame(
+            kPtsUs[index], burstDecodedAtNs);
+        if (post.action == PresentationAction::SCHEDULE) {
+            maxPostDecodeLeadNs = std::max(
+                maxPostDecodeLeadNs, post.targetTimeNs - burstDecodedAtNs);
+        }
+        if (index + 1 < std::size(kPtsUs)) {
+            twoStep.DiscardFrame(kPtsUs[index]);
+        }
+    }
+
+    const PreparedPresentationPlan latest = twoStep.PlanDecodedFrame(
+        kPtsUs[4], burstDecodedAtNs);
+    assert(twoStep.GetPendingTargetCount() == 0);
+    assert(latest.action == PreparedPresentationAction::SCHEDULE);
+    assert(maxPostDecodeLeadNs > postDecode.GetInitialLeadNs() + 3 * 8 * kMs);
+    assert(latest.targetLeadNs < twoStep.GetInitialLeadNs());
+}
+
+void TestSynthetic120FpsAverageWaitIsLower() {
+    PtsPresentationScheduler postDecode;
+    TwoStepPresentationScheduler twoStep;
+    postDecode.Configure(120.0);
+    twoStep.Configure(120.0);
+
+    constexpr double kFrameUs = 1000000.0 / 120.0;
+    constexpr int64_t kDecodePatternMs[] = {2, 3, 4, 6, 5};
+    int64_t postWaitNs = 0;
+    int64_t twoStepWaitNs = 0;
+    int scheduledFrames = 0;
+
+    for (int frame = 0; frame < 1200; ++frame) {
+        const int64_t ptsUs = static_cast<int64_t>(
+            std::llround(frame * kFrameUs));
+        const int64_t preparedAtNs = kStartNs + ptsUs * kUsToNs;
+        const int64_t decodedAtNs = preparedAtNs +
+            kDecodePatternMs[frame % std::size(kDecodePatternMs)] * kMs;
+
+        assert(twoStep.PrepareFrame(ptsUs, preparedAtNs));
+        const PreparedPresentationPlan prepared =
+            twoStep.PlanDecodedFrame(ptsUs, decodedAtNs);
+        const PresentationPlan post = postDecode.PlanFrame(ptsUs, decodedAtNs);
+
+        assert(prepared.action == PreparedPresentationAction::SCHEDULE);
+        assert(post.action == PresentationAction::SCHEDULE);
+        postWaitNs += std::max<int64_t>(0, post.targetTimeNs - decodedAtNs);
+        twoStepWaitNs += prepared.targetLeadNs;
+        scheduledFrames++;
+    }
+
+    const int64_t averagePostWaitNs = postWaitNs / scheduledFrames;
+    const int64_t averageTwoStepWaitNs = twoStepWaitNs / scheduledFrames;
+    std::cout << "synthetic 120 fps average wait: post-decode="
+              << averagePostWaitNs / 1000 << " us, two-step="
+              << averageTwoStepWaitNs / 1000 << " us\n";
+    assert(averagePostWaitNs - averageTwoStepWaitNs > kMs);
+}
+
+void TestPreparedTargetStorageIsBounded() {
+    TwoStepPresentationScheduler scheduler;
+    scheduler.Configure(120.0);
+
+    for (int frame = 0; frame < 256; ++frame) {
+        const int64_t ptsUs = frame * 8333LL;
+        scheduler.PrepareFrame(ptsUs, kStartNs + ptsUs * kUsToNs);
+    }
+
+    assert(scheduler.GetPendingTargetCount() == 64);
+}
+
+void TestNtscCadencePreservesPreparedTargets() {
+    TwoStepPresentationScheduler scheduler;
+    scheduler.Configure(119.88);
+    constexpr double kFrameUs = 1000000.0 / 119.88;
+
+    int64_t previousPtsUs = 0;
+    int64_t previousTargetNs = 0;
+    for (int frame = 0; frame <= 2500; ++frame) {
+        const int64_t ptsUs = static_cast<int64_t>(
+            std::llround(frame * kFrameUs));
+        const int64_t preparedAtNs = kStartNs + ptsUs * kUsToNs;
+        assert(scheduler.PrepareFrame(ptsUs, preparedAtNs));
+        const PreparedPresentationPlan plan = scheduler.PlanDecodedFrame(
+            ptsUs, preparedAtNs + 3 * kMs);
+
+        assert(plan.action == PreparedPresentationAction::SCHEDULE);
+        if (frame > 0) {
+            assert(plan.targetTimeNs - previousTargetNs ==
+                (ptsUs - previousPtsUs) * kUsToNs);
+        }
+        previousPtsUs = ptsUs;
+        previousTargetNs = plan.targetTimeNs;
+    }
+}
+
+void TestDiscontinuityClearsOldTargets() {
+    TwoStepPresentationScheduler scheduler;
+    scheduler.Configure(60.0);
+
+    assert(scheduler.PrepareFrame(1000000, kStartNs));
+    assert(scheduler.PrepareFrame(1016667, kStartNs + 16 * kMs));
+    assert(scheduler.GetPendingTargetCount() == 2);
+
+    assert(scheduler.PrepareFrame(0, kStartNs + 32 * kMs));
+    assert(scheduler.GetPendingTargetCount() == 1);
+    const PreparedPresentationPlan plan = scheduler.PlanDecodedFrame(
+        0, kStartNs + 35 * kMs);
+    assert(plan.action == PreparedPresentationAction::SCHEDULE);
+    assert(scheduler.GetPendingTargetCount() == 0);
+}
+
+void TestDuplicateOutputIsDroppedOnce() {
+    TwoStepPresentationScheduler scheduler;
+    scheduler.Configure(60.0);
+
+    assert(scheduler.PrepareFrame(1000, kStartNs));
+    assert(scheduler.PrepareFrame(1000, kStartNs + 17 * kMs));
+    const PreparedPresentationPlan first = scheduler.PlanDecodedFrame(
+        1000, kStartNs + 18 * kMs);
+    const PreparedPresentationPlan duplicate = scheduler.PlanDecodedFrame(
+        1000, kStartNs + 19 * kMs);
+
+    assert(first.action == PreparedPresentationAction::SCHEDULE);
+    assert(duplicate.action == PreparedPresentationAction::DROP);
+    assert(duplicate.event == PreparedPresentationEvent::NON_MONOTONIC_PTS);
+    assert(scheduler.GetPendingTargetCount() == 0);
+}
+} // namespace
+
+int main() {
+    TestDecodeTimeConsumesPreparedLead();
+    TestExpiredPreparedTargetRendersImmediately();
+    TestMissingTargetDoesNotPoisonNewTimeline();
+    TestFarFutureTargetRendersImmediately();
+    TestTargetsFollowPtsAcrossOutputLookup();
+    TestSyncDrainKeepsOnlyLatestPreparedTarget();
+    TestSynthetic120FpsAverageWaitIsLower();
+    TestPreparedTargetStorageIsBounded();
+    TestNtscCadencePreservesPreparedTargets();
+    TestDiscontinuityClearsOldTargets();
+    TestDuplicateOutputIsDroppedOnce();
+    std::cout << "two-step presentation scheduler tests passed\n";
+    return 0;
+}


### PR DESCRIPTION
## 改了啥呀

- 在帧进入解码器前按 host PTS 准备呈现目标，解码输出后再按 PTS 精确取回，不依赖 FIFO 或 buffer index
- 使用固定 64 项目标表；缺失、过期或过远目标立即呈现，避免杂鱼目标继续堆 Surface 延迟
- 同步解码恢复有界 `drain-to-latest`，突发输出只把最新帧交给二步调度器
- 保持异步 L2/L4/L5 策略与 #72 基线一致，不把额外丢帧策略混进这次 A/B
- 补齐 NTSC、PTS 跳变、重复/缺失目标、容量边界和 120 Hz 对比测试

## 为啥要改

#72 的后置 PTS 版本已经得到不错的用户反馈，所以它继续作为稳定基线。这次只验证真正二步是否能让解码耗时消耗已有呈现余量，并在同步解码突发时避免把一串旧帧排入 Surface，而不是再叠动态余量、额外一帧缓存或新的恢复状态机。

合成 120 Hz 场景中，平均解码后等待从约 `8333 us` 降到 `6333 us`。主要设备风险仍是同步 `drain-to-latest` 会主动丢弃已经过时的解码输出，需要实机 A/B 判断 120 Hz 流畅度和操作延迟是否真正改善。

## 验证

- `presentation_scheduler_test`：通过
- `presentation_observability_test`：通过
- `two_step_presentation_scheduler_test`（ASan/UBSan）：通过
- `node hvigorw.js assembleApp --mode project -p product=default -p buildMode=debug --no-daemon`：通过
- `git diff --check origin/master...HEAD`：通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 引入两阶段画面呈现调度，优化主机节奏模式下的帧准备、呈现与丢弃。
  - 改善解码帧与目标呈现时间的匹配，支持对过期、缺失、过远及非连续帧进行处理。
  - 增强视频输出结束及丢帧场景下的呈现状态管理。

- **测试**
  - 新增多种帧率、时间间隔、重复帧和异常时序场景的调度验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->