### PR TITLE
style(stream-menu): restore glass translucency

### DIFF
--- a/entry/src/main/ets/common/OverlayConstants.ets
+++ b/entry/src/main/ets/common/OverlayConstants.ets
@@ -52,6 +52,8 @@ export class StreamMenuColors {
   static readonly TextFaint = $r('app.color.stream_menu_text_faint');
   static readonly AccentBlue = $r('app.color.stream_menu_accent_blue');
   static readonly AccentPink = $r('app.color.stream_menu_accent_pink');
+  static readonly AccentBlueText = $r('app.color.stream_menu_accent_blue_text');
+  static readonly AccentPinkText = $r('app.color.stream_menu_accent_pink_text');
   static readonly AccentGold = $r('app.color.stream_menu_accent_gold');
   static readonly BlueSurface = $r('app.color.stream_menu_blue_surface');
   static readonly BlueBorder = $r('app.color.stream_menu_blue_border');

--- a/entry/src/main/ets/common/OverlayConstants.ets
+++ b/entry/src/main/ets/common/OverlayConstants.ets
@@ -63,7 +63,6 @@ export class StreamMenuColors {
   static readonly OnAccent = $r('app.color.stream_menu_on_accent');
   static readonly Success = $r('app.color.stream_menu_success');
   static readonly SuccessSurface = $r('app.color.stream_menu_success_surface');
-  static readonly OnPastel = $r('app.color.stream_menu_on_pastel');
 }
 
 /** 覆盖层背景色 */

--- a/entry/src/main/ets/components/dialogs/GameMenuDialog.ets
+++ b/entry/src/main/ets/components/dialogs/GameMenuDialog.ets
@@ -921,9 +921,7 @@ export struct GameMenuDialog {
     .width(OV_CARD_WIDTH)
     .height(36)
     .padding({ left: 14, right: 14 })
-    .borderRadius(OV_CARD_RADIUS)
-    .backgroundColor(StreamMenuColors.Surface)
-    .border({ width: 1, color: StreamMenuColors.Border })
+    .cardStyle()
     .alignItems(VerticalAlign.Center)
     .onClick(() => {
       animateTo({ duration: 200, curve: Curve.EaseInOut }, () => {
@@ -1001,7 +999,7 @@ export struct GameMenuDialog {
         Text('编辑布局')
           .fontSize(12)
           .fontWeight(FontWeight.Medium)
-          .fontColor(StreamMenuColors.AccentPink)
+          .fontColor(StreamMenuColors.AccentPinkText)
           .padding({ left: 14, right: 14, top: 7, bottom: 7 })
           .borderRadius(14)
           .backgroundColor(StreamMenuColors.PinkSurface)
@@ -1013,7 +1011,7 @@ export struct GameMenuDialog {
         Text('导出')
           .fontSize(12)
           .fontWeight(FontWeight.Medium)
-          .fontColor(StreamMenuColors.AccentBlue)
+          .fontColor(StreamMenuColors.AccentBlueText)
           .padding({ left: 14, right: 14, top: 7, bottom: 7 })
           .borderRadius(14)
           .backgroundColor(StreamMenuColors.BlueSurface)
@@ -1025,7 +1023,7 @@ export struct GameMenuDialog {
         Text('导入')
           .fontSize(12)
           .fontWeight(FontWeight.Medium)
-          .fontColor(StreamMenuColors.AccentBlue)
+          .fontColor(StreamMenuColors.AccentBlueText)
           .padding({ left: 14, right: 14, top: 7, bottom: 7 })
           .borderRadius(14)
           .backgroundColor(StreamMenuColors.BlueSurface)
@@ -1052,7 +1050,7 @@ export struct GameMenuDialog {
         if (this.isPanZoomActive) {
           Text('重置')
             .fontSize(11)
-            .fontColor(StreamMenuColors.AccentBlue)
+            .fontColor(StreamMenuColors.AccentBlueText)
             .fontWeight(FontWeight.Medium)
             .padding({ left: 10, right: 10, top: 4, bottom: 4 })
             .borderRadius(10)
@@ -1154,7 +1152,7 @@ export struct GameMenuDialog {
             Blank()
             Text(`${Math.round(this.controllerOpacityLocal * 100)}%`)
               .fontSize(OV_FONT_MD)
-              .fontColor(StreamMenuColors.AccentBlue)
+              .fontColor(StreamMenuColors.AccentBlueText)
               .fontWeight(FontWeight.Medium)
           }
           .width('100%')
@@ -1199,7 +1197,7 @@ export struct GameMenuDialog {
             Blank()
             Text(`${Math.round(this.controllerScaleLocal * 100)}%`)
               .fontSize(OV_FONT_MD)
-              .fontColor(StreamMenuColors.AccentBlue)
+              .fontColor(StreamMenuColors.AccentBlueText)
               .fontWeight(FontWeight.Medium)
           }
           .width('100%')
@@ -1306,7 +1304,7 @@ export struct GameMenuDialog {
             Blank()
             Text(`${this.audioVibrationStrength}%`)
               .fontSize(OV_FONT_MD)
-              .fontColor(StreamMenuColors.AccentPink)
+              .fontColor(StreamMenuColors.AccentPinkText)
               .fontWeight(FontWeight.Medium)
           }
           .width('100%')
@@ -1399,7 +1397,7 @@ export struct GameMenuDialog {
         Blank()
         Text(this.formatBitrate(this.currentBitrate))
           .fontSize(12)
-          .fontColor(StreamMenuColors.AccentPink)
+          .fontColor(StreamMenuColors.AccentPinkText)
           .fontWeight(FontWeight.Medium)
       }
       .width('100%')
@@ -1470,7 +1468,7 @@ export struct GameMenuDialog {
             Blank()
             Text(this.isAdjustingBitrate ? '调整中...' : this.formatBitrate(this.sliderValueToBitrate(this.bitrateSliderValue)))
               .fontSize(OV_FONT_MD)
-              .fontColor(this.isAdjustingBitrate ? StreamMenuColors.TextDim : StreamMenuColors.AccentPink)
+              .fontColor(this.isAdjustingBitrate ? StreamMenuColors.TextDim : StreamMenuColors.AccentPinkText)
               .fontWeight(FontWeight.Bold)
             Blank()
             Text('200').fontSize(OV_FONT_SM).fontColor(StreamMenuColors.TextDim)
@@ -1517,7 +1515,7 @@ export struct GameMenuDialog {
 
       Text(this.hasGyroscope ? '陀螺仪 → 右摇杆映射' : '⚠ 设备无陀螺仪')
         .fontSize(OV_FONT_SM)
-        .fontColor(this.hasGyroscope ? StreamMenuColors.TextFaint : StreamMenuColors.AccentPink)
+        .fontColor(this.hasGyroscope ? StreamMenuColors.TextFaint : StreamMenuColors.AccentPinkText)
         .width('100%')
         .padding({ left: 16, right: 16, bottom: this.gyroEnabled ? 8 : 14 })
 
@@ -1530,7 +1528,7 @@ export struct GameMenuDialog {
             Blank()
             Text(`${this.gyroSensitivity.toFixed(1)}x`)
               .fontSize(OV_FONT_MD)
-              .fontColor(StreamMenuColors.AccentBlue)
+              .fontColor(StreamMenuColors.AccentBlueText)
               .fontWeight(FontWeight.Medium)
           }
           .width('100%')

--- a/entry/src/main/ets/components/dialogs/GameMenuDialog.ets
+++ b/entry/src/main/ets/components/dialogs/GameMenuDialog.ets
@@ -65,6 +65,7 @@ interface MenuItem {
   label: string;
   bgColor: string;
   borderColor: string;
+  textColor: string;
 }
 
 /** 触摸模式选项 */
@@ -103,13 +104,13 @@ const CARD_USAGE_KEY = 'game_menu_card_usage';
 
 // 马卡龙色系菜单配置
 const MENU_ITEMS: MenuItem[] = [
-  { icon: '✦', label: 'HDR', bgColor: '#F7EBC7', borderColor: '#D0A850' },
-  { icon: '◎', label: 'USB驱动', bgColor: '#F7D1D1', borderColor: '#D87070' },
-  { icon: '⌨', label: '键盘', bgColor: '#C7F7E0', borderColor: '#50C080' },
-  { icon: '☝', label: '触控', bgColor: '#E0D4F7', borderColor: '#9080C0' },
-  { icon: '🎮', label: '手柄', bgColor: '#D4E8F7', borderColor: '#6098C0' },
-  { icon: '🖱', label: '鼠标', bgColor: '#F7E0C7', borderColor: '#C08050' },
-  { icon: '✕', label: '退出', bgColor: '#F7CFCF', borderColor: '#D06060' }
+  { icon: '✦', label: 'HDR', bgColor: '#F7EBC7', borderColor: '#D0A850', textColor: '#7B632F' },
+  { icon: '◎', label: 'USB驱动', bgColor: '#F7D1D1', borderColor: '#D87070', textColor: '#8A4848' },
+  { icon: '⌨', label: '键盘', bgColor: '#C7F7E0', borderColor: '#50C080', textColor: '#30734D' },
+  { icon: '☝', label: '触控', bgColor: '#E0D4F7', borderColor: '#9080C0', textColor: '#5F547F' },
+  { icon: '🎮', label: '手柄', bgColor: '#D4E8F7', borderColor: '#6098C0', textColor: '#406681' },
+  { icon: '🖱', label: '鼠标', bgColor: '#F7E0C7', borderColor: '#C08050', textColor: '#835736' },
+  { icon: '✕', label: '退出', bgColor: '#F7CFCF', borderColor: '#D06060', textColor: '#904242' }
 ];
 
 const MENU_OFFSETS: number[] = [25, 55, 70, 35, 45, 30, 50];
@@ -117,6 +118,7 @@ const MENU_OFFSETS: number[] = [25, 55, 70, 35, 45, 30, 50];
 // 激活色
 const ACTIVE_BG_COLOR = '#C7F7D4';
 const ACTIVE_BORDER_COLOR = '#50A860';
+const ACTIVE_TEXT_COLOR = '#367241';
 
 @CustomDialog
 export struct GameMenuDialog {
@@ -564,6 +566,13 @@ export struct GameMenuDialog {
       return ACTIVE_BORDER_COLOR;
     }
     return MENU_ITEMS[index].borderColor;
+  }
+
+  private getMenuTextColor(index: number): string {
+    if ((index === 1 && this.isUsbDriverMode) || (index === 5 && this.isMouseEmulationActive)) {
+      return ACTIVE_TEXT_COLOR;
+    }
+    return MENU_ITEMS[index].textColor;
   }
 
   private async loadGyroSettings(): Promise<void> {
@@ -1734,7 +1743,7 @@ export struct GameMenuDialog {
         Text(this.getMenuLabel(index))
           .fontSize(12)
           .fontWeight(FontWeight.Bold)
-          .fontColor(StreamMenuColors.OnPastel)
+          .fontColor(this.getMenuTextColor(index))
       }
       .width(75)
       .height(36)
@@ -1758,7 +1767,6 @@ export struct GameMenuDialog {
     }
     .height(40)
     .padding(2)
-    .shadow({ radius: 6, color: StreamMenuColors.Shadow, offsetY: 2 })
     .scale({ x: this.scales[index], y: this.scales[index] })
     .translate({ x: this.positions[index] })
     .margin({ right: MENU_OFFSETS[index], bottom: 4 })

--- a/entry/src/main/resources/base/element/color.json
+++ b/entry/src/main/resources/base/element/color.json
@@ -118,7 +118,7 @@
     },
     {
       "name": "stream_menu_surface",
-      "value": "#EAF7F9FC"
+      "value": "#C0F7F9FC"
     },
     {
       "name": "stream_menu_control",
@@ -146,15 +146,15 @@
     },
     {
       "name": "stream_menu_text_medium",
-      "value": "#E03B4852"
+      "value": "#F52E3A44"
     },
     {
       "name": "stream_menu_text_dim",
-      "value": "#ED48545E"
+      "value": "#F535424C"
     },
     {
       "name": "stream_menu_text_faint",
-      "value": "#E044505A"
+      "value": "#E02E3A44"
     },
     {
       "name": "stream_menu_accent_blue",
@@ -163,6 +163,14 @@
     {
       "name": "stream_menu_accent_pink",
       "value": "#9C294B"
+    },
+    {
+      "name": "stream_menu_accent_blue_text",
+      "value": "#0E436C"
+    },
+    {
+      "name": "stream_menu_accent_pink_text",
+      "value": "#741A34"
     },
     {
       "name": "stream_menu_accent_gold",

--- a/entry/src/main/resources/base/element/color.json
+++ b/entry/src/main/resources/base/element/color.json
@@ -207,10 +207,6 @@
     {
       "name": "stream_menu_success_surface",
       "value": "#14126638"
-    },
-    {
-      "name": "stream_menu_on_pastel",
-      "value": "#E61A1E24"
     }
   ]
 }

--- a/entry/src/main/resources/dark/element/color.json
+++ b/entry/src/main/resources/dark/element/color.json
@@ -207,10 +207,6 @@
     {
       "name": "stream_menu_success_surface",
       "value": "#40202F27"
-    },
-    {
-      "name": "stream_menu_on_pastel",
-      "value": "#E61A1E24"
     }
   ]
 }

--- a/entry/src/main/resources/dark/element/color.json
+++ b/entry/src/main/resources/dark/element/color.json
@@ -118,7 +118,7 @@
     },
     {
       "name": "stream_menu_surface",
-      "value": "#B31A1E24"
+      "value": "#A61A1E24"
     },
     {
       "name": "stream_menu_control",
@@ -150,11 +150,11 @@
     },
     {
       "name": "stream_menu_text_dim",
-      "value": "#C8FFFFFF"
+      "value": "#D0FFFFFF"
     },
     {
       "name": "stream_menu_text_faint",
-      "value": "#C0FFFFFF"
+      "value": "#C8FFFFFF"
     },
     {
       "name": "stream_menu_accent_blue",
@@ -162,6 +162,14 @@
     },
     {
       "name": "stream_menu_accent_pink",
+      "value": "#FFD0D9"
+    },
+    {
+      "name": "stream_menu_accent_blue_text",
+      "value": "#BCE5F0"
+    },
+    {
+      "name": "stream_menu_accent_pink_text",
       "value": "#FFD0D9"
     },
     {


### PR DESCRIPTION
## 改了啥呀

- 将浅色菜单表面不透明度从约 92% 调整为 75%，深色从约 70% 调整为 65%，让现有 20vp backdrop blur 真正透出来
- 让“更多设置”折叠条复用统一 cardStyle，补齐模糊、边框和阴影层次
- 拆分控件强调色与强调文字色，并收紧四级正文颜色，浅色/深色主题继续由资源自动切换
- 恢复右侧袜子菜单各自的金、红、绿、紫、蓝、棕色标签，并使用同色深阶保证小字号可读性
- 移除袜子最外层新增的矩形 shadow，避免圆润袜子外出现方形边框阴影

## 为啥要改

之前高不透明表面把毛玻璃几乎完全盖住了，看起来更像实色卡片。这个杂鱼状态收拾掉啦：现在通过透明度恢复玻璃感，不把主卡片 blur 拉回 40，避免在持续刷新的串流画面上增加多层实时模糊成本。

袜子菜单继续保留原本的分色识别，不再统一成单一深色；文字色与对应马卡龙背景的最低对比度为 4.81:1。新增在无圆角外层上的 shadow 会按矩形边界绘制，现已撤销。

## 验证

- npm run check
- JAVA_HOME=/Users/mac/ohos-sdk-cache/jdk17-temurin/Home DEVECO_SDK_HOME=/Users/mac/ohos-sdk-cache/6.1-Release-mac/sdk-ci-shape /Users/mac/.nvm/versions/node/v20.20.1/bin/node hvigorw.js assembleHap --mode module -p module=entry@default -p product=default --no-daemon
- git diff --check origin/master...HEAD
- 主菜单极端背景与强调文字对比度计算：最低 4.60:1
- 袜子标签与马卡龙背景对比度计算：4.81–4.88:1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **样式优化**
  * 优化串流菜单的底色与文字层级透明度，浅色与深色主题均已同步更新。
  * 新增蓝色/粉色强调文字配色，并将相关菜单按钮与数值显示统一到对应强调色。
  * 菜单按钮的文字颜色支持按激活状态动态切换，提升交互可读性。
  * “更多设置”区域改用统一卡片样式，相关按钮卡片阴影样式一并移除。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->