### PR TITLE
fix(hdr): 打通 HEVC/AV1 CUVA HDR Vivid 链路

### DIFF
--- a/nativelib/src/main/cpp/hdr_vivid_metadata_scanner.cpp
+++ b/nativelib/src/main/cpp/hdr_vivid_metadata_scanner.cpp
@@ -17,6 +17,9 @@ namespace {
 constexpr uint8_t kHevcPrefixSeiNalType = 39;
 constexpr uint8_t kHevcSuffixSeiNalType = 40;
 constexpr uint32_t kRegisteredT35PayloadType = 4;
+constexpr uint8_t kAv1MetadataObuType = 5;
+constexpr uint64_t kAv1ItutT35MetadataType = 4;
+constexpr uint8_t kAv1MaxLeb128Bytes = 8;
 
 // CUVA 005.1 HDR Vivid identifier in user_data_registered_itu_t_t35.
 constexpr uint8_t kCuvaCountryCode = 0x26;
@@ -69,9 +72,54 @@ bool ReadSeiValue(RbspByteReader& reader, uint32_t& value) {
     return true;
 }
 
+bool ReadLeb128(const uint8_t* data, size_t size, size_t& offset, uint64_t& value) {
+    value = 0;
+    uint8_t shift = 0;
+    for (uint8_t count = 0; count < kAv1MaxLeb128Bytes && offset < size; ++count) {
+        const uint8_t current = data[offset++];
+        value |= static_cast<uint64_t>(current & 0x7F) << shift;
+        if ((current & 0x80) == 0) {
+            return true;
+        }
+        shift = static_cast<uint8_t>(shift + 7);
+    }
+    return false;
+}
+
+bool IsCuvaT35Identifier(const uint8_t* identifier, size_t size) {
+    if (identifier == nullptr || size < 5) {
+        return false;
+    }
+
+    const uint16_t terminalProviderCode =
+        static_cast<uint16_t>(identifier[1] << 8) | identifier[2];
+    const uint16_t providerOrientedCode =
+        static_cast<uint16_t>(identifier[3] << 8) | identifier[4];
+    return identifier[0] == kCuvaCountryCode &&
+           terminalProviderCode == kCuvaTerminalProviderCode &&
+           providerOrientedCode == kCuvaProviderOrientedCode;
+}
+
 } // namespace
 
