### PR TITLE
feat(haptics): add in-stream controls and output mixing

### DIFF
--- a/entry/src/main/ets/components/dialogs/GameMenuDialog.ets
+++ b/entry/src/main/ets/components/dialogs/GameMenuDialog.ets
@@ -101,6 +101,7 @@ const CARD_SHORTCUT = 'shortcut';
 const CARD_SUPERCMD = 'supercmd';
 const CARD_BITRATE = 'bitrate';
 const CARD_CUSTOMKEY = 'customkey';
+const CARD_AUDIO_VIBRATION = 'audio_vibration';
 const CARD_UNLOCK = 'unlock';
 const CARD_MIC = 'mic';
 const CARD_USAGE_KEY = 'game_menu_card_usage';
@@ -165,6 +166,11 @@ export struct GameMenuDialog {
   @State private abrEnabled: boolean = false;
   private bitrateDebounceTimer: number = -1;
 
+  // 音频振动会话设置
+  @State private audioVibrationEnabled: boolean = false;
+  @State private audioVibrationStrength: number = 60;
+  @State private audioVibrationSceneMode: string = '游戏/电影';
+
   // 体感助手状态
   @State private gyroEnabled: boolean = false;
   @State private gyroSensitivity: number = 1.0;
@@ -220,6 +226,17 @@ export struct GameMenuDialog {
     this.currentBitrate = this.viewModel.getCurrentBitrate();
     this.bitrateSliderValue = this.bitrateToSliderValue(this.currentBitrate);
     this.abrEnabled = this.viewModel.isAbrEnabled();
+    const streamConfig = this.viewModel.streamConfig;
+    if (streamConfig) {
+      this.audioVibrationEnabled = streamConfig.enableAudioVibration;
+      this.audioVibrationStrength = Math.max(
+        10, Math.min(100, streamConfig.audioVibrationStrength));
+      // ABI v1 的 AUTO 当前按 GAME 处理，菜单只展示两个实际不同的场景。
+      this.audioVibrationSceneMode =
+        streamConfig.audioVibrationSceneMode === '音乐/节奏'
+          ? '音乐/节奏'
+          : '游戏/电影';
+    }
     this.controllerOpacityLocal = this.controllerOpacity;
     this.controllerScaleLocal = this.controllerScale;
     this.touchPassthroughLocal = this.touchPassthrough;
@@ -588,6 +605,7 @@ export struct GameMenuDialog {
     if (this.shortcuts.length > 0) visible.push(CARD_SHORTCUT);
     if (this.superCmds.length > 0) visible.push(CARD_SUPERCMD);
     visible.push(CARD_BITRATE);
+    visible.push(CARD_AUDIO_VIBRATION);
     visible.push(CARD_CUSTOMKEY);
     // 按使用次数降序排列，次数相同保持原始顺序
     visible.sort((a: string, b: string): number => {
@@ -631,6 +649,34 @@ export struct GameMenuDialog {
     } catch (error) {
       console.error('[GyroAssist] 保存设置失败:', error);
     }
+  }
+
+  private applyAudioVibrationSettings(persist: boolean): void {
+    this.viewModel.updateAudioVibrationSettings(
+      this.audioVibrationEnabled,
+      this.audioVibrationStrength,
+      this.audioVibrationSceneMode
+    );
+    if (!persist) return;
+
+    PreferencesUtil.put(
+      SettingsKeys.ENABLE_AUDIO_VIBRATION,
+      this.audioVibrationEnabled
+    ).catch((error: Error) => {
+      console.error('[AudioVibration] 保存启用状态失败:', error);
+    });
+    PreferencesUtil.put(
+      SettingsKeys.AUDIO_VIBRATION_STRENGTH,
+      this.audioVibrationStrength
+    ).catch((error: Error) => {
+      console.error('[AudioVibration] 保存强度失败:', error);
+    });
+    PreferencesUtil.put(
+      SettingsKeys.AUDIO_VIBRATION_SCENE_MODE,
+      this.audioVibrationSceneMode
+    ).catch((error: Error) => {
+      console.error('[AudioVibration] 保存场景失败:', error);
+    });
   }
 
   build() {
@@ -757,6 +803,8 @@ export struct GameMenuDialog {
       this.BitrateCard()
     } else if (cardId === CARD_CUSTOMKEY) {
       this.CustomKeyCard()
+    } else if (cardId === CARD_AUDIO_VIBRATION) {
+      this.AudioVibrationCard()
     }
   }
 
@@ -1194,6 +1242,153 @@ export struct GameMenuDialog {
     }
     .width(OV_CARD_WIDTH)
     .cardStyle()
+  }
+
+  @Builder
+  AudioVibrationCard() {
+    Column() {
+      Row() {
+        Image($r('app.media.ic_pulse'))
+          .width(OV_FONT_LG)
+          .height(OV_FONT_LG)
+          .fillColor(OV_TEXT_BRIGHT)
+        Text(' 音频振动')
+          .fontSize(OV_FONT_LG)
+          .fontWeight(FontWeight.Medium)
+          .fontColor(OV_TEXT_BRIGHT)
+        Blank()
+        Toggle({
+          type: ToggleType.Switch,
+          isOn: this.audioVibrationEnabled
+        })
+          .selectedColor(OV_ACCENT_PINK)
+          .switchPointColor(OV_TEXT_WHITE)
+          .width(40)
+          .height(22)
+          .onChange((isOn: boolean) => {
+            this.audioVibrationEnabled = isOn;
+            this.applyAudioVibrationSettings(true);
+            this.recordCardUsage(CARD_AUDIO_VIBRATION);
+          })
+      }
+      .width('100%')
+      .padding({ left: 16, right: 12, top: 14, bottom: 4 })
+
+      Text(this.audioVibrationEnabled
+        ? '场景和强度会在当前串流中即时生效'
+        : '跟随游戏或音乐节奏产生触觉反馈')
+        .fontSize(OV_FONT_SM)
+        .fontColor(OV_TEXT_FAINT)
+        .width('100%')
+        .padding({
+          left: 16,
+          right: 16,
+          bottom: this.audioVibrationEnabled ? 8 : 14
+        })
+
+      if (this.audioVibrationEnabled) {
+        Row().width('85%').height(1).backgroundColor(OV_BG_DIVIDER)
+
+        Column() {
+          Text('场景')
+            .fontSize(OV_FONT_MD)
+            .fontColor(OV_TEXT_MEDIUM)
+            .width('100%')
+            .padding({ bottom: 6 })
+          Row({ space: 8 }) {
+            this.AudioVibrationSceneButton('游戏', '游戏/电影')
+            this.AudioVibrationSceneButton('音乐', '音乐/节奏')
+          }
+          .width('100%')
+        }
+        .width('100%')
+        .padding({ left: 14, right: 14, top: 10, bottom: 8 })
+
+        Column() {
+          Row() {
+            Text('强度').fontSize(OV_FONT_MD).fontColor(OV_TEXT_MEDIUM)
+            Blank()
+            Text(`${this.audioVibrationStrength}%`)
+              .fontSize(OV_FONT_MD)
+              .fontColor(OV_ACCENT_PINK)
+              .fontWeight(FontWeight.Medium)
+          }
+          .width('100%')
+          .padding({ bottom: 4 })
+
+          Slider({
+            value: this.audioVibrationStrength,
+            min: 10,
+            max: 100,
+            step: 5,
+            style: SliderStyle.OutSet
+          })
+            .width('100%')
+            .blockColor(OV_ACCENT_PINK)
+            .trackColor(OV_BG_TRACK)
+            .selectedColor(OV_ACCENT_PINK)
+            .showSteps(false)
+            .showTips(false)
+            .sliderInteractionMode(SliderInteraction.SLIDE_ONLY)
+            .onChange((value: number, mode: SliderChangeMode) => {
+              this.audioVibrationStrength =
+                Math.max(10, Math.min(100, Math.round(value / 5) * 5));
+              const persist =
+                mode === SliderChangeMode.End ||
+                mode === SliderChangeMode.Click;
+              this.applyAudioVibrationSettings(persist);
+              if (persist) {
+                this.recordCardUsage(CARD_AUDIO_VIBRATION);
+              }
+            })
+
+          Row() {
+            Text('10%').fontSize(OV_FONT_XS).fontColor(OV_TEXT_FAINT)
+            Blank()
+            Text('100%').fontSize(OV_FONT_XS).fontColor(OV_TEXT_FAINT)
+          }
+          .width('100%')
+        }
+        .width('100%')
+        .padding({ left: 14, right: 14, bottom: 12 })
+      }
+    }
+    .width(OV_CARD_WIDTH)
+    .cardStyle()
+  }
+
+  @Builder
+  AudioVibrationSceneButton(label: string, sceneMode: string) {
+    Text(label)
+      .fontSize(OV_FONT_MD)
+      .fontWeight(
+        this.audioVibrationSceneMode === sceneMode
+          ? FontWeight.Bold
+          : FontWeight.Normal)
+      .fontColor(
+        this.audioVibrationSceneMode === sceneMode
+          ? OV_TEXT_WHITE
+          : OV_TEXT_DIM)
+      .textAlign(TextAlign.Center)
+      .layoutWeight(1)
+      .padding({ top: 7, bottom: 7 })
+      .borderRadius(14)
+      .backgroundColor(
+        this.audioVibrationSceneMode === sceneMode
+          ? OV_BLUE_50
+          : OV_BG_DIVIDER)
+      .border({
+        width: 1,
+        color: this.audioVibrationSceneMode === sceneMode
+          ? OV_ACCENT_BLUE
+          : (this.isCurrentDark() ? OV_BG_CARD_DARKER : OV_BG_CARD_LIGHTER)
+      })
+      .onClick(() => {
+        if (this.audioVibrationSceneMode === sceneMode) return;
+        this.audioVibrationSceneMode = sceneMode;
+        this.applyAudioVibrationSettings(true);
+        this.recordCardUsage(CARD_AUDIO_VIBRATION);
+      })
   }
 
   @Builder

--- a/entry/src/main/ets/service/AudioVibrationService.ets
+++ b/entry/src/main/ets/service/AudioVibrationService.ets
@@ -8,7 +8,6 @@
  * (at your option) any later version.
  */
 
-import { vibrator } from '@kit.SensorServiceKit';
 import { GamepadManager } from './input/GamepadManager';
 import { RUMBLE_MAX } from './input/GamepadTypes';
 
@@ -36,19 +35,15 @@ export class AudioVibrationService {
   private static readonly FLAG_CONTINUOUS_CHANGED: number = 1 << 0;
   private static readonly FLAG_TRANSIENT: number = 1 << 1;
   private static readonly FLAG_STOP: number = 1 << 2;
-  private static readonly SCENE_MUSIC: number = 1;
   private static readonly MINIMUM_INTENSITY: number = 4;
   private static readonly TRANSIENT_MINIMUM_INTERVAL_MS: number = 12;
   private static readonly CONTINUOUS_MINIMUM_INTERVAL_MS: number = 60;
-  private static readonly GAME_CONTINUOUS_LEASE_MS: number = 1000;
-  private static readonly MUSIC_CONTINUOUS_LEASE_MS: number = 240;
 
   private enabled: boolean = false;
   private strength: number = 100;
   private vibrationMode: string = '自动';
   private sceneMode: string = '游戏/电影';
 
-  private hdHapticSupported: boolean | null = null;
   private isDeviceVibrating: boolean = false;
   private isUsbRumbling: boolean = false;
 
@@ -218,125 +213,14 @@ export class AudioVibrationService {
   private renderDevice(continuous: number, transient: number,
     transientDurationMs: number, sharpness: number, hasTransient: boolean,
     activeScene: number): void {
-    if (this.hdHapticSupported === null) {
-      try {
-        this.hdHapticSupported = vibrator.isHdHapticSupported();
-      } catch (_) {
-        this.hdHapticSupported = false;
-      }
-    }
-
-    try {
-      if (this.hdHapticSupported) {
-        this.renderHdPattern(
-          continuous,
-          transient,
-          transientDurationMs,
-          sharpness,
-          hasTransient,
-          activeScene
-        );
-      } else {
-        this.renderTimeFallback(
-          continuous,
-          transient,
-          transientDurationMs,
-          hasTransient,
-          activeScene
-        );
-      }
-      this.isDeviceVibrating = true;
-    } catch (_) {
-      this.renderTimeFallback(
-        continuous,
-        transient,
-        transientDurationMs,
-        hasTransient,
-        activeScene
-      );
-    }
-  }
-
-  private renderHdPattern(continuous: number, transient: number,
-    transientDurationMs: number, sharpness: number, hasTransient: boolean,
-    activeScene: number): void {
-    const builder = new vibrator.VibratorPatternBuilder();
-    const frequency = Math.round(30 + Math.max(0, Math.min(1, sharpness)) * 40);
-    let hasEvent = false;
-
-    if (hasTransient &&
-        transient >= AudioVibrationService.MINIMUM_INTENSITY) {
-      builder.addTransientEvent(0, {
-        intensity: transient,
-        frequency: frequency,
-        index: 0
-      });
-      hasEvent = true;
-    }
-
-    if (continuous >= AudioVibrationService.MINIMUM_INTENSITY) {
-      const startMs = hasTransient
-        ? Math.max(8, Math.min(35, Math.round(transientDurationMs)))
-        : 0;
-      const leaseMs = activeScene === AudioVibrationService.SCENE_MUSIC
-        ? AudioVibrationService.MUSIC_CONTINUOUS_LEASE_MS
-        : AudioVibrationService.GAME_CONTINUOUS_LEASE_MS;
-      builder.addContinuousEvent(startMs, leaseMs, {
-        intensity: continuous,
-        frequency: Math.max(25, frequency - 8),
-        index: 0
-      });
-      hasEvent = true;
-    }
-
-    if (!hasEvent) {
-      this.stopDeviceVibration();
-      return;
-    }
-
-    vibrator.startVibration({
-      type: 'pattern',
-      pattern: builder.build()
-    }, {
-      id: 0,
-      usage: 'physicalFeedback'
-    }).catch((_: Error): void => {
-      this.renderTimeFallback(
-        continuous,
-        transient,
-        transientDurationMs,
-        hasTransient,
-        activeScene
-      );
-    });
-  }
-
-  private renderTimeFallback(continuous: number, transient: number,
-    transientDurationMs: number, hasTransient: boolean,
-    activeScene: number): void {
-    const selected = hasTransient
-      ? Math.max(transient, continuous)
-      : continuous;
-    if (selected < AudioVibrationService.MINIMUM_INTENSITY) return;
-
-    let duration: number;
-    if (hasTransient) {
-      const authored = Math.max(18, Math.min(100,
-        Math.round(transientDurationMs)));
-      duration = Math.max(15, Math.round(authored * (0.65 + selected / 285)));
-    } else {
-      duration = activeScene === AudioVibrationService.SCENE_MUSIC
-        ? AudioVibrationService.MUSIC_CONTINUOUS_LEASE_MS
-        : 500;
-    }
-
-    vibrator.startVibration({
-      type: 'time',
-      duration: duration
-    }, {
-      id: 0,
-      usage: 'physicalFeedback'
-    }).catch((_: Error): void => { /* best-effort fallback */ });
+    GamepadManager.getInstance().submitAudioDeviceHaptics(
+      continuous,
+      transient,
+      transientDurationMs,
+      sharpness,
+      hasTransient,
+      activeScene
+    );
     this.isDeviceVibrating = true;
   }
 
@@ -379,7 +263,7 @@ export class AudioVibrationService {
       Math.floor(base * lowWeight * (1 - spatialFactor))));
     const high = Math.max(0, Math.min(RUMBLE_MAX,
       Math.floor(base * highWeight * (1 + spatialFactor))));
-    GamepadManager.getInstance().rumbleUsbControllers(0, low, high);
+    GamepadManager.getInstance().submitAudioUsbRumble(0, low, high);
     this.isUsbRumbling = true;
   }
 
@@ -393,18 +277,12 @@ export class AudioVibrationService {
   }
 
   private stopDeviceVibration(): void {
-    try {
-      vibrator.stopVibrationSync();
-    } catch (_) {
-      try {
-        vibrator.stopVibration();
-      } catch (_) { /* best effort */ }
-    }
+    GamepadManager.getInstance().clearAudioDeviceHaptics();
     this.isDeviceVibrating = false;
   }
 
   private stopUsbRumble(): void {
-    GamepadManager.getInstance().rumbleUsbControllers(0, 0, 0);
+    GamepadManager.getInstance().submitAudioUsbRumble(0, 0, 0);
     this.isUsbRumbling = false;
   }
 }

--- a/entry/src/main/ets/service/AudioVibrationService.ets
+++ b/entry/src/main/ets/service/AudioVibrationService.ets
@@ -44,8 +44,8 @@ export class AudioVibrationService {
   private vibrationMode: string = '自动';
   private sceneMode: string = '游戏/电影';
 
-  private isDeviceVibrating: boolean = false;
-  private isUsbRumbling: boolean = false;
+  private isDeviceSourceActive: boolean = false;
+  private isUsbSourceActive: boolean = false;
 
   private currentContinuousIntensity: number = 0;
   private currentLowBandRatio: number = 50;
@@ -166,7 +166,7 @@ export class AudioVibrationService {
         hasTransient,
         frame.activeScene
       );
-    } else if (this.isDeviceVibrating) {
+    } else if (this.isDeviceSourceActive) {
       this.stopDeviceVibration();
     }
 
@@ -179,7 +179,7 @@ export class AudioVibrationService {
         lowBandRatio,
         stereoBalance
       );
-    } else if (this.isUsbRumbling) {
+    } else if (this.isUsbSourceActive) {
       this.stopUsbRumble();
     }
   }
