### PR TITLE
fix(streaming): recover RTSP host resolution

### DIFF
--- a/entry/src/main/ets/service/streaming/StreamingSession.ets
+++ b/entry/src/main/ets/service/streaming/StreamingSession.ets
@@ -14,7 +14,7 @@ import { ComputerManager } from '../ComputerManager';
 import { ComputerInfo, selectBestAddress } from '../../model/ComputerInfo';
 import { NvHttp, LaunchConfig } from './NvHttp';
 import { CryptoUtil } from '../../utils/CryptoUtil';
-import { parseAddressAndPort } from '../../utils/NetHelper';
+import { parseAddressAndPort, parseRtspSessionHost } from '../../utils/NetHelper';
 import { common, abilityAccessCtrl, bundleManager, Permissions } from '@kit.AbilityKit';
 import { display } from '@kit.ArkUI';
 import { GamepadManager } from '../input/GamepadManager';
@@ -43,7 +43,8 @@ import {
   VK_MENU,
   VK_LWIN,
   KEY_ACTION_DOWN,
-  KEY_ACTION_UP
+  KEY_ACTION_UP,
+  STAGE_NAME_RESOLUTION
 } from './MoonBridge';
 import nativeLib from 'libmoonlight_nativelib.so';
 
@@ -387,6 +388,7 @@ export class StreamingSession {
   private userInitiatedStop: boolean = false;
   private isStartingConnection: boolean = false;
   private connectionStartPromise: Promise<number> | null = null;
+  private lastFailedStage: number = 0;
   private computer: ComputerInfo | null = null;
   /** 本次串流最终选中的连接地址（手动/锁定/轮询胜出地址），保证 HTTP 与原生串流阶段一致 */
   private connectionAddress: string = '';
@@ -1206,6 +1208,7 @@ export class StreamingSession {
       stageComplete: (stage: number): void => { console.info(`连接阶段完成: ${stage}`); },
       stageFailed: (stage: number, errorCode: number): void => {
         const name = STAGE_NAMES[stage] || `阶段 ${stage}`;
+        this.lastFailedStage = stage;
         console.error(`连接阶段失败: stage=${stage} (${name}), error=${errorCode}`);
       },
       connectionStarted: (): void => {
@@ -1437,11 +1440,13 @@ export class StreamingSession {
       `vsync=${this.config.enableVsync}, hostPaced=${this.config.enableHostPacedPresentation ?? false}, ` +
       `vrr=${this.config.enableVrr}`);
 
-    const callStart = async (): Promise<number> => {
+    const callStart = async (address: string): Promise<number> => {
       this.isStartingConnection = true;
+      this.lastFailedStage = 0;
       try {
+        console.info(`StreamingSession: native connection address=${address}`);
         const pendingStart: Promise<number> = this.nativeModule.startConnectionAsync(
-          this.connectionAddress,
+          address,
           this.serverAppVersion,
           this.serverGfeVersion,
           this.rtspSessionUrl,
@@ -1469,7 +1474,31 @@ export class StreamingSession {
       }
     };
 
-    let result = await callStart();
+    let activeConnectionAddress = this.connectionAddress;
+    let result = await callStart(activeConnectionAddress);
+
+    // getaddrinfo() may fail after /launch succeeds when the selected hostname
+    // is stale or temporarily unavailable. In that specific stage, retry with
+    // the concrete host Sunshine just advertised in sessionUrl0. Do not use
+    // this address unconditionally: behind IPv4 NAT, sessionUrl0 may contain a
+    // private host while the selected WAN address is the correct route.
+    const rtspSessionHost = parseRtspSessionHost(this.rtspSessionUrl);
+    if (result === -2 &&
+        this.lastFailedStage === STAGE_NAME_RESOLUTION &&
+        rtspSessionHost &&
+        rtspSessionHost !== activeConnectionAddress) {
+      if (this.userInitiatedStop) {
+        return;
+      }
+      console.warn(`StreamingSession: 名称解析失败，改用 sessionUrl0 主机 ${rtspSessionHost} 重试`);
+      this.nativeModule.stopConnection();
+      activeConnectionAddress = rtspSessionHost;
+      result = await callStart(activeConnectionAddress);
+      if (result === 0) {
+        console.info('StreamingSession: sessionUrl0 主机回退成功');
+      }
+    }
+
     // RTSP/ENet 瞬态错误自动重试 1 次：errno 4=EINTR、110=ETIMEDOUT、104=ECONNRESET、32=EPIPE
     // 这类错误通常是 ENet service 循环被打断或网络抖动，host 端不需要重新 launchApp，
     // 只需 stopConnection 释放 native 资源后等待短暂窗口再重试即可恢复。
@@ -1488,7 +1517,7 @@ export class StreamingSession {
       if (this.userInitiatedStop) {
         return;
       }
-      result = await callStart();
+      result = await callStart(activeConnectionAddress);
       if (result === 0) {
         console.info('StreamingSession: 重试成功');
       }

--- a/entry/src/main/ets/utils/NetHelper.ets
+++ b/entry/src/main/ets/utils/NetHelper.ets
@@ -487,6 +487,22 @@ export function parseAddressAndPort(input: string): AddressPort {
 }
 
 /**
+ * Extract the host advertised by Sunshine in sessionUrl0.
+ *
+ * The native Moonlight core still resolves SERVER_INFORMATION.address for
+ * the RTSP socket. This host is therefore a fallback for cases where the
+ * selected hostname can no longer be resolved after /launch or /resume.
+ */
+export function parseRtspSessionHost(sessionUrl: string): string {
+  const match = /^(?:rtsp|rtspenc):\/\/([^/?#]+)/i.exec(sessionUrl.trim());
+  if (!match || match.length < 2) {
+    return '';
+  }
+
+  return parseAddressAndPort(match[1]).host;
+}
+
+/**
  * 格式化地址用于 URL：IPv6 地址需要加方括号
  *
  *   - "fe80::1"      → "[fe80::1]"

--- a/entry/src/main/ets/utils/NetworkErrorClassifierSelfCheck.ets
+++ b/entry/src/main/ets/utils/NetworkErrorClassifierSelfCheck.ets
@@ -22,6 +22,7 @@ import {
   isPrivateIPv4,
   isPublicAddress,
   parseAddressAndPort,
+  parseRtspSessionHost,
 } from './NetHelper';
 import { selectBestAddress } from '../model/ComputerInfo';
 
@@ -216,6 +217,9 @@ export class NetworkErrorClassifierSelfCheck {
       { name: 'formatAddressForUrl IPv4', actual: formatAddressForUrl('192.168.1.10'), expected: '192.168.1.10', reason: 'IPv4 不加方括号' },
       { name: 'formatAddressForUrl IPv6', actual: formatAddressForUrl('fe80::1'), expected: '[fe80::1]', reason: 'URL 中 IPv6 必须加方括号' },
       { name: 'formatAddressForUrl bracket IPv6', actual: formatAddressForUrl('[::1]'), expected: '[::1]', reason: '已有方括号不重复添加' },
+      { name: 'parseRtspSessionHost IPv4', actual: parseRtspSessionHost('rtsp://192.168.1.10:48010'), expected: '192.168.1.10', reason: '提取 Sunshine 返回的 IPv4 RTSP 主机' },
+      { name: 'parseRtspSessionHost IPv6', actual: parseRtspSessionHost('rtspenc://[240e:1234::10]:48010'), expected: '240e:1234::10', reason: '提取 Sunshine 返回的带方括号 IPv6 RTSP 主机' },
+      { name: 'parseRtspSessionHost rejects HTTP', actual: parseRtspSessionHost('https://sunshine.example.com:47984'), expected: '', reason: '只接受 RTSP 会话 URL' },
     ];
 
     for (const c of typeCases) {


### PR DESCRIPTION
## 改了啥呀

- 从 Sunshine 返回的 `sessionUrl0` 提取 RTSP 主机，兼容 IPv4、带方括号 IPv6 和 `rtspenc://`
- 记录 native 连接失败阶段
- 仅当返回 `-2` 且失败于名称解析阶段时，停止旧连接并用 `sessionUrl0` 主机重试一次
- 后续瞬态网络重试继续沿用已经生效的地址

## 为啥要这样

日志里 Sunshine 已完成 launch、虚拟显示器与编码器准备，但鸿蒙端在发出 RTSP DESCRIBE 前就以 `-2` 结束；Qt 客户端连接一次后鸿蒙又恢复，符合所选 hostname 在 launch/resume 后解析失效的表现。

不能无条件改用 `sessionUrl0`：公网 IPv4/NAT 场景里它可能是不可达的内网地址。所以只在“名称解析阶段 + -2”这个明确条件下回退，别让修复变成另一只杂鱼 bug 呀。

## 验证

- `npm run check`（仓库检查、许可证检查、11 组 mock 连接测试）
- DevEco Hvigor `assembleApp` 完整构建成功
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 优化连接失败后的自动重试机制，可根据失败阶段智能切换至 RTSP 会话实际提供的主机地址。
  - 在启动返回瞬态错误时，重试将继续使用当前有效连接地址，提升连接稳定性。

- **自检**
  - 增加对 RTSP、RTSP over TLS 及 IPv4/IPv6 地址解析的启动期检查。
  - 非 RTSP 地址将被正确识别并跳过解析。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->