### PR TITLE
feat(input): lock cursor during fullscreen streaming

### DIFF
--- a/entry/src/main/ets/pages/StreamPage.ets
+++ b/entry/src/main/ets/pages/StreamPage.ets
@@ -213,6 +213,7 @@ struct StreamPage {
   // 使用 DisplaySync 直接向系统合成器请求高刷新率，
   // 解决无触摸时 ArkUI .onMouse 降至 ~30Hz 的问题
   private mouseDisplaySync: displaySync.DisplaySync | null = null;
+  private mouseInputSuspended: boolean = false;
   
   // ── 解耦的处理器/管理器 ──
   private inputHandler: StreamInputHandler = new StreamInputHandler();
@@ -328,6 +329,15 @@ struct StreamPage {
     // 初始化窗口管理器
     this.windowManager = new StreamWindowManager(this.context);
     this.windowManager.setOnWindowSizeChanged(() => this.recalculateXComponentSize());
+    this.windowManager.setOnWindowFocusChanged((focused: boolean) => {
+      if (!this.viewModel.isConnected) return;
+      if (!focused) {
+        this.inputHandler.stopMouseInterceptor();
+        this.stopMouseKeepAlive();
+      } else if (!this.mouseInputSuspended) {
+        this.resumeMouseInterceptor();
+      }
+    });
 
     // 注册 Network Boost 网络场景监听（弱信号/拥塞 提示）
     this.netSceneListener = (scene: SystemNetScene): void => {
@@ -843,7 +853,7 @@ struct StreamPage {
   private buildGameMenuCallbacks(): GameMenuCallbacks {
     return {
       onDismiss: () => {
-        this.resumeMouseInterceptor();
+        this.handleGameMenuDismissed();
       },
       onDisconnect: () => {
         this.gameMenuDialogController?.close();
@@ -962,6 +972,13 @@ struct StreamPage {
     };
   }
 
+  private handleGameMenuDismissed(): void {
+    this.gameMenuDialogController = null;
+    if (!this.mouseInputSuspended) return;
+    this.mouseInputSuspended = false;
+    this.resumeMouseInterceptor();
+  }
+
   /**
    * 显示串流菜单
    */
@@ -969,6 +986,7 @@ struct StreamPage {
     if (!this.menuManager) return;
 
     // 暂停鼠标全速轮询（Monitor 暂停 + DisplaySync 停止）
+    this.mouseInputSuspended = true;
     this.inputHandler.stopMouseInterceptor();
     this.stopMouseKeepAlive();
     
@@ -990,7 +1008,11 @@ struct StreamPage {
       }),
       alignment: DialogAlignment.CenterEnd,
       customStyle: true,
-      backgroundColor: Color.Transparent
+      backgroundColor: Color.Transparent,
+      onWillDismiss: (action: DismissDialogAction): void => {
+        action.dismiss();
+        this.handleGameMenuDismissed();
+      }
     });
     this.gameMenuDialogController.open();
   }
@@ -1117,10 +1139,13 @@ struct StreamPage {
    * 恢复鼠标全速轮询（对话框关闭后调用）
    */
   private resumeMouseInterceptor(): void {
-    if (!this.viewModel.isConnected) return;
+    if (!this.viewModel.isConnected || this.mouseInputSuspended) return;
+    this.stopMouseKeepAlive();
     const monitorOk = this.inputHandler.startMouseInterceptor(
       this.getXComponentWidthVp(),
-      this.getXComponentHeightVp()
+      this.getXComponentHeightVp(),
+      this.windowManager?.windowId ?? -1,
+      this.windowManager?.isFullscreen ?? false
     );
     if (!monitorOk) {
       this.startMouseKeepAlive();
@@ -1455,7 +1480,9 @@ struct StreamPage {
       // 启动鼠标全速轮询：优先 C++ Monitor，不可用时 DisplaySync 兜底
       const monitorOk = this.inputHandler.startMouseInterceptor(
         this.getXComponentWidthVp(),
-        this.getXComponentHeightVp()
+        this.getXComponentHeightVp(),
+        this.windowManager?.windowId ?? -1,
+        this.windowManager?.isFullscreen ?? false
       );
       if (!monitorOk) {
         this.startMouseKeepAlive();

--- a/entry/src/main/ets/service/input/InputInterceptorService.ets
+++ b/entry/src/main/ets/service/input/InputInterceptorService.ets
@@ -52,6 +52,9 @@ interface MouseInterceptorNative {
                             screenWidth: number, screenHeight: number,
                             relativeMode: boolean): void;
   isMouseInterceptorActive(): boolean;
+  isCursorLockAvailable(): boolean;
+  lockCursor(windowId: number, followMovement: boolean): number;
+  unlockCursor(windowId: number): number;
 }
 
 /**
@@ -149,6 +152,7 @@ export class MouseInterceptorService {
   private static instance: MouseInterceptorService;
   private native: MouseInterceptorNative | null;
   private active: boolean = false;
+  private lockedWindowId: number = -1;
 
   private constructor() {
     this.native = (nativeLib as Record<string, Object>)['MouseInterceptor'] as MouseInterceptorNative;
@@ -207,10 +211,13 @@ export class MouseInterceptorService {
    * 停止鼠标拦截器
    */
   stop(): void {
-    if (!this.active || !this.native) return;
-    this.native.removeMouseInterceptor();
-    this.active = false;
-    console.info('MouseInterceptor: 鼠标拦截器已停止');
+    if (!this.native) return;
+    if (this.active) {
+      this.native.removeMouseInterceptor();
+      this.active = false;
+      console.info('MouseInterceptor: 鼠标拦截器已停止');
+    }
+    this.unlockCursor();
   }
 
   isActive(): boolean {
@@ -218,5 +225,35 @@ export class MouseInterceptorService {
       return this.native.isMouseInterceptorActive();
     }
     return false;
+  }
+
+  isCursorLockAvailable(): boolean {
+    return this.native?.isCursorLockAvailable() ?? false;
+  }
+
+  lockCursor(windowId: number, followMovement: boolean): number {
+    if (!this.native || windowId < 0) return 801;
+    if (this.lockedWindowId >= 0 && this.lockedWindowId !== windowId) {
+      this.unlockCursor();
+    }
+    const result = this.native.lockCursor(windowId, followMovement);
+    if (result === 0) {
+      this.lockedWindowId = windowId;
+      console.info(`MouseInterceptor: 光标锁定成功 (windowId=${windowId}, followMovement=${followMovement})`);
+    }
+    return result;
+  }
+
+  unlockCursor(): number {
+    if (!this.native || this.lockedWindowId < 0) return 0;
+    const windowId = this.lockedWindowId;
+    const result = this.native.unlockCursor(windowId);
+    if (result === 0) {
+      this.lockedWindowId = -1;
+      console.info(`MouseInterceptor: 光标已释放 (windowId=${windowId})`);
+    } else {
+      console.warn(`MouseInterceptor: 光标释放失败 (windowId=${windowId}, error=${result})`);
+    }
+    return result;
   }
 }

--- a/entry/src/main/ets/service/streaming/StreamInputHandler.ets
+++ b/entry/src/main/ets/service/streaming/StreamInputHandler.ets
@@ -161,11 +161,16 @@ export class StreamInputHandler {
    *
    * @param viewWidth 视图宽度 (vp)
    * @param viewHeight 视图高度 (vp)
+   * @param windowId 主窗口 ID
+   * @param isFullscreen 是否处于全屏模式
    * @returns true 表示 C++ Monitor 已启动（不需要 keepalive），
-   *          false 表示 Monitor 不可用（调用方应启用 keepalive 动画来保持 ArkUI 帧率）
+   *          false 表示应启用 keepalive，由 ArkUI 处理鼠标事件
    */
-  startMouseInterceptor(viewWidth: number, viewHeight: number): boolean {
+  startMouseInterceptor(viewWidth: number, viewHeight: number,
+                        windowId: number, isFullscreen: boolean): boolean {
     const mouseInterceptor = MouseInterceptorService.getInstance();
+    mouseInterceptor.stop();
+    this.mouseInterceptorActive = false;
 
     // 保存 XComponent 实际尺寸，供 ArkUI 回退路径绝对模式使用
     this.viewWidthVp = viewWidth;
@@ -186,6 +191,21 @@ export class StreamInputHandler {
 
     // 读取游戏鼠标模式设置
     const relativeMode = this.viewModel?.inputSettings?.gameMouseMode ?? false;
+
+    // API 22+ 全屏窗口使用系统光标锁定。相对模式锁定后坐标保持不变，
+    // 必须由 ArkUI rawDelta 处理移动，不能再用 C++ Monitor 计算坐标差。
+    let cursorLocked = false;
+    if (isFullscreen && windowId >= 0 && mouseInterceptor.isCursorLockAvailable()) {
+      const lockResult = mouseInterceptor.lockCursor(windowId, !relativeMode);
+      cursorLocked = lockResult === 0;
+      if (!cursorLocked) {
+        console.info(`StreamInputHandler: 光标锁定不可用 (${lockResult})，保留原有鼠标处理`);
+      }
+    }
+    if (relativeMode && cursorLocked) {
+      console.info('StreamInputHandler: 游戏鼠标模式已锁定光标，使用 ArkUI rawDelta');
+      return false;
+    }
 
     // 初始使用屏幕尺寸（全屏时完全正确），窗口模式下异步获取实际窗口矩形更新
     mouseInterceptor.configure(0, 0, screenWidthPx, screenHeightPx,
@@ -255,7 +275,6 @@ export class StreamInputHandler {
    * 停止鼠标高速轮询
    */
   stopMouseInterceptor(): void {
-    if (!this.mouseInterceptorActive) return;
     MouseInterceptorService.getInstance().stop();
     this.mouseInterceptorActive = false;
   }
@@ -285,10 +304,9 @@ export class StreamInputHandler {
     if (event.action === MouseAction.Move) {
       const relativeMode = this.viewModel?.inputSettings?.gameMouseMode ?? false;
       if (relativeMode) {
-        // 相对模式（Monitor 不可用时回退）：使用 rawDelta 发送相对位移
-        // rawDelta 为 vp 单位，转 px 后 ×1.5 补偿 ArkUI 事件频率损失
-        const dx = vp2px(event.rawDeltaX ?? 0) * 1.5;
-        const dy = vp2px(event.rawDeltaY ?? 0) * 1.5;
+        // rawDelta 是鼠标硬件上报的原始位移，不是 vp/px，直接转发给远端。
+        const dx = event.rawDeltaX ?? 0;
+        const dy = event.rawDeltaY ?? 0;
         if (dx !== 0 || dy !== 0) {
           MoonBridge.sendMouseMove(Math.round(dx), Math.round(dy));
         }

--- a/entry/src/main/ets/service/streaming/StreamWindowManager.ets
+++ b/entry/src/main/ets/service/streaming/StreamWindowManager.ets
@@ -49,10 +49,19 @@ export class StreamWindowManager {
   private windowSizeChangeHandler: ((size: window.Size) => void) | null = null;
   /** windowSizeChange 防抖定时器 */
   private windowSizeDebounceTimer: number = -1;
+  /** 主窗口 ID，供 Native WindowManager API 使用 */
+  private mainWindowId: number = -1;
+  /** 主窗口焦点变化回调 */
+  private onWindowFocusChanged: ((focused: boolean) => void) | null = null;
+  private windowEventHandler: ((event: window.WindowEventType) => void) | null = null;
 
   /** 查询当前是否全屏 */
   get isFullscreen(): boolean {
     return this._isFullscreen;
+  }
+
+  get windowId(): number {
+    return this.mainWindowId;
   }
   
   constructor(context: common.UIAbilityContext) {
@@ -64,6 +73,10 @@ export class StreamWindowManager {
    */
   setOnWindowSizeChanged(callback: (() => void) | null): void {
     this.onWindowSizeChanged = callback;
+  }
+
+  setOnWindowFocusChanged(callback: ((focused: boolean) => void) | null): void {
+    this.onWindowFocusChanged = callback;
   }
   
   /**
@@ -109,6 +122,8 @@ export class StreamWindowManager {
   async configureWindow(): Promise<void> {
     try {
       const win = await window.getLastWindow(this.context);
+      this.mainWindowId = win.getWindowProperties().id;
+      this.registerWindowEventListener(win);
       win.setWindowKeepScreenOn(true).catch(() => {
         // TODO: Implement error handling.
       });
@@ -133,6 +148,7 @@ export class StreamWindowManager {
     try {
       const win = await window.getLastWindow(this.context);
       this.unregisterWindowSizeListener(win);
+      this.unregisterWindowEventListener(win);
       win.setWindowKeepScreenOn(false);
       await this.exitImmersiveFullscreen(win);
 
@@ -146,6 +162,7 @@ export class StreamWindowManager {
       win.setWindowBrightness(-1);
 
       this._isFullscreen = false;
+      this.mainWindowId = -1;
       console.info('StreamWindowManager: 已恢复窗口设置');
     } catch (err) {
       console.error('恢复窗口设置失败:', err);
@@ -214,6 +231,29 @@ export class StreamWindowManager {
       clearTimeout(this.windowSizeDebounceTimer);
       this.windowSizeDebounceTimer = -1;
     }
+  }
+
+  private registerWindowEventListener(win: window.Window): void {
+    this.unregisterWindowEventListener(win);
+    this.windowEventHandler = (event: window.WindowEventType): void => {
+      if (event === window.WindowEventType.WINDOW_ACTIVE) {
+        this.onWindowFocusChanged?.(true);
+      } else if (event === window.WindowEventType.WINDOW_INACTIVE ||
+        event === window.WindowEventType.WINDOW_HIDDEN) {
+        this.onWindowFocusChanged?.(false);
+      }
+    };
+    try {
+      win.on('windowEvent', this.windowEventHandler);
+    } catch (_e) {}
+  }
+
+  private unregisterWindowEventListener(win: window.Window): void {
+    if (!this.windowEventHandler) return;
+    try {
+      win.off('windowEvent', this.windowEventHandler);
+    } catch (_e) {}
+    this.windowEventHandler = null;
   }
 
   /**

--- a/entry/src/main/module.json5
+++ b/entry/src/main/module.json5
@@ -133,6 +133,9 @@
           "abilities": ["EntryAbility"],
           "when": "always"
         }
+      },
+      {
+        "name": "ohos.permission.LOCK_WINDOW_CURSOR"
       }
     ]
   }

--- a/nativelib/src/main/cpp/mouse_interceptor.cpp
+++ b/nativelib/src/main/cpp/mouse_interceptor.cpp
@@ -30,10 +30,12 @@
  */
 
 #include "mouse_interceptor.h"
+#include <dlfcn.h>
 #include <multimodalinput/oh_input_manager.h>
 #include <hilog/log.h>
 #include <atomic>
 #include <chrono>
+#include <mutex>
 
 #include "moonlight-common-c/src/Limelight.h"
 
@@ -46,6 +48,72 @@
 // ==================== 配置状态 ====================
 
 static std::atomic<bool> g_active{false};
+
+// OH_WindowManager_LockCursor is API 22+. Resolve it at runtime so the
+// native library can still be loaded on devices matching compatibleSdk 12.
+using LockCursorFunction = int32_t (*)(int32_t, bool);
+using UnlockCursorFunction = int32_t (*)(int32_t);
+
+static constexpr int32_t WINDOW_MANAGER_OK = 0;
+static constexpr int32_t WINDOW_MANAGER_ERROR_NO_PERMISSION = 201;
+static constexpr int32_t WINDOW_MANAGER_ERROR_INVALID_PARAM = 401;
+static constexpr int32_t WINDOW_MANAGER_ERROR_DEVICE_NOT_SUPPORTED = 801;
+static constexpr int32_t WINDOW_MANAGER_ERROR_STATE_ABNORMAL = 1300002;
+
+static std::once_flag g_cursorApiLoadOnce;
+static void* g_windowManagerHandle = nullptr;
+static LockCursorFunction g_lockCursor = nullptr;
+static UnlockCursorFunction g_unlockCursor = nullptr;
+static std::atomic<bool> g_warnedCursorPermission{false};
+static std::atomic<bool> g_warnedCursorUnsupported{false};
+
+static void LoadCursorApi()
+{
+    g_windowManagerHandle = dlopen("libnative_window_manager.so", RTLD_NOW | RTLD_LOCAL);
+    if (!g_windowManagerHandle) {
+        const char* error = dlerror();
+        LOGI("光标锁定 API 不可用，将保留原有鼠标处理: %{public}s", error ? error : "unknown");
+        return;
+    }
+
+    g_lockCursor = reinterpret_cast<LockCursorFunction>(
+        dlsym(g_windowManagerHandle, "OH_WindowManager_LockCursor"));
+    g_unlockCursor = reinterpret_cast<UnlockCursorFunction>(
+        dlsym(g_windowManagerHandle, "OH_WindowManager_UnlockCursor"));
+    if (!g_lockCursor || !g_unlockCursor) {
+        LOGI("当前系统未导出光标锁定 API，将保留原有鼠标处理");
+        g_lockCursor = nullptr;
+        g_unlockCursor = nullptr;
+        dlclose(g_windowManagerHandle);
+        g_windowManagerHandle = nullptr;
+        return;
+    }
+
+    LOGI("光标锁定 API 已加载");
+}
+
+static bool IsCursorApiAvailable()
+{
+    std::call_once(g_cursorApiLoadOnce, LoadCursorApi);
+    return g_lockCursor != nullptr && g_unlockCursor != nullptr;
+}
+
+static void LogCursorApiError(const char* action, int32_t result)
+{
+    if (result == WINDOW_MANAGER_ERROR_DEVICE_NOT_SUPPORTED) {
+        if (!g_warnedCursorUnsupported.exchange(true)) {
+            LOGW("%{public}s光标失败: 设备不支持该能力 (%{public}d)", action, result);
+        }
+        return;
+    }
+    if (result == WINDOW_MANAGER_ERROR_NO_PERMISSION) {
+        if (!g_warnedCursorPermission.exchange(true)) {
+            LOGW("%{public}s光标失败: 缺少 LOCK_WINDOW_CURSOR 权限 (%{public}d)", action, result);
+        }
+        return;
+    }
+    LOGW("%{public}s光标失败: %{public}d", action, result);
+}
 
 // 鼠标模式：false=绝对模式（远程桌面），true=相对模式（游戏）
 static std::atomic<bool> g_relativeMode{false};
@@ -382,6 +450,84 @@ static napi_value IsMouseInterceptorActive(napi_env env, napi_callback_info info
     return result;
 }
 
+/**
+ * isCursorLockAvailable(): boolean
+ */
+static napi_value IsCursorLockAvailable(napi_env env, napi_callback_info info)
+{
+    napi_value result;
+    napi_get_boolean(env, IsCursorApiAvailable(), &result);
+    return result;
+}
+
+/**
+ * lockCursor(windowId, isCursorFollowMovement): number
+ */
+static napi_value LockCursor(napi_env env, napi_callback_info info)
+{
+    size_t argc = 2;
+    napi_value argv[2];
+    napi_get_cb_info(env, info, &argc, argv, nullptr, nullptr);
+
+    int32_t result = WINDOW_MANAGER_ERROR_INVALID_PARAM;
+    if (argc >= 2 && IsCursorApiAvailable()) {
+        int32_t windowId = -1;
+        bool followMovement = true;
+        napi_get_value_int32(env, argv[0], &windowId);
+        napi_get_value_bool(env, argv[1], &followMovement);
+
+        if (windowId >= 0) {
+            result = g_lockCursor(windowId, followMovement);
+            if (result == WINDOW_MANAGER_OK) {
+                LOGI("光标已锁定: windowId=%{public}d mode=%{public}s",
+                     windowId, followMovement ? "confined" : "locked");
+            } else {
+                LogCursorApiError("锁定", result);
+            }
+        }
+    } else if (argc >= 2) {
+        result = WINDOW_MANAGER_ERROR_DEVICE_NOT_SUPPORTED;
+    }
+
+    napi_value nResult;
+    napi_create_int32(env, result, &nResult);
+    return nResult;
+}
+
+/**
+ * unlockCursor(windowId): number
+ */
+static napi_value UnlockCursor(napi_env env, napi_callback_info info)
+{
+    size_t argc = 1;
+    napi_value argv[1];
+    napi_get_cb_info(env, info, &argc, argv, nullptr, nullptr);
+
+    int32_t result = WINDOW_MANAGER_ERROR_INVALID_PARAM;
+    if (argc >= 1 && IsCursorApiAvailable()) {
+        int32_t windowId = -1;
+        napi_get_value_int32(env, argv[0], &windowId);
+        if (windowId >= 0) {
+            result = g_unlockCursor(windowId);
+            if (result == WINDOW_MANAGER_OK) {
+                LOGI("光标已解锁: windowId=%{public}d", windowId);
+            } else if (result == WINDOW_MANAGER_ERROR_STATE_ABNORMAL) {
+                // Losing focus releases the cursor automatically. Cleanup after that is idempotent.
+                LOGI("光标已由系统释放: windowId=%{public}d", windowId);
+                result = WINDOW_MANAGER_OK;
+            } else {
+                LogCursorApiError("解锁", result);
+            }
+        }
+    } else if (argc >= 1) {
+        result = WINDOW_MANAGER_ERROR_DEVICE_NOT_SUPPORTED;
+    }
+
+    napi_value nResult;
+    napi_create_int32(env, result, &nResult);
+    return nResult;
+}
+
 // ==================== 模块初始化 ====================
 
 napi_value MouseInterceptor_Init(napi_env env, napi_value exports)
@@ -394,6 +540,9 @@ napi_value MouseInterceptor_Init(napi_env env, napi_value exports)
         {"removeMouseInterceptor", nullptr, RemoveMouseInterceptor, nullptr, nullptr, nullptr, napi_default, nullptr},
         {"configureMouseInterceptor", nullptr, ConfigureMouseInterceptor, nullptr, nullptr, nullptr, napi_default, nullptr},
         {"isMouseInterceptorActive", nullptr, IsMouseInterceptorActive, nullptr, nullptr, nullptr, napi_default, nullptr},
+        {"isCursorLockAvailable", nullptr, IsCursorLockAvailable, nullptr, nullptr, nullptr, napi_default, nullptr},
+        {"lockCursor", nullptr, LockCursor, nullptr, nullptr, nullptr, napi_default, nullptr},
+        {"unlockCursor", nullptr, UnlockCursor, nullptr, nullptr, nullptr, napi_default, nullptr},
     };
 
     napi_define_properties(env, interceptorObj, sizeof(methods) / sizeof(methods[0]), methods);


### PR DESCRIPTION
## 改了啥呀

- 接入 API 22+ 的 `OH_WindowManager_LockCursor` / `OH_WindowManager_UnlockCursor`，把会跑出全屏串流窗口的系统光标按住啦
- 普通桌面模式保留光标跟随并限制窗口边界；游戏鼠标模式固定本地光标，直接转发 ArkUI `rawDelta`
- 串流菜单、窗口失焦、退后台和串流结束时释放光标，恢复焦点或关闭菜单后重新锁定
- 通过运行时符号解析兼容 `compatibleSdkVersion 12`，并声明 `LOCK_WINDOW_CURSOR` 权限；旧系统和不支持设备继续使用原鼠标路径

## 为啥要改

全屏串流连接实体鼠标时，系统光标仍可能碰到窗口外或边缘区域，沉浸模式和应用层回弹管不到这一层。现在由窗口管理器负责边界，输入处理器只负责把位移送去远端，职责终于不打架了，杂鱼边缘状态退散。

Refs #80

本 PR 只处理 Issue 中第一项鼠标锁定需求；三指触控手势不在本次范围，因此不会自动关闭整个 Issue。

## 验证

- `npm run check`
- `node hvigorw.js assembleApp --mode project -p product=default -p buildMode=debug --no-daemon`
- API 24 模拟器绝对模式：`followMovement=true`，日志确认 `mode=confined`
- API 24 模拟器游戏鼠标模式：`followMovement=false`，日志确认 `mode=locked` 并进入 ArkUI `rawDelta` 路径
- Back 打开菜单会解锁，Back 关闭菜单会按原模式重新锁定
- Home 退后台由系统自动释放，回到前台重新锁定成功

模拟器缺少 `INPUT_MONITORING` 权限时会正确回退 ArkUI + DisplaySync。模拟器的视频解码仍为黑屏，且 UITest 注入的是触摸事件，实体鼠标 `rawDelta` 的手感仍建议在真机补充确认。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 支持全屏串流时锁定系统光标，提升鼠标相对移动体验。
  * 增加窗口焦点感知，窗口失焦或游戏菜单打开时自动暂停鼠标拦截，恢复后自动继续。
  * 游戏菜单关闭时统一恢复鼠标输入状态。

* **改进**
  * 优化相对鼠标移动数据处理，提升移动响应的准确性。
  * 增加光标锁定能力检测及自动释放机制，避免窗口切换或退出后残留锁定状态。
  * 补充光标锁定所需的系统权限配置。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->