+HdrVividMetadataScanner::HdrVividMetadataScanner(HdrVividBitstreamFormat format)
+    : format_(format) {}
+
 bool HdrVividMetadataScanner::Scan(const uint8_t* data, size_t size) {
+    if (format_ == HdrVividBitstreamFormat::AV1_LOW_OVERHEAD_OBU) {
+        return ScanAv1(data, size);
+    }
+    return ScanHevc(data, size);
+}
+
+bool HdrVividMetadataScanner::Finish() {
+    if (format_ == HdrVividBitstreamFormat::AV1_LOW_OVERHEAD_OBU) {
+        return FinishAv1();
+    }
+    return FinishHevc();
+}
+
+bool HdrVividMetadataScanner::ScanHevc(const uint8_t* data, size_t size) {
     if (detected_ || data == nullptr) {
         return detected_;
     }
@@ -113,7 +161,7 @@ bool HdrVividMetadataScanner::Scan(const uint8_t* data, size_t size) {
     return detected_;
 }
 
-bool HdrVividMetadataScanner::Finish() {
+bool HdrVividMetadataScanner::FinishHevc() {
     if (!detected_ && inNal_ && FinishNal()) {
         detected_ = true;
     }
@@ -185,15 +233,137 @@ bool HdrVividMetadataScanner::ContainsCuvaT35Payload(
         }
 
         if (isCuvaPayload) {
-            const uint16_t terminalProviderCode =
-                static_cast<uint16_t>(identifier[1] << 8) | identifier[2];
-            const uint16_t providerOrientedCode =
-                static_cast<uint16_t>(identifier[3] << 8) | identifier[4];
-            if (identifier[0] == kCuvaCountryCode &&
-                terminalProviderCode == kCuvaTerminalProviderCode &&
-                providerOrientedCode == kCuvaProviderOrientedCode) {
+            if (IsCuvaT35Identifier(identifier, sizeof(identifier))) {
                 return true;
             }
         }
     }
+}
+
+bool HdrVividMetadataScanner::ScanAv1(const uint8_t* data, size_t size) {
+    if (detected_ || data == nullptr ||
+        av1State_ == Av1ParseState::INVALID) {
+        return detected_;
+    }
+
+    for (size_t index = 0; index < size; ++index) {
+        const uint8_t current = data[index];
+        switch (av1State_) {
+            case Av1ParseState::OBU_HEADER:
+                // obu_forbidden_bit and obu_reserved_1bit must both be zero.
+                if ((current & 0x81) != 0) {
+                    av1State_ = Av1ParseState::INVALID;
+                    return false;
+                }
+                StartAv1Obu(current);
+                break;
+
+            case Av1ParseState::OBU_EXTENSION:
+                // extension_header_reserved_3bits must be zero.
+                if ((current & 0x07) != 0) {
+                    av1State_ = Av1ParseState::INVALID;
+                    return false;
+                }
+                av1State_ = av1HasSizeField_ ?
+                    Av1ParseState::OBU_SIZE : Av1ParseState::OBU_PAYLOAD;
+                break;
+
+            case Av1ParseState::OBU_SIZE:
+                if (av1LebBytes_ >= kAv1MaxLeb128Bytes) {
+                    av1State_ = Av1ParseState::INVALID;
+                    return false;
+                }
+
+                av1LebValue_ |=
+                    static_cast<uint64_t>(current & 0x7F) << av1LebShift_;
+                av1LebBytes_++;
+                if ((current & 0x80) != 0) {
+                    av1LebShift_ = static_cast<uint8_t>(av1LebShift_ + 7);
+                    break;
+                }
+
+                av1ObuSize_ = av1LebValue_;
+                av1PayloadBytesRead_ = 0;
+                av1State_ = Av1ParseState::OBU_PAYLOAD;
+                if (av1ObuSize_ == 0 && FinishAv1Obu()) {
+                    return true;
+                }
+                break;
+
+            case Av1ParseState::OBU_PAYLOAD:
+                if (av1CaptureMetadata_ &&
+                    av1MetadataPrefixSize_ < av1MetadataPrefix_.size()) {
+                    av1MetadataPrefix_[av1MetadataPrefixSize_++] = current;
+                }
+                av1PayloadBytesRead_++;
+
+                if (av1HasSizeField_ &&
+                    av1PayloadBytesRead_ == av1ObuSize_ &&
+                    FinishAv1Obu()) {
+                    return true;
+                }
+                break;
+
+            case Av1ParseState::INVALID:
+                return false;
+        }
+    }
+
+    return detected_;
+}
+
+bool HdrVividMetadataScanner::FinishAv1() {
+    if (detected_) {
+        return true;
+    }
+    if (av1State_ == Av1ParseState::OBU_PAYLOAD &&
+        !av1HasSizeField_) {
+        return FinishAv1Obu();
+    }
+
+    // Sized OBUs must end exactly at the decode-unit boundary. Header state
+    // means the final OBU was already completed while scanning.
+    return av1State_ == Av1ParseState::OBU_HEADER && detected_;
+}
+
+void HdrVividMetadataScanner::StartAv1Obu(uint8_t header) {
+    const uint8_t obuType = static_cast<uint8_t>((header >> 3) & 0x0F);
+    const bool extensionFlag = (header & 0x04) != 0;
+    av1HasSizeField_ = (header & 0x02) != 0;
+    av1CaptureMetadata_ = obuType == kAv1MetadataObuType;
+    av1MetadataPrefixSize_ = 0;
+    av1ObuSize_ = 0;
+    av1PayloadBytesRead_ = 0;
+    av1LebValue_ = 0;
+    av1LebShift_ = 0;
+    av1LebBytes_ = 0;
+    av1State_ = extensionFlag ?
+        Av1ParseState::OBU_EXTENSION :
+        (av1HasSizeField_ ?
+            Av1ParseState::OBU_SIZE : Av1ParseState::OBU_PAYLOAD);
+}
+
+bool HdrVividMetadataScanner::FinishAv1Obu() {
+    if (av1CaptureMetadata_ &&
+        ContainsCuvaAv1Metadata(
+            av1MetadataPrefix_.data(), av1MetadataPrefixSize_)) {
+        detected_ = true;
+    }
+
+    av1State_ = Av1ParseState::OBU_HEADER;
+    av1CaptureMetadata_ = false;
+    av1MetadataPrefixSize_ = 0;
+    return detected_;
+}
+
+bool HdrVividMetadataScanner::ContainsCuvaAv1Metadata(
+        const uint8_t* payload, size_t payloadSize) {
+    size_t offset = 0;
+    uint64_t metadataType = 0;
+    if (!ReadLeb128(payload, payloadSize, offset, metadataType) ||
+        metadataType != kAv1ItutT35MetadataType) {
+        return false;
+    }
+
+    return IsCuvaT35Identifier(payload + offset, payloadSize - offset);
 }

--- a/nativelib/src/main/cpp/hdr_vivid_metadata_scanner.h
+++ b/nativelib/src/main/cpp/hdr_vivid_metadata_scanner.h
@@ -15,22 +15,50 @@
 #include <cstddef>
 #include <cstdint>
 
+enum class HdrVividBitstreamFormat {
+    HEVC_ANNEX_B,
+    AV1_LOW_OVERHEAD_OBU,
+};
+
 /**
- * Incrementally scans an HEVC Annex-B decode unit for HDR Vivid/CUVA SEI.
+ * Incrementally scans a decode unit for HDR Vivid/CUVA T.35 metadata.
  * One scanner can consume multiple scatter-gather segments in order.
  */
 class HdrVividMetadataScanner {
 public:
+    explicit HdrVividMetadataScanner(
+        HdrVividBitstreamFormat format = HdrVividBitstreamFormat::HEVC_ANNEX_B);
+
     bool Scan(const uint8_t* data, size_t size);
     bool Finish();
 
 private:
     static constexpr size_t kMaxSeiNalSize = 8192;
+    static constexpr size_t kMaxAv1MetadataPrefixSize = 32;
 
+    enum class Av1ParseState {
+        OBU_HEADER,
+        OBU_EXTENSION,
+        OBU_SIZE,
+        OBU_PAYLOAD,
+        INVALID,
+    };
+
+    bool ScanHevc(const uint8_t* data, size_t size);
+    bool FinishHevc();
     void StartNal();
     void AppendNalByte(uint8_t value);
     bool FinishNal();
     static bool ContainsCuvaT35Payload(const uint8_t* nalData, size_t nalSize);
+
+    bool ScanAv1(const uint8_t* data, size_t size);
+    bool FinishAv1();
+    void StartAv1Obu(uint8_t header);
+    bool FinishAv1Obu();
+    static bool ContainsCuvaAv1Metadata(
+        const uint8_t* payload, size_t payloadSize);
+
+    HdrVividBitstreamFormat format_;
 
     std::array<uint8_t, kMaxSeiNalSize> seiNal_{};
     size_t seiNalSize_ = 0;
@@ -40,6 +68,17 @@ private:
     bool captureNal_ = false;
     bool nalOverflow_ = false;
     bool detected_ = false;
+
+    Av1ParseState av1State_ = Av1ParseState::OBU_HEADER;
+    std::array<uint8_t, kMaxAv1MetadataPrefixSize> av1MetadataPrefix_{};
+    size_t av1MetadataPrefixSize_ = 0;
+    uint64_t av1ObuSize_ = 0;
+    uint64_t av1PayloadBytesRead_ = 0;
+    uint64_t av1LebValue_ = 0;
+    uint8_t av1LebShift_ = 0;
+    uint8_t av1LebBytes_ = 0;
+    bool av1HasSizeField_ = false;
+    bool av1CaptureMetadata_ = false;
 };
 
 #endif // HDR_VIVID_METADATA_SCANNER_H

--- a/nativelib/src/main/cpp/moonlight_bridge.cpp
+++ b/nativelib/src/main/cpp/moonlight_bridge.cpp
@@ -121,7 +121,8 @@ static DECODER_RENDERER_CALLBACKS g_videoCallbacksStruct = {
     .stop = BridgeDrStop,
     .cleanup = BridgeDrCleanup,
     .submitDecodeUnit = (int (*)(PDECODE_UNIT))BridgeDrSubmitDecodeUnit,
-    .capabilities = CAPABILITY_DIRECT_SUBMIT,  // 直接从网络线程提交，减少延迟
+    // 保留 HEVC SEI，确保 CUVA HDR Vivid 动态元数据同时到达硬件解码器和性能统计扫描器。
+    .capabilities = CAPABILITY_DIRECT_SUBMIT | CAPABILITY_PRESERVE_HEVC_SEI,
 };
 
 static AUDIO_RENDERER_CALLBACKS g_audioCallbacksStruct = {
@@ -515,7 +516,7 @@ static int StartConnectionWithPreparedInfo(SERVER_INFORMATION* serverInfo, STREA
                                            int32_t videoCapabilities) {
     g_streamConfig = *streamConfig;
     g_videoCapabilities = videoCapabilities;
-    g_videoCallbacksStruct.capabilities = videoCapabilities;
+    g_videoCallbacksStruct.capabilities = videoCapabilities | CAPABILITY_PRESERVE_HEVC_SEI;
 
     bool enableHdr = (streamConfig->supportedVideoFormats & 0xAA00) != 0;
     VideoDecoderInstance::SetHdrConfig(enableHdr, streamConfig->hdrMode,

--- a/nativelib/src/main/cpp/video_decoder.cpp
+++ b/nativelib/src/main/cpp/video_decoder.cpp
@@ -480,7 +480,9 @@ int VideoDecoder::Init(const VideoDecoderConfig& config, OHNativeWindow* window)
     config_ = config;
     hdrVividProbeDecodeUnits_.store(0, std::memory_order_relaxed);
     hdrVividProbeActive_.store(
-        config.codec == VideoCodecType::HEVC && config.enableHdr &&
+        (config.codec == VideoCodecType::HEVC ||
+         config.codec == VideoCodecType::AV1) &&
+        config.enableHdr &&
         config.hdrType == HdrType::HLG,
         std::memory_order_relaxed);
     hdrVividDetected_.store(false, std::memory_order_relaxed);
@@ -1150,7 +1152,11 @@ int VideoDecoder::SubmitDecodeUnitScatter(const BufferSegment* segments, int seg
             if (probeIndex + 1 == kHdrVividProbeDecodeUnits) {
                 hdrVividProbeActive_.store(false, std::memory_order_relaxed);
             }
-            HdrVividMetadataScanner scanner;
+            const HdrVividBitstreamFormat bitstreamFormat =
+                config_.codec == VideoCodecType::AV1 ?
+                    HdrVividBitstreamFormat::AV1_LOW_OVERHEAD_OBU :
+                    HdrVividBitstreamFormat::HEVC_ANNEX_B;
+            HdrVividMetadataScanner scanner(bitstreamFormat);
             for (int index = 0; index < segmentCount; ++index) {
                 if (scanner.Scan(segments[index].data,
                                  static_cast<size_t>(segments[index].length))) {
@@ -1161,7 +1167,9 @@ int VideoDecoder::SubmitDecodeUnitScatter(const BufferSegment* segments, int seg
                 hdrVividDetected_.store(true, std::memory_order_relaxed);
                 hdrVividProbeActive_.store(false, std::memory_order_relaxed);
                 OH_LOG_INFO(LOG_APP,
-                            "HDR Vivid CUVA dynamic metadata detected in HEVC SEI");
+                            "HDR Vivid CUVA dynamic metadata detected in %{public}s",
+                            config_.codec == VideoCodecType::AV1 ?
+                                "AV1 Metadata OBU" : "HEVC SEI");
             }
         } else {
             hdrVividProbeActive_.store(false, std::memory_order_relaxed);

--- a/nativelib/src/test/cpp/hdr_vivid_metadata_scanner_test.cpp
+++ b/nativelib/src/test/cpp/hdr_vivid_metadata_scanner_test.cpp
@@ -59,6 +59,17 @@ void TestIgnoresHdr10PlusT35() {
     Expect(!ScanSegments(segments), "ignore HDR10+ T.35 metadata");
 }
 
+void TestDetectsCuvaAfterHdr10PlusInSameSeiNal() {
+    const std::vector<std::vector<uint8_t>> segments = {{
+        0x00, 0x00, 0x00, 0x01, 0x4E, 0x01,
+        0x04, 0x05, 0xB5, 0x00, 0x3C, 0x00, 0x01,
+        0x04, 0x06, 0x26, 0x00, 0x04, 0x00, 0x05, 0x01,
+        0x80,
+    }};
+    Expect(ScanSegments(segments),
+           "detect CUVA after HDR10+ in the same prefix SEI NAL");
+}
+
 void TestRemovesEmulationPreventionBytes() {
     const std::vector<std::vector<uint8_t>> segments = {{
         0x00, 0x00, 0x01, 0x4E, 0x01,
@@ -75,6 +86,7 @@ int main() {
     TestDetectsCuvaSuffixSei();
     TestIgnoresHevcWithoutSei();
     TestIgnoresHdr10PlusT35();
+    TestDetectsCuvaAfterHdr10PlusInSameSeiNal();
     TestRemovesEmulationPreventionBytes();
     std::cout << "HDR Vivid metadata scanner tests passed\n";
     return 0;

--- a/nativelib/src/test/cpp/hdr_vivid_metadata_scanner_test.cpp
+++ b/nativelib/src/test/cpp/hdr_vivid_metadata_scanner_test.cpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <iostream>
+#include <utility>
 #include <vector>
 
 namespace {
@@ -16,8 +17,11 @@ void Expect(bool condition, const char* description) {
     std::exit(EXIT_FAILURE);
 }
 
-bool ScanSegments(const std::vector<std::vector<uint8_t>>& segments) {
-    HdrVividMetadataScanner scanner;
+bool ScanSegments(
+        const std::vector<std::vector<uint8_t>>& segments,
+        HdrVividBitstreamFormat format =
+            HdrVividBitstreamFormat::HEVC_ANNEX_B) {
+    HdrVividMetadataScanner scanner(format);
     for (const std::vector<uint8_t>& segment : segments) {
         if (scanner.Scan(segment.data(), segment.size())) {
             return true;
@@ -79,6 +83,67 @@ void TestRemovesEmulationPreventionBytes() {
     Expect(ScanSegments(segments), "remove emulation prevention bytes");
 }
 
+void TestDetectsCuvaAv1MetadataObuAcrossScatterSegments() {
+    const std::vector<std::vector<uint8_t>> segments = {
+        // OBU_METADATA, obu_has_size_field=1, payload size=7.
+        {0x2A},
+        {0x07, 0x04, 0x26},
+        {0x00, 0x04, 0x00},
+        {0x05, 0x01},
+    };
+    Expect(ScanSegments(
+               segments, HdrVividBitstreamFormat::AV1_LOW_OVERHEAD_OBU),
+           "detect CUVA AV1 metadata OBU across scatter segments");
+}
+
+void TestDetectsCuvaAv1MetadataObuWithExtensionHeader() {
+    const std::vector<std::vector<uint8_t>> segments = {{
+        // Empty temporal delimiter OBU.
+        0x12, 0x00,
+        // OBU_METADATA with extension header and a valid CUVA T.35 payload.
+        0x2E, 0x00, 0x07,
+        0x04, 0x26, 0x00, 0x04, 0x00, 0x05, 0x01,
+    }};
+    Expect(ScanSegments(
+               segments, HdrVividBitstreamFormat::AV1_LOW_OVERHEAD_OBU),
+           "detect CUVA AV1 metadata OBU with extension header");
+}
+
+void TestDetectsCuvaAv1MetadataObuWithMultiByteSize() {
+    std::vector<uint8_t> decodeUnit = {
+        // OBU_METADATA with a 130-byte payload (LEB128 0x82 0x01).
+        0x2A, 0x82, 0x01,
+        0x04, 0x26, 0x00, 0x04, 0x00, 0x05, 0x01,
+    };
+    decodeUnit.resize(3 + 130, 0x00);
+    const std::vector<std::vector<uint8_t>> segments = {
+        std::move(decodeUnit),
+    };
+    Expect(ScanSegments(
+               segments, HdrVividBitstreamFormat::AV1_LOW_OVERHEAD_OBU),
+           "detect CUVA AV1 metadata OBU with multi-byte size");
+}
+
+void TestDetectsCuvaAv1MetadataObuWithoutSizeAtEnd() {
+    const std::vector<std::vector<uint8_t>> segments = {{
+        // A size-less OBU consumes the rest of this decode unit.
+        0x28, 0x04, 0x26, 0x00, 0x04, 0x00, 0x05, 0x01,
+    }};
+    Expect(ScanSegments(
+               segments, HdrVividBitstreamFormat::AV1_LOW_OVERHEAD_OBU),
+           "detect CUVA AV1 metadata OBU without size at decode-unit end");
+}
+
+void TestIgnoresHdr10PlusAv1MetadataObu() {
+    const std::vector<std::vector<uint8_t>> segments = {{
+        0x2A, 0x07,
+        0x04, 0xB5, 0x00, 0x3C, 0x00, 0x01, 0x04,
+    }};
+    Expect(!ScanSegments(
+               segments, HdrVividBitstreamFormat::AV1_LOW_OVERHEAD_OBU),
+           "ignore HDR10+ AV1 metadata OBU");
+}
+
 } // namespace
 
 int main() {
@@ -88,6 +153,11 @@ int main() {
     TestIgnoresHdr10PlusT35();
     TestDetectsCuvaAfterHdr10PlusInSameSeiNal();
     TestRemovesEmulationPreventionBytes();
+    TestDetectsCuvaAv1MetadataObuAcrossScatterSegments();
+    TestDetectsCuvaAv1MetadataObuWithExtensionHeader();
+    TestDetectsCuvaAv1MetadataObuWithMultiByteSize();
+    TestDetectsCuvaAv1MetadataObuWithoutSizeAtEnd();
+    TestIgnoresHdr10PlusAv1MetadataObu();
     std::cout << "HDR Vivid metadata scanner tests passed\n";
     return 0;
 }


### PR DESCRIPTION
## 改了啥呀

- 更新 `moonlight-common-c` 到配套 HEVC 修复： https://github.com/qiin2333/moonlight-common-c/pull/15
- HarmonyOS 渲染器显式启用 `CAPABILITY_PRESERVE_HEVC_SEI`，让 CUVA SEI 同时到达硬件解码器和状态扫描器。
- 将 HDR Vivid 扫描器扩展为 HEVC Annex-B SEI + AV1 low-overhead Metadata OBU 两种输入。
- AV1 解析支持跨 scatter 分段、可选 extension header、LEB128 OBU size、多字节 size 和末尾无 size OBU。
- HEVC/AV1 在 HDR+HLG 会话中共用同一个探测状态，识别后性能覆盖层显示 `HDR Vivid`。
- 保留 HDR10+ 排除逻辑，避免只看到 ITU-T T.35 就误报 Vivid。

## 为啥要改

Foundation Sunshine 已经在两条编码路径注入同一份 CUVA T.35 动态元数据：HEVC 使用 `seiPayloadArray`，AV1 使用 `obuPayloadArray`。客户端原来有两只杂鱼断点：HEVC SEI 在解包层提前被删掉，AV1 虽然完整透传给硬解，但探测器被硬编码成只扫描 HEVC，因此覆盖层永远无法确认 AV1 Vivid。

现在链路变为：

`Sunshine CUVA SEI/OBU → common-c 完整 decode unit → HarmonyOS AVCodec → HEVC/AV1 元数据扫描 → HDR Vivid 覆盖层状态`

AV1 解码输入没有被改写，只增加只读扫描；是否实际呈现动态效果仍由设备的 HarmonyOS AV1 HDR Vivid 硬解能力决定。

## 用户影响

- HEVC + HLG + CUVA：动态元数据不再丢失，硬解与覆盖层都能收到。
- AV1 + HLG + CUVA：原有 OBU 继续原样进入硬解，覆盖层现在也能识别。
- HEVC/AV1 + HLG 但无 CUVA：保持 `HDR HLG`，不会把 HDR10+ 误判为 Vivid。
- H.264、AV1 RTP 重组、网络协商和码流字节均未改变。

## 验证

- `g++ -std=c++17 -Wall -Wextra -Werror nativelib/src/main/cpp/hdr_vivid_metadata_scanner.cpp nativelib/src/test/cpp/hdr_vivid_metadata_scanner_test.cpp -I nativelib/src/main/cpp -o .codex-build/hdr_vivid_metadata_scanner_test.exe`
- `.codex-build/hdr_vivid_metadata_scanner_test.exe`：`HDR Vivid metadata scanner tests passed`
- `ninja -C C:\Users\mohaha\StudioProjects\moonlight-harmonyos\nativelib\.cxx\default\default\debug\arm64-v8a moonlight_nativelib`：arm64 原生库编译并链接成功。
- `git diff --check`：通过，仅有工作区 CRLF 转换提示。

覆盖用例包括：HEVC prefix/suffix SEI、同一 SEI 中 HDR10+ 后跟 CUVA、AV1 OBU 跨分段、extension header、多字节 LEB128 size、末尾无 size OBU，以及 HEVC/AV1 HDR10+ 排除。

补充：Hvigor 顶层任务仍被现有的 `The root node is not yet available for build` 配置错误阻断，因此使用已有 HarmonyOS arm64 Ninja 构建树完成原生链路验证。设备端 AV1 Vivid 实际渲染仍需在支持 AV1 HDR Vivid 的 HarmonyOS 设备上验收。