### PR TITLE
fix(hdr): 保留客户端黑位精度

### DIFF
--- a/entry/src/main/ets/pages/SettingsPageV2.ets
+++ b/entry/src/main/ets/pages/SettingsPageV2.ets
@@ -1145,7 +1145,7 @@ struct SettingsPageV2 {
               {
                 title: 'HDR 模式',
                 tooltip: this.hdrMode === 'HLG'
-                  ? 'HLG (Hybrid Log-Gamma)\n• 需要 Sunshine Foundation 版本\n• 无需色调映射，亮度更自然\n• 兼容 HDR Vivid 显示设备\n• 推荐搭配全范围色彩使用'
+                  ? 'HLG (Hybrid Log-Gamma)\n• 需要 Sunshine Foundation 版本\n• 无需色调映射，亮度更自然\n• 兼容 HDR Vivid 显示设备'
                   : 'HDR10 (PQ)\n• 兼容所有主流串流服务端\n• 使用 PQ 传输曲线，高亮细节更丰富\n• 部分设备可能出现偏暗',
                 type: 'segment',
                 value: this.hdrMode,
@@ -1275,7 +1275,10 @@ struct SettingsPageV2 {
               },
               {
                 title: '全范围颜色',
-                subtitle: '使用完整颜色范围 (0-255)',
+                subtitle: this.enableHdr
+                  ? 'HDR 模式下需与服务端编码范围一致'
+                  : '使用完整颜色范围 (0-255)',
+                tooltip: '仅在服务端与解码器均使用全范围时开启；范围不一致会导致黑位或高光异常',
                 type: 'toggle',
                 value: this.fullRange,
                 action: () => {

--- a/entry/src/main/ets/service/streaming/NvHttp.ets
+++ b/entry/src/main/ets/service/streaming/NvHttp.ets
@@ -21,6 +21,10 @@ import { DEFAULT_HTTP_PORT, DEFAULT_HTTPS_PORT } from '../../common/NetworkConst
 import { parseAddressAndPort, formatAddressForUrl } from '../../utils/NetHelper';
 import { selectBestAddress, NvHttpHost } from '../../model/ComputerInfo';
 
+// HarmonyOS BrightnessInfo exposes peak/headroom but not the panel black level.
+// Match Sunshine's unknown-display fallback instead of inventing a raised black floor.
+export const DEFAULT_HDR_MIN_BRIGHTNESS_NITS: number = 0.001;
+
 /**
  * NvHTTP - 与 NVIDIA GameStream / Sunshine 服务器通信
  *
@@ -1111,7 +1115,7 @@ export class NvHttp {
     }
 
     // 客户端屏幕亮度范围（用于服务端 HDR tone mapping）
-    const minBrightness = config.minBrightness ?? 2;
+    const minBrightness = config.minBrightness ?? DEFAULT_HDR_MIN_BRIGHTNESS_NITS;
     const maxBrightness = config.maxBrightness ?? 500;
     const maxAvgBrightness = config.maxAverageBrightness ?? 200;
     params.push(`minBrightness=${minBrightness}`);

--- a/entry/src/main/ets/service/streaming/StreamingSession.ets
+++ b/entry/src/main/ets/service/streaming/StreamingSession.ets
@@ -12,7 +12,7 @@ import { StreamConfig, HdrMode, getSurroundAudioInfo } from '../../model/StreamC
 import { InputEvent, InputType, ControllerButtonEvent, ControllerAxisEvent, ControllerButton } from '../../model/InputEvent';
 import { ComputerManager } from '../ComputerManager';
 import { ComputerInfo, selectBestAddress } from '../../model/ComputerInfo';
-import { NvHttp, LaunchConfig } from './NvHttp';
+import { NvHttp, LaunchConfig, DEFAULT_HDR_MIN_BRIGHTNESS_NITS } from './NvHttp';
 import { CryptoUtil } from '../../utils/CryptoUtil';
 import { parseAddressAndPort, parseRtspSessionHost } from '../../utils/NetHelper';
 import { common, abilityAccessCtrl, bundleManager, Permissions } from '@kit.AbilityKit';
@@ -345,7 +345,7 @@ export class StreamingSession {
    * @returns [minBrightness, maxBrightness, maxAverageBrightness] (nits)
    */
   private static getBrightnessRange(): number[] {
-    let minBrightness = 2;
+    const minBrightness = DEFAULT_HDR_MIN_BRIGHTNESS_NITS;
     let maxBrightness = 500;
     let maxAverageBrightness = 200;
 
@@ -367,8 +367,10 @@ export class StreamingSession {
   }
 
   private static applyBrightnessOverride(range: number[], peakBrightnessNits: number): number[] {
-    const rawMinBrightness = range.length > 0 ? range[0] : 1;
-    const minBrightness = Math.max(1, Math.round(rawMinBrightness));
+    const rawMinBrightness = range.length > 0 ? range[0] : DEFAULT_HDR_MIN_BRIGHTNESS_NITS;
+    const minBrightness = Number.isFinite(rawMinBrightness) && rawMinBrightness > 0
+      ? rawMinBrightness
+      : DEFAULT_HDR_MIN_BRIGHTNESS_NITS;
     const peakBrightness = Math.max(minBrightness + 1, Math.max(300, Math.min(4000, Math.round(peakBrightnessNits))));
     const maxAverageBrightness = Math.max(minBrightness, Math.max(100, Math.min(1000, Math.round(peakBrightness * 0.2))));
     return [minBrightness, peakBrightness, maxAverageBrightness];

--- a/scripts/sunshine-mock-connection-test.js
+++ b/scripts/sunshine-mock-connection-test.js
@@ -23,6 +23,7 @@ const DEFAULT_HTTPS_PORT = 47984;
 const HOST = '127.0.0.1';
 const CLIENT_UNIQUE_ID = 'moonlight-harmony-test-client';
 const CLIENT_NAME = 'Moonlight-HarmonyOS-Test';
+const DEFAULT_HDR_MIN_BRIGHTNESS_NITS = 0.001;
 
 function xmlEscape(value) {
   return String(value)
@@ -675,7 +676,7 @@ class ConnectionModelClient {
       params.push('clientHdrCapDisplayData=0x0x0x0x0x0x0x0x0x0x0');
     }
 
-    params.push(`minBrightness=${config.minBrightness ?? 2}`);
+    params.push(`minBrightness=${config.minBrightness ?? DEFAULT_HDR_MIN_BRIGHTNESS_NITS}`);
     params.push(`maxBrightness=${config.maxBrightness ?? 500}`);
     params.push(`maxAverageBrightness=${config.maxAverageBrightness ?? 200}`);
 
@@ -965,6 +966,12 @@ async function testLaunchResumeQuitModel() {
     assert.strictEqual(launchRequest.query.display_name, 'DISPLAY\\GSM0001');
     assert.strictEqual(launchRequest.query.customScreenMode, '2');
     assert.strictEqual(launchRequest.query.maxBrightness, '1000');
+
+    const defaultBrightnessQuery = new URLSearchParams(client.buildLaunchQuery(1, {
+      ...config,
+      minBrightness: undefined
+    }));
+    assert.strictEqual(defaultBrightnessQuery.get('minBrightness'), '0.001');
 
     const resumeUrl = await client.resumeApp(config);
     assert.strictEqual(resumeUrl, 'rtsp://127.0.0.1:48010');

--- a/scripts/sunshine-mock-connection-test.js
+++ b/scripts/sunshine-mock-connection-test.js
@@ -951,7 +951,7 @@ async function testLaunchResumeQuitModel() {
       enableHdr: true,
       hdrMode: 2,
       displayGuid: 'DISPLAY\\GSM0001',
-      minBrightness: 1,
+      minBrightness: undefined,
       maxBrightness: 1000,
       maxAverageBrightness: 400,
       screenCombinationMode: 2
@@ -965,13 +965,8 @@ async function testLaunchResumeQuitModel() {
     assert.strictEqual(launchRequest.query.hdrMode, '2');
     assert.strictEqual(launchRequest.query.display_name, 'DISPLAY\\GSM0001');
     assert.strictEqual(launchRequest.query.customScreenMode, '2');
+    assert.strictEqual(launchRequest.query.minBrightness, '0.001');
     assert.strictEqual(launchRequest.query.maxBrightness, '1000');
-
-    const defaultBrightnessQuery = new URLSearchParams(client.buildLaunchQuery(1, {
-      ...config,
-      minBrightness: undefined
-    }));
-    assert.strictEqual(defaultBrightnessQuery.get('minBrightness'), '0.001');
 
     const resumeUrl = await client.resumeApp(config);
     assert.strictEqual(resumeUrl, 'rtsp://127.0.0.1:48010');


### PR DESCRIPTION
## 问题

鸿蒙的 `BrightnessInfo` 只提供峰值/动态范围，不提供面板最小亮度。客户端此前把未知黑位写成 `2 nit`，手动峰值覆盖还会把它至少取整到 `1 nit`；这些值映射到 Sunshine 虚拟显示器或物理显示器色彩配置后，会人为抬高内容黑位元数据，影响 HLG / HDR Vivid 输出。

## 修改

- 未知黑位统一回退到 Sunshine 同款 `0.001 nit`
- 手动峰值覆盖保留合法的小数黑位，不再强制取整到 `1 nit`
- 补充连接模型回归测试，确认 launch 查询发送 `minBrightness=0.001`
- 移除“HDR 推荐全范围”的过度表述，明确范围只需与服务端编码和解码器配置一致

## 验证

- `npm run check`
- `assembleHar`（nativelib，debug）
- `assembleApp`（project，debug）
- `git diff --check`

这次只修黑位元数据和设置说明，没去乱碰解码链路，杂鱼也能放心测啦。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改进**
  - 优化“视频设置”中 HDR 相关提示文案：调整 HLG 辅助说明，并让“全范围颜色”提示随 HDR 开关动态展示，强调与服务端编码范围一致。
  - 调整 HDR 最小亮度默认策略（更细的暗部表现），提升暗场显示稳定性并减少不必要的黑位偏差。
- **测试**
  - 更新连接与启动相关用例：当最小亮度未提供时，验证实际请求参数按新的默认值传递。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->