### PR TITLE
feat(video): detect HDR Vivid metadata in performance overlay

### DIFF
--- a/entry/src/main/ets/components/PerformanceOverlay.ets
+++ b/entry/src/main/ets/components/PerformanceOverlay.ets
@@ -59,6 +59,7 @@ export struct PerformanceOverlay {
   @State perfNetworkLatency: number = 0;
   @State perfHostLatency: number = 0;
   @State perfPacketLoss: number = 0;
+  @State perfHdrVivid: boolean = false;
   @State perfBatteryLevel: number = 100;
   @State perfIsCharging: boolean = false;
   @State perfUpscaleMode: number = 0;
@@ -222,6 +223,7 @@ export struct PerformanceOverlay {
       this.perfNetworkLatency = stats.networkLatency;
       this.perfHostLatency = stats.hostLatency;
       this.perfPacketLoss = stats.packetLoss;
+      this.perfHdrVivid = stats.hdrVivid;
 
       // 🎃 愚人节彩蛋：负延迟串流™
       if (isAprilFools()) {
@@ -551,7 +553,8 @@ export struct PerformanceOverlay {
     // 解码器行
     if (this.enabledItemsList.includes(PerformanceItem.DECODER)) {
       Row() {
-        Text(getDecoderString(this.viewModel.actualCodec || 'HEVC', this.viewModel.actualHdr))
+        Text(getDecoderString(this.viewModel.actualCodec || 'HEVC', this.viewModel.actualHdr,
+          this.viewModel.streamConfig?.hdrMode || 0, this.perfHdrVivid))
           .fontSize(12)
           .fontWeight(FontWeight.Bold)
           .fontColor('#FFFFFF')
@@ -696,7 +699,8 @@ export struct PerformanceOverlay {
       
       // 解码器
       if (this.enabledItemsList.includes(PerformanceItem.DECODER)) {
-        Text(getDecoderString(this.viewModel.actualCodec || 'HEVC', this.viewModel.actualHdr))
+        Text(getDecoderString(this.viewModel.actualCodec || 'HEVC', this.viewModel.actualHdr,
+          this.viewModel.streamConfig?.hdrMode || 0, this.perfHdrVivid))
           .fontSize(11)
           .fontWeight(FontWeight.Bold)
           .fontColor('#FFFFFF')

--- a/entry/src/main/ets/components/PerformanceOverlayManager.ets
+++ b/entry/src/main/ets/components/PerformanceOverlayManager.ets
@@ -246,7 +246,8 @@ export function formatDataRate(bps: number): string {
 /**
  * 获取解码器显示字符串
  */
-export function getDecoderString(codec: string, isHdr: boolean): string {
+export function getDecoderString(codec: string, isHdr: boolean,
+  hdrMode: number, hdrVivid: boolean): string {
   let result = codec.toUpperCase();
   if (result.includes('HEVC') || result.includes('H265')) {
     result = 'HEVC';
@@ -256,7 +257,13 @@ export function getDecoderString(codec: string, isHdr: boolean): string {
     result = 'AV1';
   }
   if (isHdr) {
-    result += ' HDR';
+    if (hdrVivid) {
+      result += ' HDR Vivid';
+    } else if (hdrMode === 2) {
+      result += ' HDR HLG';
+    } else {
+      result += ' HDR PQ';
+    }
   }
   return result;
 }

--- a/entry/src/main/ets/service/streaming/StreamingSession.ets
+++ b/entry/src/main/ets/service/streaming/StreamingSession.ets
@@ -66,6 +66,7 @@ export interface StreamStats {
   decodedFrames: number;
   codecOutputFrames: number;
   droppedFrames: number;
+  hdrVivid: boolean;       // 码流中检测到 CUVA HDR Vivid 动态元数据
   framesLost: number;
   totalFrames: number;
   globalAvgDecodeLatency: number;  // 全局平均解码延迟 ms
@@ -234,6 +235,7 @@ interface VideoStats {
   totalHostLatencyMs: number;
   framesWithHostLatency: number;
   globalAvgFps: number;
+  hdrVivid: boolean;
   // 网络丢帧统计
   framesLost: number;
   totalFrames: number;
@@ -439,6 +441,7 @@ export class StreamingSession {
     fps: 0, codecOutputFps: 0, renderedFps: 0, bitrate: 0, latency: 0,
     hostLatency: 0, networkLatency: 0, packetLoss: 0,
     decodedFrames: 0, codecOutputFrames: 0, droppedFrames: 0,
+    hdrVivid: false,
     framesLost: 0, totalFrames: 0,
     globalAvgDecodeLatency: 0, globalAvgHostLatency: 0, globalAvgFps: 0,
     droppedByL1: 0, droppedByL2: 0, droppedByL3: 0, droppedByL4: 0, droppedByL5: 0,
@@ -905,6 +908,7 @@ export class StreamingSession {
       this.stats.decodedFrames = vs.framesDecoded;
       this.stats.codecOutputFrames = vs.codecOutputFrames || 0;
       this.stats.droppedFrames = vs.framesDropped;
+      this.stats.hdrVivid = vs.hdrVivid || false;
       this.stats.fps = vs.fps || 0;
       this.stats.codecOutputFps = vs.codecOutputFps || 0;
       this.stats.renderedFps = vs.renderedFps || 0;
@@ -992,6 +996,7 @@ export class StreamingSession {
       decodedFrames: this.stats.decodedFrames,
       codecOutputFrames: this.stats.codecOutputFrames,
       droppedFrames: this.stats.droppedFrames,
+      hdrVivid: this.stats.hdrVivid,
       framesLost: this.stats.framesLost,
       totalFrames: this.stats.totalFrames,
       globalAvgDecodeLatency: this.stats.globalAvgDecodeLatency,

--- a/nativelib/src/main/cpp/CMakeLists.txt
+++ b/nativelib/src/main/cpp/CMakeLists.txt
@@ -88,6 +88,7 @@ set(SOURCE_FILES
     audio_haptics_engine.cpp
     opus_libopus.cpp
     opus_encoder.cpp
+    hdr_vivid_metadata_scanner.cpp
     video_decoder.cpp
     audio_renderer.cpp
     mic_capturer.cpp

--- a/nativelib/src/main/cpp/hdr_vivid_metadata_scanner.cpp
+++ b/nativelib/src/main/cpp/hdr_vivid_metadata_scanner.cpp
@@ -1,0 +1,199 @@
+/*
+ * Moonlight for HarmonyOS
+ * Copyright (C) 2024-2025 Moonlight/AlkaidLab
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#include "hdr_vivid_metadata_scanner.h"
+
+#include <limits>
+
+namespace {
+
+constexpr uint8_t kHevcPrefixSeiNalType = 39;
+constexpr uint8_t kHevcSuffixSeiNalType = 40;
+constexpr uint32_t kRegisteredT35PayloadType = 4;
+
+// CUVA 005.1 HDR Vivid identifier in user_data_registered_itu_t_t35.
+constexpr uint8_t kCuvaCountryCode = 0x26;
+constexpr uint16_t kCuvaTerminalProviderCode = 0x0004;
+constexpr uint16_t kCuvaProviderOrientedCode = 0x0005;
+
+class RbspByteReader {
+public:
+    RbspByteReader(const uint8_t* data, size_t size)
+        : data_(data), size_(size) {}
+
+    bool Read(uint8_t& value) {
+        while (offset_ < size_) {
+            const uint8_t current = data_[offset_++];
+            if (!justSkippedPreventionByte_ && zeroCount_ >= 2 && current == 0x03) {
+                justSkippedPreventionByte_ = true;
+                continue;
+            }
+
+            justSkippedPreventionByte_ = false;
+            value = current;
+            if (current == 0x00) {
+                zeroCount_++;
+            } else {
+                zeroCount_ = 0;
+            }
+            return true;
+        }
+        return false;
+    }
+
+private:
+    const uint8_t* data_;
+    size_t size_;
+    size_t offset_ = 0;
+    int zeroCount_ = 0;
+    bool justSkippedPreventionByte_ = false;
+};
+
+bool ReadSeiValue(RbspByteReader& reader, uint32_t& value) {
+    value = 0;
+    uint8_t current = 0;
+    do {
+        if (!reader.Read(current) ||
+            value > std::numeric_limits<uint32_t>::max() - current) {
+            return false;
+        }
+        value += current;
+    } while (current == 0xFF);
+    return true;
+}
+
+} // namespace
+
+bool HdrVividMetadataScanner::Scan(const uint8_t* data, size_t size) {
+    if (detected_ || data == nullptr) {
+        return detected_;
+    }
+
+    for (size_t index = 0; index < size; ++index) {
+        const uint8_t current = data[index];
+        if (!inNal_) {
+            if (current == 0x00) {
+                pendingZeroCount_++;
+            } else if (current == 0x01 && pendingZeroCount_ >= 2) {
+                StartNal();
+            } else {
+                pendingZeroCount_ = 0;
+            }
+            continue;
+        }
+
+        if (current == 0x00) {
+            pendingZeroCount_++;
+            continue;
+        }
+
+        if (current == 0x01 && pendingZeroCount_ >= 2) {
+            if (FinishNal()) {
+                detected_ = true;
+                return true;
+            }
+            StartNal();
+            continue;
+        }
+
+        while (pendingZeroCount_ > 0) {
+            AppendNalByte(0x00);
+            pendingZeroCount_--;
+        }
+        AppendNalByte(current);
+    }
+
+    return detected_;
+}
+
+bool HdrVividMetadataScanner::Finish() {
+    if (!detected_ && inNal_ && FinishNal()) {
+        detected_ = true;
+    }
+    inNal_ = false;
+    pendingZeroCount_ = 0;
+    return detected_;
+}
+
+void HdrVividMetadataScanner::StartNal() {
+    inNal_ = true;
+    pendingZeroCount_ = 0;
+    seiNalSize_ = 0;
+    nalByteCount_ = 0;
+    captureNal_ = false;
+    nalOverflow_ = false;
+}
+
+void HdrVividMetadataScanner::AppendNalByte(uint8_t value) {
+    if (nalByteCount_ == 0) {
+        const uint8_t nalType = static_cast<uint8_t>((value >> 1) & 0x3F);
+        captureNal_ = nalType == kHevcPrefixSeiNalType ||
+                      nalType == kHevcSuffixSeiNalType;
+    }
+    nalByteCount_++;
+
+    if (!captureNal_ || nalOverflow_) {
+        return;
+    }
+    if (seiNalSize_ >= seiNal_.size()) {
+        nalOverflow_ = true;
+        return;
+    }
+    seiNal_[seiNalSize_++] = value;
+}
+
+bool HdrVividMetadataScanner::FinishNal() {
+    if (!captureNal_ || nalOverflow_) {
+        return false;
+    }
+    return ContainsCuvaT35Payload(seiNal_.data(), seiNalSize_);
+}
+
+bool HdrVividMetadataScanner::ContainsCuvaT35Payload(
+        const uint8_t* nalData, size_t nalSize) {
+    if (nalSize <= 2) {
+        return false;
+    }
+
+    RbspByteReader reader(nalData + 2, nalSize - 2);
+    while (true) {
+        uint32_t payloadType = 0;
+        uint32_t payloadSize = 0;
+        if (!ReadSeiValue(reader, payloadType) ||
+            !ReadSeiValue(reader, payloadSize)) {
+            return false;
+        }
+
+        bool isCuvaPayload = payloadType == kRegisteredT35PayloadType &&
+                             payloadSize >= 5;
+        uint8_t identifier[5] = {};
+        for (uint32_t index = 0; index < payloadSize; ++index) {
+            uint8_t value = 0;
+            if (!reader.Read(value)) {
+                return false;
+            }
+            if (index < sizeof(identifier)) {
+                identifier[index] = value;
+            }
+        }
+
+        if (isCuvaPayload) {
+            const uint16_t terminalProviderCode =
+                static_cast<uint16_t>(identifier[1] << 8) | identifier[2];
+            const uint16_t providerOrientedCode =
+                static_cast<uint16_t>(identifier[3] << 8) | identifier[4];
+            if (identifier[0] == kCuvaCountryCode &&
+                terminalProviderCode == kCuvaTerminalProviderCode &&
+                providerOrientedCode == kCuvaProviderOrientedCode) {
+                return true;
+            }
+        }
+    }
+}

--- a/nativelib/src/main/cpp/hdr_vivid_metadata_scanner.h
+++ b/nativelib/src/main/cpp/hdr_vivid_metadata_scanner.h
@@ -1,0 +1,45 @@
+/*
+ * Moonlight for HarmonyOS
+ * Copyright (C) 2024-2025 Moonlight/AlkaidLab
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#ifndef HDR_VIVID_METADATA_SCANNER_H
+#define HDR_VIVID_METADATA_SCANNER_H
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+/**
+ * Incrementally scans an HEVC Annex-B decode unit for HDR Vivid/CUVA SEI.
+ * One scanner can consume multiple scatter-gather segments in order.
+ */
+class HdrVividMetadataScanner {
+public:
+    bool Scan(const uint8_t* data, size_t size);
+    bool Finish();
+
+private:
+    static constexpr size_t kMaxSeiNalSize = 8192;
+
+    void StartNal();
+    void AppendNalByte(uint8_t value);
+    bool FinishNal();
+    static bool ContainsCuvaT35Payload(const uint8_t* nalData, size_t nalSize);
+
+    std::array<uint8_t, kMaxSeiNalSize> seiNal_{};
+    size_t seiNalSize_ = 0;
+    size_t nalByteCount_ = 0;
+    size_t pendingZeroCount_ = 0;
+    bool inNal_ = false;
+    bool captureNal_ = false;
+    bool nalOverflow_ = false;
+    bool detected_ = false;
+};
+
+#endif // HDR_VIVID_METADATA_SCANNER_H

--- a/nativelib/src/main/cpp/moonlight_bridge.cpp
+++ b/nativelib/src/main/cpp/moonlight_bridge.cpp
@@ -1768,6 +1768,7 @@ napi_value MoonBridge_GetVideoStats(napi_env env, napi_callback_info info) {
     setCounter("syncDrainFrames", stats.syncDrainFrames);
     setBoolean("syncDecode", stats.syncDecode);
     setBoolean("hostPacedPresentationActive", stats.hostPacedPresentationActive);
+    setBoolean("hdrVivid", stats.hdrVivid);
     setCounter("presentationPrepared", stats.presentation.preparedTargets);
     setCounter("presentationScheduled", stats.presentation.scheduledFrames);
     setCounter("presentationExpired", stats.presentation.expiredTargets);

--- a/nativelib/src/main/cpp/video_decoder.cpp
+++ b/nativelib/src/main/cpp/video_decoder.cpp
@@ -479,6 +479,10 @@ int VideoDecoder::Init(const VideoDecoderConfig& config, OHNativeWindow* window)
     
     config_ = config;
     hdrVividProbeDecodeUnits_.store(0, std::memory_order_relaxed);
+    hdrVividProbeActive_.store(
+        config.codec == VideoCodecType::HEVC && config.enableHdr &&
+        config.hdrType == HdrType::HLG,
+        std::memory_order_relaxed);
     hdrVividDetected_.store(false, std::memory_order_relaxed);
     window_ = window;
     render_ = NativeRender::GetInstance();
@@ -1036,6 +1040,7 @@ void VideoDecoder::Cleanup() {
     lastAsyncOutputTimeMs_ = 0;
     consecutiveCriticalPipelineFrames_ = 0;
     hdrVividProbeDecodeUnits_.store(0, std::memory_order_relaxed);
+    hdrVividProbeActive_.store(false, std::memory_order_relaxed);
     hdrVividDetected_.store(false, std::memory_order_relaxed);
     
     OH_LOG_INFO(LOG_APP, "Video decoder cleaned up");
@@ -1138,12 +1143,13 @@ int VideoDecoder::SubmitDecodeUnitScatter(const BufferSegment* segments, int seg
     // 首次调用时设置线程优先级 + 绑定大核
     SetupDecodeThreadPriority();
 
-    if (config_.codec == VideoCodecType::HEVC && config_.enableHdr &&
-        config_.hdrType == HdrType::HLG &&
-        !hdrVividDetected_.load(std::memory_order_relaxed)) {
+    if (hdrVividProbeActive_.load(std::memory_order_relaxed)) {
         const uint32_t probeIndex = hdrVividProbeDecodeUnits_.fetch_add(
             1, std::memory_order_relaxed);
         if (probeIndex < kHdrVividProbeDecodeUnits) {
+            if (probeIndex + 1 == kHdrVividProbeDecodeUnits) {
+                hdrVividProbeActive_.store(false, std::memory_order_relaxed);
+            }
             HdrVividMetadataScanner scanner;
             for (int index = 0; index < segmentCount; ++index) {
                 if (scanner.Scan(segments[index].data,
@@ -1153,9 +1159,12 @@ int VideoDecoder::SubmitDecodeUnitScatter(const BufferSegment* segments, int seg
             }
             if (scanner.Finish()) {
                 hdrVividDetected_.store(true, std::memory_order_relaxed);
+                hdrVividProbeActive_.store(false, std::memory_order_relaxed);
                 OH_LOG_INFO(LOG_APP,
                             "HDR Vivid CUVA dynamic metadata detected in HEVC SEI");
             }
+        } else {
+            hdrVividProbeActive_.store(false, std::memory_order_relaxed);
         }
     }
     

--- a/nativelib/src/main/cpp/video_decoder.cpp
+++ b/nativelib/src/main/cpp/video_decoder.cpp
@@ -14,6 +14,7 @@
  */
 
 #include "video_decoder.h"
+#include "hdr_vivid_metadata_scanner.h"
 #include "native_render.h"
 #include "gl_post_processor.h"
 #include <algorithm>
@@ -369,6 +370,7 @@ static constexpr int kMaxTimeoutMs = 100;       // 最大等待超时 (ms) - 增
 // 统计配置
 static constexpr int64_t kStatsUpdateIntervalMs = 1000;  // 统计更新间隔
 static constexpr int64_t kSyncLogIntervalMs = 10000;
+static constexpr uint32_t kHdrVividProbeDecodeUnits = 300;
 
 static int64_t GetSteadyTimeMs() {
     return std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -476,6 +478,8 @@ int VideoDecoder::Init(const VideoDecoderConfig& config, OHNativeWindow* window)
     }
     
     config_ = config;
+    hdrVividProbeDecodeUnits_.store(0, std::memory_order_relaxed);
+    hdrVividDetected_.store(false, std::memory_order_relaxed);
     window_ = window;
     render_ = NativeRender::GetInstance();
     
@@ -1031,6 +1035,8 @@ void VideoDecoder::Cleanup() {
     lastAsyncRenderTimeMs_ = 0;
     lastAsyncOutputTimeMs_ = 0;
     consecutiveCriticalPipelineFrames_ = 0;
+    hdrVividProbeDecodeUnits_.store(0, std::memory_order_relaxed);
+    hdrVividDetected_.store(false, std::memory_order_relaxed);
     
     OH_LOG_INFO(LOG_APP, "Video decoder cleaned up");
 }
@@ -1131,6 +1137,27 @@ int VideoDecoder::SubmitDecodeUnitScatter(const BufferSegment* segments, int seg
     
     // 首次调用时设置线程优先级 + 绑定大核
     SetupDecodeThreadPriority();
+
+    if (config_.codec == VideoCodecType::HEVC && config_.enableHdr &&
+        config_.hdrType == HdrType::HLG &&
+        !hdrVividDetected_.load(std::memory_order_relaxed)) {
+        const uint32_t probeIndex = hdrVividProbeDecodeUnits_.fetch_add(
+            1, std::memory_order_relaxed);
+        if (probeIndex < kHdrVividProbeDecodeUnits) {
+            HdrVividMetadataScanner scanner;
+            for (int index = 0; index < segmentCount; ++index) {
+                if (scanner.Scan(segments[index].data,
+                                 static_cast<size_t>(segments[index].length))) {
+                    break;
+                }
+            }
+            if (scanner.Finish()) {
+                hdrVividDetected_.store(true, std::memory_order_relaxed);
+                OH_LOG_INFO(LOG_APP,
+                            "HDR Vivid CUVA dynamic metadata detected in HEVC SEI");
+            }
+        }
+    }
     
     // === L4 网络抖动突发检测（仅异步模式） ===
     // 同步模式下 L1 drain-to-latest 已足够处理突发到达，L4 的 IDR 请求反而会加重负担
@@ -1454,6 +1481,7 @@ VideoDecoderStats VideoDecoder::GetStats() const {
     snapshot.syncDrainEvents = syncDrainEvents_.load(std::memory_order_relaxed);
     snapshot.syncDrainFrames = syncDrainFrames_.load(std::memory_order_relaxed);
     snapshot.syncDecode = config_.decoderMode == DecoderMode::SYNC;
+    snapshot.hdrVivid = hdrVividDetected_.load(std::memory_order_relaxed);
     if (render_ != nullptr) {
         snapshot.hostPacedPresentationActive =
             render_->IsHostPacedPresentationActive();

--- a/nativelib/src/main/cpp/video_decoder.h
+++ b/nativelib/src/main/cpp/video_decoder.h
@@ -428,8 +428,9 @@ private:
     std::atomic<uint64_t> syncDrainEvents_{0};
     std::atomic<uint64_t> syncDrainFrames_{0};
 
-    // HLG 会话开始阶段扫描 CUVA T.35 SEI，命中后保持到会话结束。
+    // HLG 会话开始阶段扫描 CUVA T.35 SEI；命中结果保持到会话结束。
     std::atomic<uint32_t> hdrVividProbeDecodeUnits_{0};
+    std::atomic<bool> hdrVividProbeActive_{false};
     std::atomic<bool> hdrVividDetected_{false};
     
     // 运行状态

--- a/nativelib/src/main/cpp/video_decoder.h
+++ b/nativelib/src/main/cpp/video_decoder.h
@@ -183,6 +183,7 @@ struct VideoDecoderStats {
     uint64_t syncDrainFrames;             // sync drain-to-latest 累计跳过帧数
     bool syncDecode;                      // 实际解码模式
     bool hostPacedPresentationActive;     // 定时提交 API 实际可用且已启用
+    bool hdrVivid;                        // 码流中检测到 CUVA HDR Vivid 动态元数据
     TwoStepPresentationStats presentation;
 };
 
@@ -426,6 +427,10 @@ private:
     uint64_t syncDrainFramesSinceLog_{0};
     std::atomic<uint64_t> syncDrainEvents_{0};
     std::atomic<uint64_t> syncDrainFrames_{0};
+
+    // HLG 会话开始阶段扫描 CUVA T.35 SEI，命中后保持到会话结束。
+    std::atomic<uint32_t> hdrVividProbeDecodeUnits_{0};
+    std::atomic<bool> hdrVividDetected_{false};
     
     // 运行状态
     std::atomic<bool> running_{false};

--- a/nativelib/src/test/cpp/hdr_vivid_metadata_scanner_test.cpp
+++ b/nativelib/src/test/cpp/hdr_vivid_metadata_scanner_test.cpp
@@ -1,12 +1,20 @@
 #include "hdr_vivid_metadata_scanner.h"
 
-#include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <iostream>
 #include <vector>
 
 namespace {
+
+void Expect(bool condition, const char* description) {
+    if (condition) {
+        return;
+    }
+    std::cerr << "FAILED: " << description << '\n';
+    std::exit(EXIT_FAILURE);
+}
 
 bool ScanSegments(const std::vector<std::vector<uint8_t>>& segments) {
     HdrVividMetadataScanner scanner;
@@ -25,7 +33,7 @@ void TestDetectsCuvaAcrossScatterSegments() {
         {0x01, 0x04, 0x05, 0x26},
         {0x00, 0x04, 0x00, 0x05, 0x80},
     };
-    assert(ScanSegments(segments));
+    Expect(ScanSegments(segments), "detect CUVA across scatter segments");
 }
 
 void TestDetectsCuvaSuffixSei() {
@@ -33,14 +41,14 @@ void TestDetectsCuvaSuffixSei() {
         0x00, 0x00, 0x00, 0x01, 0x50, 0x01,
         0x04, 0x05, 0x26, 0x00, 0x04, 0x00, 0x05, 0x80,
     }};
-    assert(ScanSegments(segments));
+    Expect(ScanSegments(segments), "detect CUVA suffix SEI");
 }
 
 void TestIgnoresHevcWithoutSei() {
     const std::vector<std::vector<uint8_t>> segments = {{
         0x00, 0x00, 0x01, 0x26, 0x01, 0xAA, 0xBB, 0xCC,
     }};
-    assert(!ScanSegments(segments));
+    Expect(!ScanSegments(segments), "ignore HEVC without SEI");
 }
 
 void TestIgnoresHdr10PlusT35() {
@@ -48,7 +56,7 @@ void TestIgnoresHdr10PlusT35() {
         0x00, 0x00, 0x01, 0x4E, 0x01,
         0x04, 0x05, 0xB5, 0x00, 0x3C, 0x00, 0x01, 0x80,
     }};
-    assert(!ScanSegments(segments));
+    Expect(!ScanSegments(segments), "ignore HDR10+ T.35 metadata");
 }
 
 void TestRemovesEmulationPreventionBytes() {
@@ -57,7 +65,7 @@ void TestRemovesEmulationPreventionBytes() {
         0x05, 0x03, 0x00, 0x00, 0x03, 0x01,
         0x04, 0x05, 0x26, 0x00, 0x04, 0x00, 0x05, 0x80,
     }};
-    assert(ScanSegments(segments));
+    Expect(ScanSegments(segments), "remove emulation prevention bytes");
 }
 
 } // namespace

--- a/nativelib/src/test/cpp/hdr_vivid_metadata_scanner_test.cpp
+++ b/nativelib/src/test/cpp/hdr_vivid_metadata_scanner_test.cpp
@@ -1,0 +1,73 @@
+#include "hdr_vivid_metadata_scanner.h"
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <vector>
+
+namespace {
+
+bool ScanSegments(const std::vector<std::vector<uint8_t>>& segments) {
+    HdrVividMetadataScanner scanner;
+    for (const std::vector<uint8_t>& segment : segments) {
+        if (scanner.Scan(segment.data(), segment.size())) {
+            return true;
+        }
+    }
+    return scanner.Finish();
+}
+
+void TestDetectsCuvaAcrossScatterSegments() {
+    const std::vector<std::vector<uint8_t>> segments = {
+        {0x00, 0x00},
+        {0x01, 0x4E},
+        {0x01, 0x04, 0x05, 0x26},
+        {0x00, 0x04, 0x00, 0x05, 0x80},
+    };
+    assert(ScanSegments(segments));
+}
+
+void TestDetectsCuvaSuffixSei() {
+    const std::vector<std::vector<uint8_t>> segments = {{
+        0x00, 0x00, 0x00, 0x01, 0x50, 0x01,
+        0x04, 0x05, 0x26, 0x00, 0x04, 0x00, 0x05, 0x80,
+    }};
+    assert(ScanSegments(segments));
+}
+
+void TestIgnoresHevcWithoutSei() {
+    const std::vector<std::vector<uint8_t>> segments = {{
+        0x00, 0x00, 0x01, 0x26, 0x01, 0xAA, 0xBB, 0xCC,
+    }};
+    assert(!ScanSegments(segments));
+}
+
+void TestIgnoresHdr10PlusT35() {
+    const std::vector<std::vector<uint8_t>> segments = {{
+        0x00, 0x00, 0x01, 0x4E, 0x01,
+        0x04, 0x05, 0xB5, 0x00, 0x3C, 0x00, 0x01, 0x80,
+    }};
+    assert(!ScanSegments(segments));
+}
+
+void TestRemovesEmulationPreventionBytes() {
+    const std::vector<std::vector<uint8_t>> segments = {{
+        0x00, 0x00, 0x01, 0x4E, 0x01,
+        0x05, 0x03, 0x00, 0x00, 0x03, 0x01,
+        0x04, 0x05, 0x26, 0x00, 0x04, 0x00, 0x05, 0x80,
+    }};
+    assert(ScanSegments(segments));
+}
+
+} // namespace
+
+int main() {
+    TestDetectsCuvaAcrossScatterSegments();
+    TestDetectsCuvaSuffixSei();
+    TestIgnoresHevcWithoutSei();
+    TestIgnoresHdr10PlusT35();
+    TestRemovesEmulationPreventionBytes();
+    std::cout << "HDR Vivid metadata scanner tests passed\n";
+    return 0;
+}


### PR DESCRIPTION
## 改了啥呀

- 新增 HEVC Annex-B SEI 扫描器，支持跨 scatter segment 起始码、RBSP 防竞争字节，以及 prefix/suffix SEI
- 按 CUVA 005.1 的 T.35 标识 `0x26 / 0x0004 / 0x0005` 判断真实 HDR Vivid 动态元数据
- 将检测结果通过 native stats、NAPI 和 StreamingSession 送到性能覆盖层
- 解码器标签现在区分 `HDR PQ`、`HDR HLG` 和 `HDR Vivid`
- 补充有效 CUVA、普通 HEVC、HDR10+、分段输入和防竞争字节测试

## 为啥要改

HLG 配置只能说明传输函数，不能证明码流真的带了 HDR Vivid 动态元数据。现在直接看码流证据，纯 HLG 不用再被杂鱼误判硬塞成 Vivid 啦。

扫描仅发生在 HEVC HLG 会话开始阶段，命中后保持会话状态，避免给正常解码路径增加持续开销。

## 验证

- `c++ -std=c++17 -Wall -Wextra -Werror -I nativelib/src/main/cpp nativelib/src/main/cpp/hdr_vivid_metadata_scanner.cpp nativelib/src/test/cpp/hdr_vivid_metadata_scanner_test.cpp -o /tmp/moonlight_hdr_vivid_scanner_test && /tmp/moonlight_hdr_vivid_scanner_test`
- `npm run check:scripts`
- `DEVECO_SDK_HOME=/Users/mac/ohos-sdk-cache/6.1-Release-mac/sdk-ci-shape JAVA_HOME=/Applications/DevEco-Studio.app/Contents/jbr/Contents/Home node hvigorw.js assembleApp --mode project -p product=default -p buildMode=debug --no-daemon`
- Hvigor 完整构建成功；仅有仓库原有的设备类型、签名和 API 弃用警告

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增 HDR Vivid 内容检测，可在播放统计中显示检测结果。
  - 性能面板中的解码器信息支持更精确区分 HDR Vivid、HDR HLG 和 HDR PQ。

- **问题修复**
  - 优化 HDR 视频解码信息展示，确保其与实际视频元数据保持一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->