### PR TITLE
fix(applist): 修复自动刷新导致应用列表跳动

### DIFF
--- a/entry/src/main/ets/components/AppCard.ets
+++ b/entry/src/main/ets/components/AppCard.ets
@@ -22,7 +22,7 @@ const CARD_TITLE_HEIGHT = 40;
  */
 @Component
 export struct AppCard {
-  @ObjectLink app: ObservableApp;
+  @ObjectLink @Watch('onAppChanged') app: ObservableApp;
   onTap: () => void = () => {};
   onLongPress: () => void = () => {};
   onSelect: () => void = () => {}; // 选中回调（用于更新背景图）
@@ -30,6 +30,18 @@ export struct AppCard {
   @State private isPressed: boolean = false;
   @State private isFocused: boolean = false;
   @State private imageLoadFailed: boolean = false;
+  private lastIconPath: string = '';
+
+  /**
+   * 卡片实例在刷新时会被复用（ForEach key 只含 id），
+   * 图标路径换了就清掉上一次的加载失败标记，否则会一直显示占位图。
+   */
+  private onAppChanged(): void {
+    if (this.app.localIconPath !== this.lastIconPath) {
+      this.lastIconPath = this.app.localIconPath;
+      this.imageLoadFailed = false;
+    }
+  }
 
   build() {
     Column() {

--- a/entry/src/main/ets/pages/AppListPageV2.ets
+++ b/entry/src/main/ets/pages/AppListPageV2.ets
@@ -524,9 +524,12 @@ struct AppListPageV2 {
         const apps = await this.getAppListWithRetry('刷新');
 
         // 静默刷新拿到空列表多半是服务端瞬时故障，保留现有列表，
-        // 否则后台轮询会把整页闪成"没有可用的应用"
+        // 否则后台轮询会把整页闪成"没有可用的应用"。
+        // 但运行状态要按刚拿到的 serverInfo 同步——否则退游戏后的收敛轮询
+        // 靠 hasRunningApp 判断，会一直等不到收敛。
         if (apps.length === 0 && silent && this.viewModel.appCount > 0) {
           console.warn('AppListPageV2: 静默刷新返回空列表，保留现有数据');
+          this.viewModel.syncRunningState(computer?.runningGameId || 0);
           return;
         }
 

--- a/entry/src/main/ets/pages/AppListPageV2.ets
+++ b/entry/src/main/ets/pages/AppListPageV2.ets
@@ -71,6 +71,7 @@ struct AppListPageV2 {
   private loadAttempt: number = 0; // 当前加载尝试次数
   private runningPollTimerId: number = -1; // 退游戏后运行状态轮询定时器
   private runningPollAttempt: number = 0;
+  private refreshInFlight: Promise<void> | null = null; // 进行中的刷新，用于合并重复请求
 
   // 空列表重试常量（匹配 Android EMPTY_LIST_THRESHOLD）
   private static readonly EMPTY_LIST_THRESHOLD = 3;
@@ -463,9 +464,42 @@ struct AppListPageV2 {
     }
   }
 
+  /**
+   * 刷新应用列表
+   *
+   * 同一时刻只允许一次实际请求：连点刷新按钮、或后台轮询与手动刷新撞车时，
+   * 后来者搭上进行中的那次，而不是并发打多份 getServerInfo / getAppList。
+   * 后来者若是手动刷新，仍会显示下拉指示条并等到请求结束。
+   */
   private async refreshApps(silent: boolean = false): Promise<void> {
-    this.isRefreshing = true;
-    
+    // 静默刷新不驱动 Refresh 组件：否则后台轮询每一轮都会让下拉指示条
+    // 展开又收起，列表被顶下去再弹回来
+    if (!silent) {
+      this.isRefreshing = true;
+    }
+
+    let pending: Promise<void>;
+    if (this.refreshInFlight) {
+      pending = this.refreshInFlight;
+    } else {
+      pending = this.doRefreshApps(silent);
+      this.refreshInFlight = pending;
+    }
+
+    try {
+      await pending;
+    } finally {
+      if (this.refreshInFlight === pending) {
+        this.refreshInFlight = null;
+      }
+      if (!silent) {
+        this.isRefreshing = false;
+      }
+    }
+  }
+
+  /** refreshApps 的实际实现，不要直接调用——走 refreshApps 才有防重入 */
+  private async doRefreshApps(silent: boolean): Promise<void> {
     try {
       const computer = this.computerManager.getComputer(this.computerId);
       if (computer && computer.pairState !== PairState.PAIRED) {
@@ -489,6 +523,13 @@ struct AppListPageV2 {
         
         const apps = await this.getAppListWithRetry('刷新');
 
+        // 静默刷新拿到空列表多半是服务端瞬时故障，保留现有列表，
+        // 否则后台轮询会把整页闪成"没有可用的应用"
+        if (apps.length === 0 && silent && this.viewModel.appCount > 0) {
+          console.warn('AppListPageV2: 静默刷新返回空列表，保留现有数据');
+          return;
+        }
+
         // 标记正在运行的应用
         this.markRunningApps(apps, computer?.runningGameId || 0);
 
@@ -509,8 +550,6 @@ struct AppListPageV2 {
       } else {
         console.warn('AppListPageV2: 刷新失败（静默）:', errMsg);
       }
-    } finally {
-      this.isRefreshing = false;
     }
   }
 
@@ -1007,7 +1046,9 @@ struct AppListPageV2 {
               onMoreAction: () => this.openAppMenu(app)
             })
           }
-        }, (app: ObservableApp) => `${app.id}_${app.isRunning}_${app.iconLoaded}`)
+          // key 只用 id：isRunning / iconLoaded 变化由 @ObjectLink 就地更新，
+          // 放进 key 会让每次状态变化都销毁重建列表项，表现为刷新时整列跳动
+        }, (app: ObservableApp) => `${app.id}`)
       }
       .width('100%')
       .height('100%')
