### PR TITLE
fix(haptics): expire stale audio output

### DIFF
--- a/entry/src/main/ets/service/AudioVibrationService.ets
+++ b/entry/src/main/ets/service/AudioVibrationService.ets
@@ -29,6 +29,8 @@ export class AudioVibrationService {
   private static readonly CONTINUOUS_MINIMUM_INTERVAL_MS: number = 100;
   private static readonly CONTINUOUS_AMPLITUDE_HYSTERESIS: number = 8;
   private static readonly MAXIMUM_PRESENTATION_DELAY_MS: number = 300;
+  // Safety bound for platforms or controllers that keep the last vibration until explicitly cleared.
+  private static readonly CONTINUOUS_OUTPUT_WATCHDOG_MS: number = 1200;
   private static readonly DEFAULT_ONSET_SENSITIVITY: number = 1.0;
   private static readonly MUSIC_ONSET_SENSITIVITY: number = 2.5;
 
@@ -48,6 +50,8 @@ export class AudioVibrationService {
   private lastContinuousSubmitTimeMs: number = 0;
   private renderEpoch: number = 0;
   private usbEffectEpoch: number = 0;
+  private continuousOutputWatchdogTimer: number = -1;
+  private continuousOutputWatchdogEpoch: number = 0;
 
   setSettings(enabled: boolean, strength: number, vibrationMode: string,
     sceneMode: string = '游戏/电影'): void {
@@ -211,6 +215,11 @@ export class AudioVibrationService {
     } else if (this.isUsbSourceActive) {
       this.stopUsbRumble();
     }
+
+    if (continuous >= AudioVibrationService.MINIMUM_INTENSITY &&
+        (this.isDeviceSourceActive || this.isUsbSourceActive)) {
+      this.armContinuousOutputWatchdog();
+    }
   }
 
   private toIntensity(amplitude: number): number {
@@ -342,7 +351,31 @@ export class AudioVibrationService {
     this.isUsbSourceActive = true;
   }
 
+  private armContinuousOutputWatchdog(): void {
+    const watchdogEpoch = ++this.continuousOutputWatchdogEpoch;
+    if (this.continuousOutputWatchdogTimer !== -1) {
+      clearTimeout(this.continuousOutputWatchdogTimer);
+    }
+    this.continuousOutputWatchdogTimer = setTimeout((): void => {
+      if (!this.enabled ||
+          watchdogEpoch !== this.continuousOutputWatchdogEpoch) {
+        return;
+      }
+      this.continuousOutputWatchdogTimer = -1;
+      this.stopAll();
+    }, AudioVibrationService.CONTINUOUS_OUTPUT_WATCHDOG_MS);
+  }
+
+  private cancelContinuousOutputWatchdog(): void {
+    this.continuousOutputWatchdogEpoch++;
+    if (this.continuousOutputWatchdogTimer !== -1) {
+      clearTimeout(this.continuousOutputWatchdogTimer);
+      this.continuousOutputWatchdogTimer = -1;
+    }
+  }
+
   private stopAll(): void {
+    this.cancelContinuousOutputWatchdog();
     this.usbEffectEpoch++;
     if (this.isDeviceSourceActive) this.stopDeviceVibration();
     if (this.isUsbSourceActive) this.stopUsbRumble();

--- a/entry/src/main/ets/service/AudioVibrationService.ets
+++ b/entry/src/main/ets/service/AudioVibrationService.ets
@@ -155,6 +155,11 @@ export class AudioVibrationService {
       return;
     }
 
+    if (continuous >= AudioVibrationService.MINIMUM_INTENSITY &&
+        (this.isDeviceSourceActive || this.isUsbSourceActive)) {
+      this.armContinuousOutputWatchdog();
+    }
+
     const now = Date.now();
     if (!hasTransient) {
       // Do not let a continuous refresh replace a beat that is still being


### PR DESCRIPTION
## 改了啥呀

- 为连续音频振动增加 1200 ms 输出安全 watchdog，每次有效输出都会重新续租
- 到期后统一清理机身与 USB 手柄的音频振动来源
- 使用 epoch 隔离旧定时器，避免旧 watchdog 误停新一轮振动
- 只清理音频来源，游戏本身的 rumble 继续参与混合，不会被顺手停掉

## 为啥要改

游戏模式静音或信号中断时，USB 手柄可能一直保持最后一次电机值，部分机身马达也可能没有按预期自然结束；此前只能等下一帧信号触发重算。现在给这种赖着不走的杂鱼残留状态加一道输出层兜底，不改 SDK 节拍、强度或场景算法。

## 验证

- `npm run check`
- `node hvigorw.js assembleHap --mode module -p module=entry@default -p product=default --no-daemon`
- HAP 构建成功；现有 ArkTS 警告不涉及本次修改

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **问题修复**
  - 增加持续振动输出保护机制，在设备或 USB 振动未按预期停止时自动清理，避免振动持续输出。
  - 停止所有振动时同步取消相关保护计时，防止延迟操作重复触发。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->