@@ -221,7 +221,7 @@ export class AudioVibrationService {
       hasTransient,
       activeScene
     );
-    this.isDeviceVibrating = true;
+    this.isDeviceSourceActive = true;
   }
 
   private renderUsb(continuous: number, transient: number,
@@ -264,13 +264,13 @@ export class AudioVibrationService {
     const high = Math.max(0, Math.min(RUMBLE_MAX,
       Math.floor(base * highWeight * (1 + spatialFactor))));
     GamepadManager.getInstance().submitAudioUsbRumble(0, low, high);
-    this.isUsbRumbling = true;
+    this.isUsbSourceActive = true;
   }
 
   private stopAll(): void {
     this.usbEffectEpoch++;
-    if (this.isDeviceVibrating) this.stopDeviceVibration();
-    if (this.isUsbRumbling) this.stopUsbRumble();
+    if (this.isDeviceSourceActive) this.stopDeviceVibration();
+    if (this.isUsbSourceActive) this.stopUsbRumble();
     this.currentContinuousIntensity = 0;
     this.currentLowBandRatio = 50;
     this.currentStereoBalance = 50;
@@ -278,11 +278,11 @@ export class AudioVibrationService {
 
   private stopDeviceVibration(): void {
     GamepadManager.getInstance().clearAudioDeviceHaptics();
-    this.isDeviceVibrating = false;
+    this.isDeviceSourceActive = false;
   }
 
   private stopUsbRumble(): void {
     GamepadManager.getInstance().submitAudioUsbRumble(0, 0, 0);
-    this.isUsbRumbling = false;
+    this.isUsbSourceActive = false;
   }
 }

--- a/entry/src/main/ets/service/input/GamepadManager.ets
+++ b/entry/src/main/ets/service/input/GamepadManager.ets
@@ -2441,9 +2441,30 @@ export class GamepadManager implements UsbDriverListener {
     this.vibrationService.handleRumbleTriggers(controllerNumber, leftTrigger, rightTrigger);
   }
 
-  /** 仅向 USB 控制器发送振动（跳过设备马达和模式路由） */
-  rumbleUsbControllers(controllerNumber: number, lowFreqMotor: number, highFreqMotor: number): void {
-    this.vibrationService.rumbleUsbControllersOnly(controllerNumber, lowFreqMotor, highFreqMotor);
+  /** 更新音频来源的 USB 振动；由平台层与游戏振动统一混合。 */
+  submitAudioUsbRumble(controllerNumber: number,
+    lowFreqMotor: number, highFreqMotor: number): void {
+    this.vibrationService.submitAudioUsbRumble(
+      controllerNumber, lowFreqMotor, highFreqMotor);
+  }
+
+  /** 更新音频来源的设备触觉；最终只有振动服务写系统马达。 */
+  submitAudioDeviceHaptics(continuous: number, transient: number,
+    transientDurationMs: number, sharpness: number, hasTransient: boolean,
+    activeScene: number): void {
+    this.vibrationService.submitAudioDeviceHaptics(
+      continuous,
+      transient,
+      transientDurationMs,
+      sharpness,
+      hasTransient,
+      activeScene
+    );
+  }
+
+  /** 只清除音频来源的设备触觉，保留游戏振动。 */
+  clearAudioDeviceHaptics(): void {
+    this.vibrationService.clearAudioDeviceHaptics();
   }
 
   /** 检查是否有 USB 控制器连接 */

--- a/entry/src/main/ets/service/input/GamepadVibrationService.ets
+++ b/entry/src/main/ets/service/input/GamepadVibrationService.ets
@@ -53,6 +53,20 @@ export class GamepadVibrationService {
   // USB 停止确认: 延迟重发 stop(0,0) 防止 USB 传输丢失
   private stopConfirmTimer: number = -1;
 
+  // 游戏与音频分别保存状态，只有本服务可以写最终执行器。
+  // 游戏是主信号，音频只填充剩余动态范围，避免简单相加削顶。
+  private gameUsbRumble = new Map<number, number[]>();
+  private audioUsbRumble = new Map<number, number[]>();
+  private gameDeviceLow: number = 0;
+  private gameDeviceHigh: number = 0;
+  private audioDeviceContinuous: number = 0;
+  private audioDeviceContinuousUntilMs: number = 0;
+  private audioDeviceTransient: number = 0;
+  private audioDeviceTransientDurationMs: number = 0;
+  private audioDeviceSharpness: number = 0.5;
+  private audioDeviceScene: number = 0;
+  private deviceRenderEpoch: number = 0;
+
   constructor(usbDriverService: UsbDriverService, deviceKeyToSlot: Map<string, number>) {
     this.usbDriverService = usbDriverService;
     this.deviceKeyToSlotLookup = deviceKeyToSlot;
@@ -74,7 +88,7 @@ export class GamepadVibrationService {
     this.gameVibrationStrength = normalizeGameVibrationStrength(strength);
     this.vibrationMode = mode;
     if ((wasEnabled && !enabled) || (previousStrength > 0 && this.gameVibrationStrength === 0)) {
-      this.stopAll();
+      this.stopGameSource();
     }
   }
 
@@ -111,27 +125,30 @@ export class GamepadVibrationService {
     switch (this.vibrationMode) {
       case '仅手柄':
         if (hasUsbController) {
-          this.rumbleUsbControllers(controllers, controllerNumber, lowFreqMotor, highFreqMotor);
+          this.submitGameUsbRumble(
+            controllers, controllerNumber, lowFreqMotor, highFreqMotor);
         }
         break;
 
       case '仅设备':
-        this.triggerDeviceVibrate(lowFreqMotor, highFreqMotor);
+        this.submitGameDeviceRumble(lowFreqMotor, highFreqMotor);
         break;
 
       case '同时':
         if (hasUsbController) {
-          this.rumbleUsbControllers(controllers, controllerNumber, lowFreqMotor, highFreqMotor);
+          this.submitGameUsbRumble(
+            controllers, controllerNumber, lowFreqMotor, highFreqMotor);
         }
-        this.triggerDeviceVibrate(lowFreqMotor, highFreqMotor);
+        this.submitGameDeviceRumble(lowFreqMotor, highFreqMotor);
         break;
 
       case '自动':
       default:
         if (hasUsbController) {
-          this.rumbleUsbControllers(controllers, controllerNumber, lowFreqMotor, highFreqMotor);
+          this.submitGameUsbRumble(
+            controllers, controllerNumber, lowFreqMotor, highFreqMotor);
         } else {
-          this.triggerDeviceVibrate(lowFreqMotor, highFreqMotor);
+          this.submitGameDeviceRumble(lowFreqMotor, highFreqMotor);
         }
         break;
     }
@@ -156,16 +173,48 @@ export class GamepadVibrationService {
     );
   }
 
-  /**
-   * 仅向 USB 控制器发送振动（跳过设备马达路由）
-   * 供 AudioVibrationService 独立路由使用，避免经过设备振动的
-   * 防抖逻辑和参数变换，保证最高精度。
-   */
-  rumbleUsbControllersOnly(controllerNumber: number, lowFreqMotor: number, highFreqMotor: number): void {
+  /** 更新音频来源的 USB 振动；最终输出会与游戏来源混合。 */
+  submitAudioUsbRumble(controllerNumber: number,
+    lowFreqMotor: number, highFreqMotor: number): void {
+    this.audioUsbRumble.set(controllerNumber, [
+      this.clampRumbleValue(lowFreqMotor),
+      this.clampRumbleValue(highFreqMotor)
+    ]);
     const controllers = this.usbDriverService.getControllers();
     if (controllers.length > 0) {
-      this.rumbleUsbControllers(controllers, controllerNumber, lowFreqMotor, highFreqMotor, false);
+      this.renderMixedUsb(controllers, controllerNumber);
     }
+  }
+
+  /**
+   * 更新音频来源的设备触觉。游戏连续振动是主信号，音频瞬态与连续
+   * 只占用剩余动态范围；音频 stop 不会再停止仍活跃的游戏振动。
+   */
+  submitAudioDeviceHaptics(continuous: number, transient: number,
+    transientDurationMs: number, sharpness: number, hasTransient: boolean,
+    activeScene: number): void {
+    this.audioDeviceContinuous = this.clampIntensity(continuous);
+    this.audioDeviceContinuousUntilMs =
+      this.audioDeviceContinuous >= 5
+        ? Date.now() + (activeScene === 1 ? 240 : 1000)
+        : 0;
+    this.audioDeviceTransient = hasTransient
+      ? this.clampIntensity(transient)
+      : 0;
+    this.audioDeviceTransientDurationMs = Math.max(
+      0, Math.min(100, Math.round(transientDurationMs)));
+    this.audioDeviceSharpness = Math.max(0, Math.min(1, sharpness));
+    this.audioDeviceScene = activeScene;
+    this.renderMixedDevice(hasTransient);
+    this.audioDeviceTransient = 0;
+  }
+
+  /** 只清理音频来源，保留游戏来源。 */
+  clearAudioDeviceHaptics(): void {
+    this.audioDeviceContinuous = 0;
+    this.audioDeviceContinuousUntilMs = 0;
+    this.audioDeviceTransient = 0;
+    this.renderMixedDevice(false);
   }
 
   /**
@@ -179,25 +228,21 @@ export class GamepadVibrationService {
    * 停止所有震动（设备马达 + USB 控制器马达）
    */
   stopAll(): void {
-    // 清除 watchdog
-    if (this.rumbleWatchdogTimer !== -1) {
-      clearTimeout(this.rumbleWatchdogTimer);
-      this.rumbleWatchdogTimer = -1;
-    }
-    // 清除 stop 确认定时器
-    if (this.stopConfirmTimer !== -1) {
-      clearTimeout(this.stopConfirmTimer);
-      this.stopConfirmTimer = -1;
-    }
-
-    // 停止设备马达
-    if (this.isVibrating) {
-      this.stopVibrationImmediate();
-    }
+    this.clearGameTimers();
+    this.gameUsbRumble.clear();
+    this.audioUsbRumble.clear();
+    this.gameDeviceLow = 0;
+    this.gameDeviceHigh = 0;
+    this.audioDeviceContinuous = 0;
+    this.audioDeviceContinuousUntilMs = 0;
+    this.audioDeviceTransient = 0;
     this.lastLowFreq = 0;
     this.lastHighFreq = 0;
 
-    // 停止 USB 控制器马达（发送 rumble(0,0)）
+    if (this.isVibrating) {
+      this.stopVibrationImmediate();
+    }
+
     try {
       const controllers = this.usbDriverService.getControllers();
       for (const controller of controllers) {
@@ -208,6 +253,40 @@ export class GamepadVibrationService {
         this.scheduleUsbStopConfirm(this.lastRumbleControllerNumber);
       }
     } catch (_) { /* ignore */ }
+  }
+
+  /** 只清理游戏来源；音频来源仍可继续输出。 */
+  private stopGameSource(): void {
+    this.clearGameTimers();
+    const affectedSlots = new Set<number>();
+    this.gameUsbRumble.forEach((_: number[], slot: number): void => {
+      affectedSlots.add(slot);
+    });
+    this.gameUsbRumble.clear();
+    this.gameDeviceLow = 0;
+    this.gameDeviceHigh = 0;
+    this.lastLowFreq = 0;
+    this.lastHighFreq = 0;
+
+    const controllers = this.usbDriverService.getControllers();
+    affectedSlots.forEach((slot: number): void => {
+      this.renderMixedUsb(controllers, slot);
+    });
+    for (const controller of controllers) {
+      controller.rumbleTriggers(0, 0);
+    }
+    this.renderMixedDevice(false);
+  }
+
+  private clearGameTimers(): void {
+    if (this.rumbleWatchdogTimer !== -1) {
+      clearTimeout(this.rumbleWatchdogTimer);
+      this.rumbleWatchdogTimer = -1;
+    }
+    if (this.stopConfirmTimer !== -1) {
+      clearTimeout(this.stopConfirmTimer);
+      this.stopConfirmTimer = -1;
+    }
   }
 
   // ==================== 内部实现 ====================
@@ -231,20 +310,30 @@ export class GamepadVibrationService {
     return controllers[0];
   }
 
-  /**
-   * 向 USB 控制器发送震动
-   */
-  private rumbleUsbControllers(
+  private submitGameUsbRumble(
     controllers: AbstractController[],
     controllerNumber: number,
     lowFreqMotor: number,
-    highFreqMotor: number,
-    applyGain: boolean = true
+    highFreqMotor: number
   ): void {
+    this.gameUsbRumble.set(controllerNumber, [
+      this.applyGameVibrationStrength(lowFreqMotor),
+      this.applyGameVibrationStrength(highFreqMotor)
+    ]);
+    this.renderMixedUsb(controllers, controllerNumber);
+  }
+
+  private renderMixedUsb(controllers: AbstractController[],
+    controllerNumber: number): void {
     const controller = this.findControllerBySlot(controllers, controllerNumber);
-    const lowValue = applyGain ? this.applyGameVibrationStrength(lowFreqMotor) : this.clampRumbleValue(lowFreqMotor);
-    const highValue = applyGain ? this.applyGameVibrationStrength(highFreqMotor) : this.clampRumbleValue(highFreqMotor);
-    controller?.rumble(lowValue, highValue);
+    if (!controller) return;
+
+    const game = this.gameUsbRumble.get(controllerNumber) ?? [0, 0];
+    const audio = this.audioUsbRumble.get(controllerNumber) ?? [0, 0];
+    controller.rumble(
+      this.mixPrimaryWithOverlay(game[0], audio[0], RUMBLE_MAX),
+      this.mixPrimaryWithOverlay(game[1], audio[1], RUMBLE_MAX)
+    );
   }
 
   private applyGameVibrationStrength(value: number): number {
@@ -261,56 +350,81 @@ export class GamepadVibrationService {
     return Math.max(0, Math.min(RUMBLE_MAX, Math.floor(value)));
   }
 
+  private clampIntensity(value: number): number {
+    if (!Number.isFinite(value)) return 0;
+    return Math.max(0, Math.min(100, Math.round(value)));
+  }
+
+  /**
+   * 游戏为主信号，音频按剩余 headroom 混入：
+   * primary + overlay * (1 - primary / max)。
+   */
+  private mixPrimaryWithOverlay(primary: number, overlay: number,
+    maximum: number): number {
+    const safePrimary = Math.max(0, Math.min(maximum, primary));
+    const safeOverlay = Math.max(0, Math.min(maximum, overlay));
+    return Math.max(0, Math.min(maximum, Math.round(
+      safePrimary + safeOverlay * (maximum - safePrimary) / maximum)));
+  }
+
   private scheduleUsbStopConfirm(controllerNumber: number): void {
     this.stopConfirmTimer = setTimeout(() => {
       this.stopConfirmTimer = -1;
       const controllers = this.usbDriverService.getControllers();
-      this.rumbleUsbControllers(controllers, controllerNumber, 0, 0);
+      this.renderMixedUsb(controllers, controllerNumber);
     }, 100);
   }
 
-  /**
-   * 触发设备震动（后备方案）
-   *
-   * 关键改进：
-   * 1. 使用 continuous 长振（而非 transient 瞬态）实现持续震动
-   * 2. 强度变化时立即停止旧震动再启动新震动
-   * 3. 使用 stopVibrationSync 同步停止确保即时性
-   */
-  private triggerDeviceVibrate(lowFreqMotor: number, highFreqMotor: number): void {
+  /** 更新游戏来源的设备振动，并交给统一输出器混合。 */
+  private submitGameDeviceRumble(lowFreqMotor: number, highFreqMotor: number): void {
     if (!this.vibrationFeedbackEnabled || this.gameVibrationStrength <= 0) return;
 
-    // 停止震动
     if (lowFreqMotor === 0 && highFreqMotor === 0) {
-      if (this.isVibrating) {
-        this.stopVibrationImmediate();
-        this.lastLowFreq = 0;
-        this.lastHighFreq = 0;
-      }
+      this.gameDeviceLow = 0;
+      this.gameDeviceHigh = 0;
+      this.lastLowFreq = 0;
+      this.lastHighFreq = 0;
+      this.renderMixedDevice(false);
       return;
     }
 
-    // 检查是否需要更新震动（强度变化超过阈值才更新，避免过于频繁）
     const lowDelta = Math.abs(lowFreqMotor - this.lastLowFreq);
     const highDelta = Math.abs(highFreqMotor - this.lastHighFreq);
     const threshold = 3000;  // 约 5% 的变化阈值
 
-    if (this.isVibrating && lowDelta < threshold && highDelta < threshold) {
+    const gameWasActive =
+      this.gameDeviceLow > 0 || this.gameDeviceHigh > 0;
+    if (gameWasActive && lowDelta < threshold && highDelta < threshold) {
       return;  // 变化太小，不更新
     }
 
     this.lastLowFreq = lowFreqMotor;
     this.lastHighFreq = highFreqMotor;
+    this.gameDeviceLow = lowFreqMotor;
+    this.gameDeviceHigh = highFreqMotor;
+    this.renderMixedDevice(false);
+  }
 
-    // 计算用户强度系数
+  private renderMixedDevice(hasAudioTransient: boolean): void {
+    const renderEpoch = ++this.deviceRenderEpoch;
     const userStrength = Math.min(this.gameVibrationStrength, GAME_VIBRATION_STRENGTH_ORIGINAL) /
       GAME_VIBRATION_STRENGTH_ORIGINAL;
+    const lowIntensity = this.clampIntensity(
+      this.gameDeviceLow / RUMBLE_MAX * userStrength * 100);
+    const highIntensity = this.clampIntensity(
+      this.gameDeviceHigh / RUMBLE_MAX * userStrength * 100);
+    const gameIntensity = Math.max(lowIntensity, highIntensity);
+    const audioContinuous =
+      Date.now() <= this.audioDeviceContinuousUntilMs
+        ? this.audioDeviceContinuous
+        : 0;
+    const mixedContinuous = this.mixPrimaryWithOverlay(
+      gameIntensity, audioContinuous, 100);
+    const mixedTransient = hasAudioTransient
+      ? this.mixPrimaryWithOverlay(
+        gameIntensity, this.audioDeviceTransient, 100)
+      : 0;
 
-    // 计算低频和高频马达的强度 (0-100)
-    const lowIntensity = Math.floor((lowFreqMotor / RUMBLE_MAX) * userStrength * 100);
-    const highIntensity = Math.floor((highFreqMotor / RUMBLE_MAX) * userStrength * 100);
-
-    // 检查是否支持高清振动（首次检查后缓存）
     if (this.hdHapticSupported === null) {
       try {
         this.hdHapticSupported = vibrator.isHdHapticSupported();
@@ -320,21 +434,25 @@ export class GamepadVibrationService {
       }
     }
 
-    // 先停止当前震动（确保即时切换）
-    if (this.isVibrating) {
-      this.stopVibrationImmediate();
-    }
-
     try {
       if (this.hdHapticSupported) {
-        this.triggerContinuousVibration(lowIntensity, highIntensity);
+        this.triggerMixedPattern(
+          lowIntensity,
+          highIntensity,
+          mixedContinuous,
+          mixedTransient,
+          hasAudioTransient,
+          renderEpoch
+        );
       } else {
-        this.triggerTimeVibration(lowIntensity, highIntensity);
+        this.triggerMixedTimeFallback(
+          mixedContinuous, mixedTransient, hasAudioTransient, renderEpoch);
       }
-      this.isVibrating = true;
+      this.isVibrating = mixedContinuous >= 5 || mixedTransient >= 5;
     } catch (err) {
       console.warn(`[VIBRATION] 设备震动异常: ${err}`);
-      this.fallbackTimeVibration(Math.max(lowIntensity, highIntensity));
+      this.triggerMixedTimeFallback(
+        mixedContinuous, mixedTransient, hasAudioTransient, renderEpoch);
     }
   }
 
@@ -342,6 +460,7 @@ export class GamepadVibrationService {
    * 立即停止震动（同步方式）
    */
   private stopVibrationImmediate(): void {
+    this.deviceRenderEpoch++;
     try {
       // 优先使用同步停止 API (API 12+)
       vibrator.stopVibrationSync();
@@ -354,74 +473,101 @@ export class GamepadVibrationService {
     this.isVibrating = false;
   }
 
-  /**
-   * 使用 continuous 长振实现持续震动 (API 18+)
-   */
-  private triggerContinuousVibration(lowIntensity: number, highIntensity: number): void {
-    try {
-      const builder = new vibrator.VibratorPatternBuilder();
+  private triggerMixedPattern(lowIntensity: number, highIntensity: number,
+    mixedContinuous: number, mixedTransient: number,
+    hasAudioTransient: boolean, renderEpoch: number): void {
+    const hasContinuous = mixedContinuous >= 5;
+    const hasTransient = hasAudioTransient && mixedTransient >= 5;
+    if (!hasContinuous && !hasTransient) {
+      if (this.isVibrating) this.stopVibrationImmediate();
+      return;
+    }
 
-      const combinedIntensity = Math.min(100, Math.max(lowIntensity, highIntensity));
-      if (combinedIntensity < 5) return;
+    const builder = new vibrator.VibratorPatternBuilder();
+    const audioFrequency = Math.round(
+      30 + this.audioDeviceSharpness * 40);
+    if (hasTransient) {
+      builder.addTransientEvent(0, {
+        intensity: mixedTransient,
+        frequency: audioFrequency,
+        index: 0
+      });
+    }
 
-      // 根据低频/高频比例计算频率
-      let frequency: number;
-      if (lowIntensity > 0 && highIntensity > 0) {
-        const ratio = highIntensity / (lowIntensity + highIntensity);
-        frequency = Math.floor(30 + ratio * 50);  // 30-80
-      } else if (lowIntensity > 0) {
-        frequency = 35;  // 低频：沉闷
-      } else {
-        frequency = 70;  // 高频：尖锐
-      }
-
-      builder.addContinuousEvent(0, 500, {
-        intensity: combinedIntensity,
+    if (hasContinuous) {
+      const gameFrequency = this.getGameDeviceFrequency(
+        lowIntensity, highIntensity);
+      const frequency = Math.max(25,
+        Math.round(Math.max(lowIntensity, highIntensity) > 0
+          ? gameFrequency
+          : audioFrequency - 8));
+      const startMs = hasTransient
+        ? Math.max(8, Math.min(35, this.audioDeviceTransientDurationMs))
+        : 0;
+      const gameActive = Math.max(lowIntensity, highIntensity) > 0;
+      const leaseMs = gameActive
+        ? 500
+        : (this.audioDeviceScene === 1 ? 240 : 1000);
+      builder.addContinuousEvent(startMs, leaseMs, {
+        intensity: mixedContinuous,
         frequency: frequency,
         index: 0
       });
-
-      vibrator.startVibration({
-        type: 'pattern',
-        pattern: builder.build()
-      }, {
-        id: 0,
-        usage: 'physicalFeedback'
-      }).catch((err: Error) => {
-        this.triggerTimeVibration(lowIntensity, highIntensity);
-      });
-    } catch (err) {
-      this.triggerTimeVibration(lowIntensity, highIntensity);
     }
-  }
-
-  /**
-   * 使用时长模式实现持续震动
-   */
-  private triggerTimeVibration(lowIntensity: number, highIntensity: number): void {
-    const combinedIntensity = Math.max(lowIntensity, highIntensity);
-    if (combinedIntensity < 5) return;
 
     vibrator.startVibration({
-      type: 'time',
-      duration: 500
+      type: 'pattern',
+      pattern: builder.build()
     }, {
       id: 0,
       usage: 'physicalFeedback'
-    }).catch((err: Error) => {
-      console.warn(`[VIBRATION] 时长震动失败: ${err.message}`);
+    }).catch((_: Error): void => {
+      this.triggerMixedTimeFallback(
+        mixedContinuous, mixedTransient, hasAudioTransient, renderEpoch);
     });
   }
 
-  /**
-   * 回退的简单时长模式震动
-   */
-  private fallbackTimeVibration(intensity: number): void {
-    if (intensity < 5) return;
-    const duration = Math.floor(50 + intensity * 4.5);  // 50-500ms
+  private getGameDeviceFrequency(lowIntensity: number,
+    highIntensity: number): number {
+    if (lowIntensity > 0 && highIntensity > 0) {
+      const ratio = highIntensity / (lowIntensity + highIntensity);
+      return Math.floor(30 + ratio * 50);
+    }
+    return lowIntensity > 0 ? 35 : 70;
+  }
 
-    vibrator.startVibration({ type: 'time', duration }, { id: 0, usage: 'physicalFeedback' })
-      .catch((err: Error) => console.warn(`[VIBRATION] 设备震动失败: ${err.message}`));
-    this.isVibrating = true;
+  private triggerMixedTimeFallback(mixedContinuous: number,
+    mixedTransient: number, hasAudioTransient: boolean,
+    renderEpoch: number): void {
+    if (renderEpoch !== this.deviceRenderEpoch) return;
+    const selected = hasAudioTransient
+      ? Math.max(mixedTransient, mixedContinuous)
+      : mixedContinuous;
+    if (selected < 5) {
+      if (this.isVibrating) this.stopVibrationImmediate();
+      return;
+    }
+
+    let duration: number;
+    if (hasAudioTransient) {
+      const authored = Math.max(
+        18, Math.min(100, this.audioDeviceTransientDurationMs));
+      duration = Math.max(
+        15, Math.round(authored * (0.65 + selected / 285)));
+    } else if (this.gameDeviceLow > 0 || this.gameDeviceHigh > 0) {
+      duration = 500;
+    } else {
+      duration = this.audioDeviceScene === 1 ? 240 : 500;
+    }
+
+    vibrator.startVibration({
+      type: 'time',
+      duration: duration
+    }, {
+      id: 0,
+      usage: 'physicalFeedback'
+    }).catch((err: Error): void => {
+      console.warn(`[VIBRATION] 时长震动失败: ${err.message}`);
+    });
   }
 }

--- a/entry/src/main/ets/service/input/GamepadVibrationService.ets
+++ b/entry/src/main/ets/service/input/GamepadVibrationService.ets
@@ -26,9 +26,21 @@ import {
   normalizeGameVibrationStrength
 } from '../../model/StreamConfig';
 
+interface MotorPair {
+  low: number;
+  high: number;
+}
+
 // ==================== 震动服务 ====================
 
 export class GamepadVibrationService {
+  private static readonly MINIMUM_DEVICE_INTENSITY = 5;
+  private static readonly DEVICE_RUMBLE_UPDATE_THRESHOLD = 3000;
+  private static readonly GAME_DEVICE_LEASE_MS = 500;
+  private static readonly AUDIO_MUSIC_LEASE_MS = 240;
+  private static readonly AUDIO_GAME_LEASE_MS = 1000;
+  private static readonly AUDIO_GAME_FALLBACK_DURATION_MS = 500;
+  private static readonly MUSIC_SCENE = 1;
   private usbDriverService: UsbDriverService;
   
   // 设置
@@ -54,9 +66,9 @@ export class GamepadVibrationService {
   private stopConfirmTimer: number = -1;
 
   // 游戏与音频分别保存状态，只有本服务可以写最终执行器。
-  // 游戏是主信号，音频只填充剩余动态范围，避免简单相加削顶。
-  private gameUsbRumble = new Map<number, number[]>();
-  private audioUsbRumble = new Map<number, number[]>();
+  // 两路幅度使用有界 headroom 混合，避免简单相加削顶。
+  private gameUsbRumble = new Map<number, MotorPair>();
+  private audioUsbRumble = new Map<number, MotorPair>();
   private gameDeviceLow: number = 0;
   private gameDeviceHigh: number = 0;
   private audioDeviceContinuous: number = 0;
@@ -176,10 +188,10 @@ export class GamepadVibrationService {
   /** 更新音频来源的 USB 振动；最终输出会与游戏来源混合。 */
   submitAudioUsbRumble(controllerNumber: number,
     lowFreqMotor: number, highFreqMotor: number): void {
-    this.audioUsbRumble.set(controllerNumber, [
-      this.clampRumbleValue(lowFreqMotor),
-      this.clampRumbleValue(highFreqMotor)
-    ]);
+    this.audioUsbRumble.set(controllerNumber, {
+      low: this.clampRumbleValue(lowFreqMotor),
+      high: this.clampRumbleValue(highFreqMotor)
+    });
     const controllers = this.usbDriverService.getControllers();
     if (controllers.length > 0) {
       this.renderMixedUsb(controllers, controllerNumber);
@@ -187,16 +199,16 @@ export class GamepadVibrationService {
   }
 
   /**
-   * 更新音频来源的设备触觉。游戏连续振动是主信号，音频瞬态与连续
-   * 只占用剩余动态范围；音频 stop 不会再停止仍活跃的游戏振动。
+   * 更新音频来源的设备触觉。游戏与音频分别保存状态并有界混合；
+   * 音频 stop 不会再停止仍活跃的游戏振动。
    */
   submitAudioDeviceHaptics(continuous: number, transient: number,
     transientDurationMs: number, sharpness: number, hasTransient: boolean,
     activeScene: number): void {
     this.audioDeviceContinuous = this.clampIntensity(continuous);
     this.audioDeviceContinuousUntilMs =
-      this.audioDeviceContinuous >= 5
-        ? Date.now() + (activeScene === 1 ? 240 : 1000)
+      this.audioDeviceContinuous >= GamepadVibrationService.MINIMUM_DEVICE_INTENSITY
+        ? Date.now() + this.getAudioContinuousLeaseMs(activeScene)
         : 0;
     this.audioDeviceTransient = hasTransient
       ? this.clampIntensity(transient)
@@ -259,7 +271,7 @@ export class GamepadVibrationService {
   private stopGameSource(): void {
     this.clearGameTimers();
     const affectedSlots = new Set<number>();
-    this.gameUsbRumble.forEach((_: number[], slot: number): void => {
+    this.gameUsbRumble.forEach((_: MotorPair, slot: number): void => {
       affectedSlots.add(slot);
     });
     this.gameUsbRumble.clear();
@@ -316,10 +328,10 @@ export class GamepadVibrationService {
     lowFreqMotor: number,
     highFreqMotor: number
   ): void {
-    this.gameUsbRumble.set(controllerNumber, [
-      this.applyGameVibrationStrength(lowFreqMotor),
-      this.applyGameVibrationStrength(highFreqMotor)
-    ]);
+    this.gameUsbRumble.set(controllerNumber, {
+      low: this.applyGameVibrationStrength(lowFreqMotor),
+      high: this.applyGameVibrationStrength(highFreqMotor)
+    });
     this.renderMixedUsb(controllers, controllerNumber);
   }
 
@@ -328,11 +340,13 @@ export class GamepadVibrationService {
     const controller = this.findControllerBySlot(controllers, controllerNumber);
     if (!controller) return;
 
-    const game = this.gameUsbRumble.get(controllerNumber) ?? [0, 0];
-    const audio = this.audioUsbRumble.get(controllerNumber) ?? [0, 0];
+    const game = this.gameUsbRumble.get(controllerNumber) ??
+      { low: 0, high: 0 };
+    const audio = this.audioUsbRumble.get(controllerNumber) ??
+      { low: 0, high: 0 };
     controller.rumble(
-      this.mixPrimaryWithOverlay(game[0], audio[0], RUMBLE_MAX),
-      this.mixPrimaryWithOverlay(game[1], audio[1], RUMBLE_MAX)
+      this.mixWithHeadroom(game.low, audio.low, RUMBLE_MAX),
+      this.mixWithHeadroom(game.high, audio.high, RUMBLE_MAX)
     );
   }
 
@@ -356,15 +370,15 @@ export class GamepadVibrationService {
   }
 
   /**
-   * 游戏为主信号，音频按剩余 headroom 混入：
-   * primary + overlay * (1 - primary / max)。
+   * 有界概率和：a + b - a*b/max。
+   * 该公式保留任一路单独输出，并避免两路叠加发生硬削顶。
    */
-  private mixPrimaryWithOverlay(primary: number, overlay: number,
+  private mixWithHeadroom(first: number, second: number,
     maximum: number): number {
-    const safePrimary = Math.max(0, Math.min(maximum, primary));
-    const safeOverlay = Math.max(0, Math.min(maximum, overlay));
+    const safeFirst = Math.max(0, Math.min(maximum, first));
+    const safeSecond = Math.max(0, Math.min(maximum, second));
     return Math.max(0, Math.min(maximum, Math.round(
-      safePrimary + safeOverlay * (maximum - safePrimary) / maximum)));
+      safeFirst + safeSecond * (maximum - safeFirst) / maximum)));
   }
 
   private scheduleUsbStopConfirm(controllerNumber: number): void {
@@ -390,11 +404,11 @@ export class GamepadVibrationService {
 
     const lowDelta = Math.abs(lowFreqMotor - this.lastLowFreq);
     const highDelta = Math.abs(highFreqMotor - this.lastHighFreq);
-    const threshold = 3000;  // 约 5% 的变化阈值
-
     const gameWasActive =
       this.gameDeviceLow > 0 || this.gameDeviceHigh > 0;
-    if (gameWasActive && lowDelta < threshold && highDelta < threshold) {
+    if (gameWasActive &&
+        lowDelta < GamepadVibrationService.DEVICE_RUMBLE_UPDATE_THRESHOLD &&
+        highDelta < GamepadVibrationService.DEVICE_RUMBLE_UPDATE_THRESHOLD) {
       return;  // 变化太小，不更新
     }
 
@@ -418,12 +432,18 @@ export class GamepadVibrationService {
       Date.now() <= this.audioDeviceContinuousUntilMs
         ? this.audioDeviceContinuous
         : 0;
-    const mixedContinuous = this.mixPrimaryWithOverlay(
+    const mixedContinuous = this.mixWithHeadroom(
       gameIntensity, audioContinuous, 100);
     const mixedTransient = hasAudioTransient
-      ? this.mixPrimaryWithOverlay(
+      ? this.mixWithHeadroom(
         gameIntensity, this.audioDeviceTransient, 100)
       : 0;
+
+    if (mixedContinuous < GamepadVibrationService.MINIMUM_DEVICE_INTENSITY &&
+        mixedTransient < GamepadVibrationService.MINIMUM_DEVICE_INTENSITY) {
+      if (this.isVibrating) this.stopVibrationImmediate();
+      return;
+    }
 
     if (this.hdHapticSupported === null) {
       try {
@@ -448,7 +468,7 @@ export class GamepadVibrationService {
         this.triggerMixedTimeFallback(
           mixedContinuous, mixedTransient, hasAudioTransient, renderEpoch);
       }
-      this.isVibrating = mixedContinuous >= 5 || mixedTransient >= 5;
+      this.isVibrating = true;
     } catch (err) {
       console.warn(`[VIBRATION] 设备震动异常: ${err}`);
       this.triggerMixedTimeFallback(
@@ -476,12 +496,10 @@ export class GamepadVibrationService {
   private triggerMixedPattern(lowIntensity: number, highIntensity: number,
     mixedContinuous: number, mixedTransient: number,
     hasAudioTransient: boolean, renderEpoch: number): void {
-    const hasContinuous = mixedContinuous >= 5;
-    const hasTransient = hasAudioTransient && mixedTransient >= 5;
-    if (!hasContinuous && !hasTransient) {
-      if (this.isVibrating) this.stopVibrationImmediate();
-      return;
-    }
+    const hasContinuous =
+      mixedContinuous >= GamepadVibrationService.MINIMUM_DEVICE_INTENSITY;
+    const hasTransient = hasAudioTransient &&
+      mixedTransient >= GamepadVibrationService.MINIMUM_DEVICE_INTENSITY;
 
     const builder = new vibrator.VibratorPatternBuilder();
     const audioFrequency = Math.round(
@@ -506,8 +524,8 @@ export class GamepadVibrationService {
         : 0;
       const gameActive = Math.max(lowIntensity, highIntensity) > 0;
       const leaseMs = gameActive
-        ? 500
-        : (this.audioDeviceScene === 1 ? 240 : 1000);
+        ? GamepadVibrationService.GAME_DEVICE_LEASE_MS
+        : this.getAudioContinuousLeaseMs(this.audioDeviceScene);
       builder.addContinuousEvent(startMs, leaseMs, {
         intensity: mixedContinuous,
         frequency: frequency,
@@ -543,11 +561,6 @@ export class GamepadVibrationService {
     const selected = hasAudioTransient
       ? Math.max(mixedTransient, mixedContinuous)
       : mixedContinuous;
-    if (selected < 5) {
-      if (this.isVibrating) this.stopVibrationImmediate();
-      return;
-    }
-
     let duration: number;
     if (hasAudioTransient) {
       const authored = Math.max(
@@ -555,9 +568,11 @@ export class GamepadVibrationService {
       duration = Math.max(
         15, Math.round(authored * (0.65 + selected / 285)));
     } else if (this.gameDeviceLow > 0 || this.gameDeviceHigh > 0) {
-      duration = 500;
+      duration = GamepadVibrationService.GAME_DEVICE_LEASE_MS;
     } else {
-      duration = this.audioDeviceScene === 1 ? 240 : 500;
+      duration = this.audioDeviceScene === GamepadVibrationService.MUSIC_SCENE
+        ? GamepadVibrationService.AUDIO_MUSIC_LEASE_MS
+        : GamepadVibrationService.AUDIO_GAME_FALLBACK_DURATION_MS;
     }
 
     vibrator.startVibration({
@@ -569,5 +584,11 @@ export class GamepadVibrationService {
     }).catch((err: Error): void => {
       console.warn(`[VIBRATION] 时长震动失败: ${err.message}`);
     });
+  }
+
+  private getAudioContinuousLeaseMs(scene: number): number {
+    return scene === GamepadVibrationService.MUSIC_SCENE
+      ? GamepadVibrationService.AUDIO_MUSIC_LEASE_MS
+      : GamepadVibrationService.AUDIO_GAME_LEASE_MS;
   }
 }

--- a/entry/src/main/ets/service/streaming/StreamingSession.ets
+++ b/entry/src/main/ets/service/streaming/StreamingSession.ets
@@ -656,6 +656,28 @@ export class StreamingSession {
     return this.config?.bitrate || 0;
   }
 
+  /**
+   * 热更新当前会话的音频振动设置。
+   *
+   * SDK 只接收场景创作配置；用户强度继续由平台渲染层统一缩放，
+   * 避免同时暴露 sensitivity 和输出增益两套旋钮。
+   */
+  updateAudioVibrationSettings(enabled: boolean, strength: number,
+    vibrationMode: string, sceneMode: string): void {
+    const normalizedStrength = Math.max(0, Math.min(100, Math.round(strength)));
+    if (this.config) {
+      this.config.enableAudioVibration = enabled;
+      this.config.audioVibrationStrength = normalizedStrength;
+      this.config.vibrationMode = vibrationMode;
+      this.config.audioVibrationSceneMode = sceneMode;
+    }
+
+    this.audioVibrationService.setSettings(
+      enabled, normalizedStrength, vibrationMode, sceneMode);
+    this.nativeModule.setAudioHapticsConfig(
+      enabled, 1.0, this.audioVibrationService.getSceneModeInt());
+  }
+
   // ---------------------------------------------------------------------------
   // 服务器控制
   // ---------------------------------------------------------------------------
@@ -1111,9 +1133,12 @@ export class StreamingSession {
 
   private applyPostConnectionSettings(config: StreamConfig): void {
     // 必须在 connectToServer() 之后，确保 SDK Core 已按实际 PCM 格式创建。
-    const sceneMode = this.audioVibrationService.getSceneModeInt();
-    this.nativeModule.setAudioHapticsConfig(
-      config.enableAudioVibration, 1.0, sceneMode);
+    this.updateAudioVibrationSettings(
+      config.enableAudioVibration,
+      config.audioVibrationStrength,
+      config.vibrationMode,
+      config.audioVibrationSceneMode
+    );
     if (config.enableAudioVibration) {
       console.info(`音频振动已启用, 强度=${config.audioVibrationStrength}, 模式=${config.vibrationMode}, 场景=${config.audioVibrationSceneMode}`);
     }

--- a/entry/src/main/ets/viewmodel/StreamViewModel.ets
+++ b/entry/src/main/ets/viewmodel/StreamViewModel.ets
@@ -523,6 +523,25 @@ export class StreamViewModel {
   getSession(): StreamingSession | null {
     return this.streamingSession;
   }
+
+  /**
+   * 更新当前串流的音频振动设置，持久化由调用方在交互结束时处理。
+   */
+  updateAudioVibrationSettings(enabled: boolean, strength: number,
+    sceneMode: string): void {
+    if (!this.streamConfig) return;
+
+    const normalizedStrength = Math.max(0, Math.min(100, Math.round(strength)));
+    this.streamConfig.enableAudioVibration = enabled;
+    this.streamConfig.audioVibrationStrength = normalizedStrength;
+    this.streamConfig.audioVibrationSceneMode = sceneMode;
+    this.streamingSession?.updateAudioVibrationSettings(
+      enabled,
+      normalizedStrength,
+      this.streamConfig.vibrationMode,
+      sceneMode
+    );
+  }
   
   /**
    * 将设置中的位置字符串转换为 SnapPosition


### PR DESCRIPTION
## 改了啥呀

- 在串流菜单新增“音频振动”功能卡，可直接启停功能。
- 支持即时切换“游戏”和“音乐”场景；ABI v1 中 `AUTO` 与游戏场景等价，因此不再给用户一个没有实际差异的选项。
- 支持 10%–100%、步进 5% 的强度调节：拖动时热更新当前会话，交互结束后才持久化，避免高频写入偏好设置。
- 将设备马达与 USB 手柄收敛为单一硬件写入点，游戏和音频分别保存来源状态，不再互相用 `stop` 清掉对方。
- 使用有界 headroom 混合：`game + audio × (1 - game)`，保留任一路单独输出并避免硬削顶；USB 低/高频马达分别计算，游戏语义通过独立来源状态和扳机独占保留。
- 保留音频连续振动租约，并为异步 HD Haptic 降级增加版本保护，避免过期音频或旧请求重新覆盖当前输出。
- 整理混合器状态：马达对改为具名字段，集中设备阈值与租约常量，并明确区分“音频来源活跃”和“执行器正在振动”。
- 继续保持职责边界：SDK 负责 DSP 与场景创作，HarmonyOS 渲染层负责用户强度、来源混合和设备路由。

## 为啥要改

之前音频振动只能在串流前进入设置页调整，听音乐或切换游戏内容时不方便对比。现在不用退出串流，就能立即感受到场景与强度变化啦。

原先游戏和音频两条链路会直接争用同一个马达，后写覆盖、游戏停止确认清掉音频、音频 stop 清掉游戏都可能发生。现在由平台振动服务统一输出，两路状态各管各的，也不会把强度做成一加就满的杂鱼混音。

功能卡沿用全局设置键，当前会话的修改也会成为下次串流的默认值；设备、手柄和同时输出等路由选项仍留在完整设置页。

## 验证

- `git diff --check`
- 头部空间混合边界：仅游戏、仅音频、50% + 50% = 75%、满幅不溢出
- `npm run check`
- DevEco/Hvigor `assembleApp --mode project -p product=default -p buildMode=debug --no-daemon --stacktrace`
- Debug HAP/App 编译、签名和打包成功