@@ -1041,12 +1082,12 @@ struct AppListPageV2 {
                     this.updateBackgroundForApp(app);
                   }
                 })
-              }, (app: ObservableApp) => `${app.id}_${app.isRunning}_${app.iconLoaded}`)
+              }, (app: ObservableApp) => `${app.id}`)
             }
             .margin({ bottom: rowIndex < this.rowCount - 1 ? AppSpacing.Medium : 0 })
           }, (rowApps: ObservableApp[], rowIndex: number) => {
-            // 行的 key 需要包含该行所有应用的 ID 和运行状态
-            const appIds = rowApps.map(a => `${a.id}:${a.isRunning ? 1 : 0}`).join(',');
+            // 行 key 只反映"这一行有哪些应用"，不含 isRunning 等易变状态
+            const appIds = rowApps.map(a => a.id).join(',');
             return `row_${rowIndex}_apps_${appIds}`;
           })
         }

--- a/entry/src/main/ets/viewmodel/AppViewModel.ets
+++ b/entry/src/main/ets/viewmodel/AppViewModel.ets
@@ -127,6 +127,20 @@ export class AppListViewModel {
   }
 
   /**
+   * 按最新的 runningGameId 同步现有列表的运行状态
+   *
+   * 用于拿不到新 applist、但已知服务端运行状态的场合（如静默刷新返回空列表时
+   * 保留旧数据）：不同步的话 hasRunningApp 会一直停在旧值，退游戏后的收敛轮询
+   * 就永远等不到收敛。
+   */
+  syncRunningState(runningGameId: number): void {
+    for (const app of this.apps) {
+      app.isRunning = runningGameId > 0 && app.id === runningGameId;
+    }
+    this.updateRunningApp();
+  }
+
+  /**
    * 取消正在进行的图标加载
    */
   cancelIconLoading(): void {

--- a/entry/src/main/ets/viewmodel/AppViewModel.ets
+++ b/entry/src/main/ets/viewmodel/AppViewModel.ets
@@ -83,33 +83,46 @@ export class AppListViewModel {
   // 排序方式
   sortBy: 'name' | 'recent' = 'name';
 
-  // 图标加载取消标志
-  private iconLoadingCancelled: boolean = false;
-  
+  // 图标加载代际标记：每次 setApps / cancelIconLoading 自增，
+  // 旧的串行加载循环在 await 恢复后发现代际已变即自行退出（避免多个循环并发跑）
+  private iconLoadGeneration: number = 0;
+
   /**
    * 设置应用列表（带图标 URL）
+   *
+   * 增量合并：按 id 复用已有的 ObservableApp 实例，只更新变化的字段。
+   * 不能全量重建——那会把 localIconPath/iconLoaded 清空，导致每次刷新
+   * 整个列表先闪回占位符再逐个恢复图标（视觉上的"跳动"）。
+   *
    * @param entries 应用列表
    * @param nvHttp NvHttp 实例（用于生成图标 URL 和加载图标）
    */
   setApps(entries: AppEntry[], nvHttp?: NvHttp): void {
-    // 取消之前的图标加载任务
-    this.iconLoadingCancelled = true;
-
     // 查找正在运行的应用
     const runningApps = entries.filter(e => e.isRunning);
     console.info(`AppListViewModel: 加载 ${entries.length} 个应用, 正在运行: ${runningApps.map(a => `${a.name}(${a.id})`).join(', ') || '无'}`);
 
+    const existing: Map<number, ObservableApp> = new Map();
+    for (const app of this.apps) {
+      existing.set(app.id, app);
+    }
+
     this.apps = entries.map(entry => {
       const iconUrl = nvHttp ? nvHttp.getBoxArtUrl(entry.id) : '';
+      const reused = existing.get(entry.id);
+      if (reused) {
+        // 复用实例：@ObjectLink 会把变化推给组件，无需重建 UI 节点
+        reused.updateFrom(entry, iconUrl);
+        return reused;
+      }
       return new ObservableApp(entry, iconUrl);
     });
     this.updateFilteredApps();
     this.updateRunningApp();
 
-    // 异步加载所有图标
+    // 异步加载尚未拿到图标的应用
     if (nvHttp) {
-      this.iconLoadingCancelled = false;
-      this.loadAllIcons(nvHttp);
+      this.loadAllIcons(nvHttp, ++this.iconLoadGeneration);
     }
   }
 
@@ -117,27 +130,32 @@ export class AppListViewModel {
    * 取消正在进行的图标加载
    */
   cancelIconLoading(): void {
-    this.iconLoadingCancelled = true;
+    this.iconLoadGeneration++;
     console.info(`AppListViewModel: 图标加载已取消`);
   }
 
   /**
    * 异步加载所有应用图标（串行加载，避免并发过多）
+   * 已加载成功的图标会被跳过，刷新时不会重新拉取。
    */
-  private async loadAllIcons(nvHttp: NvHttp): Promise<void> {
-    console.info(`AppListViewModel: 开始加载 ${this.apps.length} 个应用图标`);
+  private async loadAllIcons(nvHttp: NvHttp, generation: number): Promise<void> {
+    const pending = this.apps.filter(app => !app.iconLoaded);
+    if (pending.length === 0) {
+      return;
+    }
+    console.info(`AppListViewModel: 开始加载 ${pending.length} 个应用图标`);
 
     // 串行加载图标，避免并发过多导致卡顿
-    for (const app of this.apps) {
-      // 检查是否已取消
-      if (this.iconLoadingCancelled) {
+    for (const app of pending) {
+      // 检查是否已被更新的一轮加载取代
+      if (this.iconLoadGeneration !== generation) {
         console.info(`AppListViewModel: 图标加载被取消，停止加载`);
         return;
       }
 
       try {
         const localPath = await nvHttp.getAppAssetCached(app.id);
-        if (localPath && !this.iconLoadingCancelled) {
+        if (localPath && this.iconLoadGeneration === generation) {
           app.setLocalIconPath(localPath);
           console.info(`AppListViewModel: 图标加载成功 ${app.name}`);
         }
@@ -146,7 +164,7 @@ export class AppListViewModel {
       }
     }
 
-    if (!this.iconLoadingCancelled) {
+    if (this.iconLoadGeneration === generation) {
       console.info(`AppListViewModel: 所有图标加载完成`);
     }
   }


### PR DESCRIPTION
## 问题

用户反馈：应用列表页放在那不动，自动刷新会一直跳动。

## 原因

三个原因叠加：

1. **`setApps()` 全量重建对象** — 每次刷新都 `new ObservableApp(...)`，把 `localIconPath` / `iconLoaded` 一起清空。于是每轮刷新整列先闪回加载占位符，再串行把 9 个图标重新拉一遍。
2. **`ForEach` key 含易变状态** — key 是 `${id}_${isRunning}_${iconLoaded}`，任何一个图标加载完成都会让 ArkUI 销毁并重建那个列表项，而不是通过 `@ObjectLink` 就地更新。
3. **静默刷新驱动了 `Refresh` 组件** — `onPageShow` 和退游戏后的收敛轮询都走 `refreshApps(silent=true)`，但仍然置 `isRefreshing = true`，下拉指示条每轮展开又收起，把列表顶下去再弹回来。

## 改动

- `AppViewModel.setApps()` 改为**按 id 增量合并**：复用已有的 `ObservableApp` 实例，只更新变化字段，图标状态得以保留。
- `ForEach` 的 key 收敛到只含 `id`（网格行 key 同理去掉 `isRunning`）。
- 静默刷新不再置 `isRefreshing`。
- `loadAllIcons` 只处理 `!iconLoaded` 的应用；取消标志从布尔改为**代际计数**，修掉了旧写法下多个加载循环可能并发跑的隐患。
- `refreshApps` 增加 **in-flight 合并**：拆成外层守卫 + `doRefreshApps` 实现，同一时刻只发一次请求。此前单击刷新按钮会打出两个相隔 14ms 的 `getAppList`。撞上静默刷新的手动刷新仍会显示下拉指示条并等到结束。
- 静默刷新拿到空列表时保留现有数据，避免服务端瞬时故障把整页闪成"没有可用的应用"。
- 新增 `AppListViewModel.syncRunningState()`：上面那个"保留旧数据"分支在 return 前按刚拿到的 `computer.runningGameId` 同步运行状态。否则 `hasRunningApp` 会停在旧值，而退游戏后的收敛轮询正是靠它判断，一次瞬时空 applist 就会把卡片钉在"运行中"并耗光全部 12 次轮询。
- `AppCard` 加 `@Watch`：实例现在会跨刷新复用，图标路径变化时需要清掉 `imageLoadFailed`，否则一次加载失败会把卡片永久钉在占位图上。

## 验证

在 MatePad Pro 13 模拟器（HarmonyOS 6.1.1）上，连接真实 Sunshine host（9 个应用）实测：

| 场景 | 结果 |
|---|---|
| 首次进入列表 | 9 个图标正常加载 |
| 连续 4 轮静默刷新 | 每轮日志都有 `getAppList: HTTPS 请求成功` + `加载 9 个应用`，但**零条图标加载日志** |
| 刷新前后截图 | 逐字节相同（MD5 一致） |
| 单击刷新按钮 | 只发 **1 次** `getAppList`（修复前为 2 次） |
| 真起一局再退出 | 角标 **1.04s、第一次收敛轮询**即清除 |

关键证据是那条**消失的日志**：修复前每轮刷新都会打 `开始加载 9 个应用图标` 加 9 条 `图标加载成功`，修复后四轮刷新一条都没有。

运行状态这条通路单独跑了一遍（去掉 key 里的 `isRunning` 后是否还能及时响应）：在真机 host 上启动「桌面」再退出，

```
11:45:34.988  AppListViewModel: 加载 9 个应用, 正在运行: 桌面(334004416)
11:45:36.024  AppListViewModel: 加载 9 个应用, 正在运行: 无
11:45:36.025  AppListPageV2: 运行状态收敛（第 1 次轮询后）
```

截图确认「运行中」角标与绿色边框同时消失。订阅挂在 `@Observed` 对象上，与数组重建、`ForEach` 节点复用无关，所以 key 去掉 `isRunning` 不影响时效；页面级的 `hasRunningApp` / `runningApp` 也全是命令式使用，`build()` 里一处都没有。

## Reviewer 需要知道

未覆盖：`smallIconMode` 的列表布局（`AppListItem` 没有 `@State imageLoadFailed`，不需要 `@Watch`，但布局层面未实测）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
