### PR TITLE
fix(haptics): 恢复按键触感并统一机身振动

### DIFF
--- a/entry/src/main/ets/components/CustomKeyConstants.ets
+++ b/entry/src/main/ets/components/CustomKeyConstants.ets
@@ -14,7 +14,7 @@
  * 编辑模式相关的颜色常量、预设色板、辅助接口和振动反馈函数。
  */
 
-import { vibrator } from '@kit.SensorServiceKit';
+import { DeviceVibrationCoordinator } from '../service/input/DeviceVibrationCoordinator';
 
 // =============================================================================
 // 接口
@@ -81,9 +81,7 @@ export function doKeyHaptic(level: string): void {
     case 'heavy': duration = 80; break;
     default: return;
   }
-  try {
-    vibrator.startVibration({ type: 'time', duration }, { id: 0, usage: 'touch' });
-  } catch (_e) { /* ignore */ }
+  DeviceVibrationCoordinator.getInstance().playTouchHaptic(duration);
 }
 
 // =============================================================================

--- a/entry/src/main/ets/components/SettingSlider.ets
+++ b/entry/src/main/ets/components/SettingSlider.ets
@@ -18,7 +18,7 @@
  * - 自定义格式化显示
  */
 import { AppColors, AppSizes } from '../common/Theme';
-import { vibrator } from '@kit.SensorServiceKit';
+import { DeviceVibrationCoordinator } from '../service/input/DeviceVibrationCoordinator';
 
 /**
  * 对数滑块转换工具类
@@ -142,17 +142,7 @@ export struct SettingSlider {
    * 使用 20ms 短促振动以获得清晰的"咔嗒"手感
    */
   private triggerSnapHaptic(): void {
-    try {
-      vibrator.startVibration({
-        type: 'time',
-        duration: 20
-      }, {
-        id: 0,
-        usage: 'touch'
-      })
-    } catch (_e) {
-      // 忽略振动失败
-    }
+    DeviceVibrationCoordinator.getInstance().playTouchHaptic(20);
   }
 
   /**

--- a/entry/src/main/ets/components/virtual/VirtualController.ets
+++ b/entry/src/main/ets/components/virtual/VirtualController.ets
@@ -14,7 +14,7 @@
  */
 import { InputEvent, InputType, ControllerButton, ControllerButtonEvent, ControllerAxis, ControllerAxisEvent } from '../../model/InputEvent';
 import { AnalogStick, AnalogStickConfig } from './AnalogStick';
-import { vibrator } from '@kit.SensorServiceKit';
+import { DeviceVibrationCoordinator } from '../../service/input/DeviceVibrationCoordinator';
 import { PreferencesUtil } from '../../utils/PreferencesUtil';
 import { display } from '@kit.ArkUI';
 
@@ -616,17 +616,7 @@ export struct VirtualController {
   }
   
   private triggerVibration(): void {
-    try {
-      vibrator.startVibration({
-        type: 'time',
-        duration: 30
-      }, {
-        id: 0,
-        usage: 'touch'
-      });
-    } catch (e) {
-      // 忽略震动错误
-    }
+    DeviceVibrationCoordinator.getInstance().playTouchHaptic(30);
   }
 
 }

--- a/entry/src/main/ets/components/virtual/VirtualKeyboard.ets
+++ b/entry/src/main/ets/components/virtual/VirtualKeyboard.ets
@@ -26,7 +26,7 @@
 import { picker } from '@kit.CoreFileKit';
 import { fileIo } from '@kit.CoreFileKit';
 import { PreferencesUtil } from '../../utils/PreferencesUtil';
-import { vibrator } from '@kit.SensorServiceKit';
+import { DeviceVibrationCoordinator } from '../../service/input/DeviceVibrationCoordinator';
 import { display } from '@kit.ArkUI';
 
 // =============================================================================
@@ -611,9 +611,7 @@ export struct VirtualKeyboard {
     if (touchType === TouchType.Down) {
       this.onVirtualKeyEvent(key.vk, true);
       // 触感反馈
-      try {
-        vibrator.startVibration({ type: 'time', duration: 20 }, { id: 0, usage: 'touch' });
-      } catch (_e) {}
+      DeviceVibrationCoordinator.getInstance().playTouchHaptic(20);
     } else if (touchType === TouchType.Up || touchType === TouchType.Cancel) {
       this.onVirtualKeyEvent(key.vk, false);
 

--- a/entry/src/main/ets/service/input/DeviceVibrationCoordinator.ets
+++ b/entry/src/main/ets/service/input/DeviceVibrationCoordinator.ets
@@ -25,8 +25,10 @@ export class DeviceVibrationCoordinator {
   private sourceVibratorId: number = 0;
 
   private touchHapticTimer: number = -1;
+  private touchHapticActive: boolean = false;
   private touchHapticEpoch: number = 0;
   private sourceEpoch: number = 0;
+  private vibrationQueue: Promise<void> = Promise.resolve();
   private sourceResumeCallback: (() => void) | null = null;
 
   static getInstance(): DeviceVibrationCoordinator {
@@ -46,39 +48,21 @@ export class DeviceVibrationCoordinator {
   }
 
   isTouchHapticActive(): boolean {
-    return this.touchHapticTimer !== -1;
+    return this.touchHapticActive;
   }
 
   playTouchHaptic(durationMs: number): void {
     const duration = Math.max(1, Math.min(1000, Math.round(durationMs)));
     const touchEpoch = ++this.touchHapticEpoch;
     this.sourceEpoch++;
+    this.touchHapticActive = true;
 
     if (this.touchHapticTimer !== -1) {
       clearTimeout(this.touchHapticTimer);
+      this.touchHapticTimer = -1;
     }
-    this.touchHapticTimer = setTimeout((): void => {
-      this.finishTouchHaptic(touchEpoch);
-    }, duration);
-
-    try {
-      // 同步停止可避免异步 stop 在新脉冲启动后才生效。
-      vibrator.stopVibrationSync();
-    } catch (_) { /* startVibration 仍可尝试替换当前效果 */ }
-
-    try {
-      vibrator.startVibration({
-        type: 'time',
-        duration: duration
-      }, this.createTouchVibrateAttribute()).catch((error: Error): void => {
-        if (touchEpoch !== this.touchHapticEpoch) return;
-        console.warn('[VIBRATION] 机身按键触感失败: ' + error.message);
-        this.finishTouchHaptic(touchEpoch);
-      });
-    } catch (error) {
-      console.warn('[VIBRATION] 机身按键触感异常:', error);
-      this.finishTouchHaptic(touchEpoch);
-    }
+    this.enqueueVibrationRequest((): Promise<void> =>
+      this.executeTouchHaptic(duration, touchEpoch));
   }
 
   startSourceVibration(effect: vibrator.VibrateEffect, usage: vibrator.Usage,
@@ -86,58 +70,127 @@ export class DeviceVibrationCoordinator {
     if (this.isTouchHapticActive()) return false;
 
     const sourceEpoch = ++this.sourceEpoch;
-    try {
-      vibrator.startVibration(
-        effect,
-        this.createSourceVibrateAttribute(usage)
-      ).catch((error: Error): void => {
-        if (sourceEpoch !== this.sourceEpoch || this.isTouchHapticActive()) return;
-        console.warn('[VIBRATION] 机身振动失败: ' + error.message);
-        if (onRejected !== undefined) onRejected();
-      });
-      return true;
-    } catch (error) {
-      console.warn('[VIBRATION] 机身振动异常:', error);
-      if (sourceEpoch === this.sourceEpoch && onRejected !== undefined) {
-        onRejected();
-      }
-      return false;
-    }
+    this.enqueueVibrationRequest((): Promise<void> =>
+      this.executeSourceVibration(effect, usage, sourceEpoch, onRejected));
+    return true;
   }
 
   stopSourceVibration(): void {
-    this.sourceEpoch++;
-    if (this.isTouchHapticActive()) return;
-    this.stopLocalVibration();
+    const sourceEpoch = ++this.sourceEpoch;
+    this.enqueueVibrationRequest((): Promise<void> =>
+      this.executeSourceStop(sourceEpoch));
   }
 
   stopAll(): void {
     this.sourceEpoch++;
     this.touchHapticEpoch++;
+    this.touchHapticActive = false;
     if (this.touchHapticTimer !== -1) {
       clearTimeout(this.touchHapticTimer);
       this.touchHapticTimer = -1;
     }
-    this.stopLocalVibration();
+    this.enqueueVibrationRequest((): Promise<void> => this.stopLocalVibration());
   }
 
   private finishTouchHaptic(touchEpoch: number): void {
-    if (touchEpoch !== this.touchHapticEpoch || this.touchHapticTimer === -1) return;
-    clearTimeout(this.touchHapticTimer);
+    if (touchEpoch !== this.touchHapticEpoch || !this.touchHapticActive) return;
+    if (this.touchHapticTimer !== -1) {
+      clearTimeout(this.touchHapticTimer);
+    }
     this.touchHapticTimer = -1;
+    this.touchHapticActive = false;
     this.sourceResumeCallback?.();
   }
 
-  private stopLocalVibration(): void {
+  private enqueueVibrationRequest(request: () => Promise<void>): void {
+    this.vibrationQueue = this.vibrationQueue
+      .then(request)
+      .catch((error: Error): void => {
+        console.warn('[VIBRATION] 机身振动队列异常: ' + error.message);
+      });
+  }
+
+  private executeTouchHaptic(duration: number, touchEpoch: number): Promise<void> {
+    if (touchEpoch !== this.touchHapticEpoch || !this.touchHapticActive) {
+      return Promise.resolve();
+    }
+
+    return this.stopLocalVibration().then((): Promise<void> => {
+      if (touchEpoch !== this.touchHapticEpoch || !this.touchHapticActive) {
+        return Promise.resolve();
+      }
+
+      try {
+        return vibrator.startVibration({
+          type: 'time',
+          duration: duration
+        }, this.createTouchVibrateAttribute()).then((): void => {
+          if (touchEpoch !== this.touchHapticEpoch || !this.touchHapticActive) return;
+          this.touchHapticTimer = setTimeout((): void => {
+            this.finishTouchHaptic(touchEpoch);
+          }, duration);
+        }).catch((error: Error): void => {
+          if (touchEpoch !== this.touchHapticEpoch || !this.touchHapticActive) return;
+          console.warn('[VIBRATION] 机身按键触感失败: ' + error.message);
+          this.finishTouchHaptic(touchEpoch);
+        });
+      } catch (error) {
+        console.warn('[VIBRATION] 机身按键触感异常:', error);
+        this.finishTouchHaptic(touchEpoch);
+        return Promise.resolve();
+      }
+    });
+  }
+
+  private executeSourceVibration(effect: vibrator.VibrateEffect, usage: vibrator.Usage,
+    sourceEpoch: number, onRejected?: () => void): Promise<void> {
+    if (sourceEpoch !== this.sourceEpoch || this.isTouchHapticActive()) {
+      return Promise.resolve();
+    }
+
+    try {
+      return vibrator.startVibration(
+        effect,
+        this.createSourceVibrateAttribute(usage)
+      ).then((): void => {
+        if (sourceEpoch !== this.sourceEpoch || this.isTouchHapticActive()) return;
+      }).catch((error: Error): void => {
+        if (sourceEpoch !== this.sourceEpoch || this.isTouchHapticActive()) return;
+        console.warn('[VIBRATION] 机身振动失败: ' + error.message);
+        if (onRejected !== undefined) onRejected();
+      });
+    } catch (error) {
+      console.warn('[VIBRATION] 机身振动异常:', error);
+      if (sourceEpoch === this.sourceEpoch &&
+          !this.isTouchHapticActive() &&
+          onRejected !== undefined) {
+        onRejected();
+      }
+      return Promise.resolve();
+    }
+  }
+
+  private executeSourceStop(sourceEpoch: number): Promise<void> {
+    if (sourceEpoch !== this.sourceEpoch || this.isTouchHapticActive()) {
+      return Promise.resolve();
+    }
+    return this.stopLocalVibration().then((): void => {
+      if (sourceEpoch !== this.sourceEpoch || this.isTouchHapticActive()) return;
+    });
+  }
+
+  private stopLocalVibration(): Promise<void> {
     try {
       vibrator.stopVibrationSync();
+      return Promise.resolve();
     } catch (_) {
       try {
-        vibrator.stopVibration().catch((error: Error): void => {
+        return vibrator.stopVibration().catch((error: Error): void => {
           console.warn('[VIBRATION] 停止机身振动失败: ' + error.message);
         });
       } catch (error) {
         console.warn('[VIBRATION] 停止机身振动异常:', error);
+        return Promise.resolve();
       }
     }
   }

--- a/entry/src/main/ets/service/input/DeviceVibrationCoordinator.ets
+++ b/entry/src/main/ets/service/input/DeviceVibrationCoordinator.ets
@@ -18,6 +18,7 @@ import { deviceInfo } from '@kit.BasicServicesKit';
  * 来源状态，脉冲结束后通过回调恢复最新的混合输出。
  */
 export class DeviceVibrationCoordinator {
+  private static readonly NATIVE_OPERATION_TIMEOUT_MS: number = 2000;
   private static instance: DeviceVibrationCoordinator;
 
   private hdHapticSupported: boolean | null = null;
@@ -121,10 +122,13 @@ export class DeviceVibrationCoordinator {
       }
 
       try {
-        return vibrator.startVibration({
-          type: 'time',
-          duration: duration
-        }, this.createTouchVibrateAttribute()).then((): void => {
+        return this.withNativeTimeout(
+          vibrator.startVibration({
+            type: 'time',
+            duration: duration
+          }, this.createTouchVibrateAttribute()),
+          '机身按键触感启动'
+        ).then((): void => {
           if (touchEpoch !== this.touchHapticEpoch || !this.touchHapticActive) return;
           this.touchHapticTimer = setTimeout((): void => {
             this.finishTouchHaptic(touchEpoch);
@@ -149,9 +153,12 @@ export class DeviceVibrationCoordinator {
     }
 
     try {
-      return vibrator.startVibration(
-        effect,
-        this.createSourceVibrateAttribute(usage)
+      return this.withNativeTimeout(
+        vibrator.startVibration(
+          effect,
+          this.createSourceVibrateAttribute(usage)
+        ),
+        '机身来源振动启动'
       ).then((): void => {
         if (sourceEpoch !== this.sourceEpoch || this.isTouchHapticActive()) return;
       }).catch((error: Error): void => {
@@ -185,7 +192,10 @@ export class DeviceVibrationCoordinator {
       return Promise.resolve();
     } catch (_) {
       try {
-        return vibrator.stopVibration().catch((error: Error): void => {
+        return this.withNativeTimeout(
+          vibrator.stopVibration(),
+          '机身振动停止'
+        ).catch((error: Error): void => {
           console.warn('[VIBRATION] 停止机身振动失败: ' + error.message);
         });
       } catch (error) {
@@ -193,6 +203,30 @@ export class DeviceVibrationCoordinator {
         return Promise.resolve();
       }
     }
+  }
+
+  private withNativeTimeout(operation: Promise<void>, operationName: string): Promise<void> {
+    return new Promise<void>((resolve, reject): void => {
+      let settled: boolean = false;
+      const timeoutId: number = setTimeout((): void => {
+        if (settled) return;
+        settled = true;
+        console.warn('[VIBRATION] ' + operationName + '超时，继续处理后续请求');
+        resolve();
+      }, DeviceVibrationCoordinator.NATIVE_OPERATION_TIMEOUT_MS);
+
+      operation.then((): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeoutId);
+        resolve();
+      }).catch((error: Error): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeoutId);
+        reject(error);
+      });
+    });
   }
 
   private createTouchVibrateAttribute(): vibrator.VibrateAttribute {

--- a/entry/src/main/ets/service/input/DeviceVibrationCoordinator.ets
+++ b/entry/src/main/ets/service/input/DeviceVibrationCoordinator.ets
@@ -1,0 +1,191 @@
+/*
+ * Moonlight for HarmonyOS
+ * Copyright (C) 2024-2025 Moonlight/AlkaidLab
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import { vibrator } from '@kit.SensorServiceKit';
+import { deviceInfo } from '@kit.BasicServicesKit';
+
+/**
+ * 统一协调所有机身马达写入。
+ *
+ * 按键触感只使用本机默认马达，并在脉冲期间临时独占执行器。游戏和音频仍可更新
+ * 来源状态，脉冲结束后通过回调恢复最新的混合输出。
+ */
+export class DeviceVibrationCoordinator {
+  private static instance: DeviceVibrationCoordinator;
+
+  private hdHapticSupported: boolean | null = null;
+  private sourceVibratorDeviceId: number | null = null;
+  private sourceVibratorId: number = 0;
+
+  private touchHapticTimer: number = -1;
+  private touchHapticEpoch: number = 0;
+  private sourceEpoch: number = 0;
+  private sourceResumeCallback: (() => void) | null = null;
+
+  static getInstance(): DeviceVibrationCoordinator {
+    if (!DeviceVibrationCoordinator.instance) {
+      DeviceVibrationCoordinator.instance = new DeviceVibrationCoordinator();
+    }
+    return DeviceVibrationCoordinator.instance;
+  }
+
+  setSourceResumeCallback(callback: () => void): void {
+    this.sourceResumeCallback = callback;
+  }
+
+  isHdHapticSupported(): boolean {
+    this.ensureSourceVibrator();
+    return this.hdHapticSupported ?? false;
+  }
+
+  isTouchHapticActive(): boolean {
+    return this.touchHapticTimer !== -1;
+  }
+
+  playTouchHaptic(durationMs: number): void {
+    const duration = Math.max(1, Math.min(1000, Math.round(durationMs)));
+    const touchEpoch = ++this.touchHapticEpoch;
+    this.sourceEpoch++;
+
+    if (this.touchHapticTimer !== -1) {
+      clearTimeout(this.touchHapticTimer);
+    }
+    this.touchHapticTimer = setTimeout((): void => {
+      this.finishTouchHaptic(touchEpoch);
+    }, duration);
+
+    try {
+      // 同步停止可避免异步 stop 在新脉冲启动后才生效。
+      vibrator.stopVibrationSync();
+    } catch (_) { /* startVibration 仍可尝试替换当前效果 */ }
+
+    try {
+      vibrator.startVibration({
+        type: 'time',
+        duration: duration
+      }, this.createTouchVibrateAttribute()).catch((error: Error): void => {
+        if (touchEpoch !== this.touchHapticEpoch) return;
+        console.warn('[VIBRATION] 机身按键触感失败: ' + error.message);
+        this.finishTouchHaptic(touchEpoch);
+      });
+    } catch (error) {
+      console.warn('[VIBRATION] 机身按键触感异常:', error);
+      this.finishTouchHaptic(touchEpoch);
+    }
+  }
+
+  startSourceVibration(effect: vibrator.VibrateEffect, usage: vibrator.Usage,
+    onRejected?: () => void): boolean {
+    if (this.isTouchHapticActive()) return false;
+
+    const sourceEpoch = ++this.sourceEpoch;
+    try {
+      vibrator.startVibration(
+        effect,
+        this.createSourceVibrateAttribute(usage)
+      ).catch((error: Error): void => {
+        if (sourceEpoch !== this.sourceEpoch || this.isTouchHapticActive()) return;
+        console.warn('[VIBRATION] 机身振动失败: ' + error.message);
+        if (onRejected !== undefined) onRejected();
+      });
+      return true;
+    } catch (error) {
+      console.warn('[VIBRATION] 机身振动异常:', error);
+      if (sourceEpoch === this.sourceEpoch && onRejected !== undefined) {
+        onRejected();
+      }
+      return false;
+    }
+  }
+
+  stopSourceVibration(): void {
+    this.sourceEpoch++;
+    if (this.isTouchHapticActive()) return;
+    this.stopLocalVibration();
+  }
+
+  stopAll(): void {
+    this.sourceEpoch++;
+    this.touchHapticEpoch++;
+    if (this.touchHapticTimer !== -1) {
+      clearTimeout(this.touchHapticTimer);
+      this.touchHapticTimer = -1;
+    }
+    this.stopLocalVibration();
+  }
+
+  private finishTouchHaptic(touchEpoch: number): void {
+    if (touchEpoch !== this.touchHapticEpoch || this.touchHapticTimer === -1) return;
+    clearTimeout(this.touchHapticTimer);
+    this.touchHapticTimer = -1;
+    this.sourceResumeCallback?.();
+  }
+
+  private stopLocalVibration(): void {
+    try {
+      vibrator.stopVibrationSync();
+    } catch (_) {
+      try {
+        vibrator.stopVibration().catch((error: Error): void => {
+          console.warn('[VIBRATION] 停止机身振动失败: ' + error.message);
+        });
+      } catch (error) {
+        console.warn('[VIBRATION] 停止机身振动异常:', error);
+      }
+    }
+  }
+
+  private createTouchVibrateAttribute(): vibrator.VibrateAttribute {
+    // 不设置 deviceId 即表示本机；id 0 与 touch 保持原有按键触感语义。
+    return {
+      id: 0,
+      usage: 'touch'
+    };
+  }
+
+  private createSourceVibrateAttribute(usage: vibrator.Usage): vibrator.VibrateAttribute {
+    this.ensureSourceVibrator();
+    const attribute: vibrator.VibrateAttribute = {
+      id: this.sourceVibratorId,
+      usage: usage
+    };
+    if (deviceInfo.sdkApiVersion >= 19 && this.sourceVibratorDeviceId !== null) {
+      attribute.deviceId = this.sourceVibratorDeviceId;
+    }
+    return attribute;
+  }
+
+  private ensureSourceVibrator(): void {
+    if (this.hdHapticSupported !== null) return;
+    if (deviceInfo.sdkApiVersion < 18) {
+      this.hdHapticSupported = false;
+      return;
+    }
+
+    try {
+      this.hdHapticSupported = vibrator.isHdHapticSupported();
+      if (deviceInfo.sdkApiVersion >= 19) {
+        const localVibrators = vibrator.getVibratorInfoSync()
+          .filter((info: vibrator.VibratorInfo): boolean => info.isLocalVibrator);
+        const localVibrator = localVibrators
+          .find((info: vibrator.VibratorInfo): boolean => info.isHdHapticSupported) ?? localVibrators[0];
+        if (localVibrator !== undefined) {
+          this.sourceVibratorDeviceId = localVibrator.deviceId;
+          this.sourceVibratorId = localVibrator.vibratorId;
+          this.hdHapticSupported = localVibrator.isHdHapticSupported;
+        }
+      }
+      console.info('[VIBRATION] 本地高清振动支持: ' + this.hdHapticSupported);
+    } catch (error) {
+      console.warn('[VIBRATION] 查询本地马达失败:', error);
+      this.hdHapticSupported = false;
+    }
+  }
+}

--- a/entry/src/main/ets/service/input/GamepadVibrationService.ets
+++ b/entry/src/main/ets/service/input/GamepadVibrationService.ets
@@ -18,10 +18,10 @@
  */
 
 import { vibrator } from '@kit.SensorServiceKit';
-import { deviceInfo } from '@kit.BasicServicesKit';
 import { UsbDriverService, AbstractController } from '../usbdriver/index';
 import { AudioHapticFrameFlag } from '../AudioHapticFrame';
 import { RUMBLE_MAX } from './GamepadTypes';
+import { DeviceVibrationCoordinator } from './DeviceVibrationCoordinator';
 import {
   GAME_VIBRATION_STRENGTH_DEFAULT,
   GAME_VIBRATION_STRENGTH_ORIGINAL,
@@ -47,6 +47,7 @@ export class GamepadVibrationService {
   private static readonly MUSIC_RHYTHM_MINIMUM_INTENSITY = 70;
   private static readonly MUSIC_TRANSIENT_MINIMUM_INTENSITY = 72;
   private usbDriverService: UsbDriverService;
+  private deviceVibrationCoordinator: DeviceVibrationCoordinator;
   
   // 设置
   private vibrationFeedbackEnabled = true;
@@ -56,10 +57,6 @@ export class GamepadVibrationService {
   // 槽位→设备键的查找函数（由 GamepadManager 提供）
   private deviceKeyToSlotLookup: Map<string, number>;
   
-  // 高清振动支持缓存
-  private hdHapticSupported: boolean | null = null;
-  private localVibratorDeviceId: number | null = null;
-  private localVibratorId: number = 0;
   // 上次震动参数缓存（用于检测变化）
   private lastLowFreq: number = 0;
   private lastHighFreq: number = 0;
@@ -89,6 +86,10 @@ export class GamepadVibrationService {
   constructor(usbDriverService: UsbDriverService, deviceKeyToSlot: Map<string, number>) {
     this.usbDriverService = usbDriverService;
     this.deviceKeyToSlotLookup = deviceKeyToSlot;
+    this.deviceVibrationCoordinator = DeviceVibrationCoordinator.getInstance();
+    this.deviceVibrationCoordinator.setSourceResumeCallback((): void => {
+      this.renderMixedDevice(false);
+    });
   }
 
   // ==================== 设置 ====================
@@ -262,9 +263,8 @@ export class GamepadVibrationService {
     this.lastLowFreq = 0;
     this.lastHighFreq = 0;
 
-    if (this.isVibrating) {
-      this.stopVibrationImmediate();
-    }
+    this.deviceVibrationCoordinator.stopAll();
+    this.isVibrating = false;
 
     try {
       const controllers = this.usbDriverService.getControllers();
@@ -450,8 +450,10 @@ export class GamepadVibrationService {
         gameIntensity, this.audioDeviceTransient, 100)
       : 0;
 
-    this.ensureHdHapticSupport();
-    const minimumTransientIntensity = this.hdHapticSupported
+    if (this.deviceVibrationCoordinator.isTouchHapticActive()) return;
+
+    const hdHapticSupported = this.deviceVibrationCoordinator.isHdHapticSupported();
+    const minimumTransientIntensity = hdHapticSupported
       ? 1
       : GamepadVibrationService.MINIMUM_DEVICE_INTENSITY;
     if (mixedContinuous < GamepadVibrationService.MINIMUM_DEVICE_INTENSITY &&
@@ -462,7 +464,7 @@ export class GamepadVibrationService {
     }
 
     try {
-      if (this.hdHapticSupported) {
+      if (hdHapticSupported) {
         this.triggerMixedPattern(
           lowIntensity,
           highIntensity,
@@ -488,15 +490,7 @@ export class GamepadVibrationService {
    */
   private stopVibrationImmediate(): void {
     this.deviceRenderEpoch++;
-    try {
-      // 优先使用同步停止 API (API 12+)
-      vibrator.stopVibrationSync();
-    } catch (_) {
-      // 回退到异步停止
-      try {
-        vibrator.stopVibration();
-      } catch (_) { /* ignore */ }
-    }
+    this.deviceVibrationCoordinator.stopSourceVibration();
     this.isVibrating = false;
   }
 
@@ -549,10 +543,10 @@ export class GamepadVibrationService {
       }
     }
 
-    vibrator.startVibration({
+    this.deviceVibrationCoordinator.startSourceVibration({
       type: 'pattern',
       pattern: builder.build()
-    }, this.createVibrateAttribute(gameActive)).catch((_: Error): void => {
+    }, gameActive ? 'physicalFeedback' : 'media', (): void => {
       this.triggerMixedTimeFallback(
         mixedContinuous, mixedTransient, hasAudioTransient, renderEpoch);
     });
@@ -607,24 +601,10 @@ export class GamepadVibrationService {
     }
 
     const gameActive = this.gameDeviceLow > 0 || this.gameDeviceHigh > 0;
-    vibrator.startVibration({
+    this.deviceVibrationCoordinator.startSourceVibration({
       type: 'time',
       duration: duration
-    }, this.createVibrateAttribute(gameActive)).catch((err: Error): void => {
-      console.warn(`[VIBRATION] 时长震动失败: ${err.message}`);
-    });
-  }
-
-  private createVibrateAttribute(gameActive: boolean): vibrator.VibrateAttribute {
-    const attribute: vibrator.VibrateAttribute = {
-      id: this.localVibratorId,
-      usage: gameActive ? 'physicalFeedback' : 'media'
-    };
-    if (deviceInfo.sdkApiVersion >= 19 &&
-        this.localVibratorDeviceId !== null) {
-      attribute.deviceId = this.localVibratorDeviceId;
-    }
-    return attribute;
+    }, gameActive ? 'physicalFeedback' : 'media');
   }
 
   private getAudioContinuousLeaseMs(scene: number): number {
@@ -638,8 +618,7 @@ export class GamepadVibrationService {
    * 时长回退马达需要更高的幅度下限与稍长脉冲，才能稳定感知弱节拍。
    */
   private applyMusicTransientPolicy(frameFlags: AudioHapticFrameFlag): void {
-    this.ensureHdHapticSupport();
-    if (this.hdHapticSupported) {
+    if (this.deviceVibrationCoordinator.isHdHapticSupported()) {
       this.audioDeviceTransientDurationMs = Math.round(Math.max(
         28, Math.min(34, this.audioDeviceTransientDurationMs * 0.58)));
       return;
@@ -670,30 +649,4 @@ export class GamepadVibrationService {
         this.audioDeviceTransientDurationMs * durationScale)));
   }
 
-  private ensureHdHapticSupport(): void {
-    if (this.hdHapticSupported !== null) return;
-    if (deviceInfo.sdkApiVersion < 18) {
-      this.hdHapticSupported = false;
-      return;
-    }
-    try {
-      this.hdHapticSupported = vibrator.isHdHapticSupported();
-      if (deviceInfo.sdkApiVersion >= 19) {
-        const localVibrators = vibrator.getVibratorInfoSync()
-          .filter((info: vibrator.VibratorInfo): boolean =>
-            info.isLocalVibrator);
-        const localVibrator = localVibrators
-          .find((info: vibrator.VibratorInfo): boolean =>
-            info.isHdHapticSupported) ?? localVibrators[0];
-        if (localVibrator !== undefined) {
-          this.localVibratorDeviceId = localVibrator.deviceId;
-          this.localVibratorId = localVibrator.vibratorId;
-          this.hdHapticSupported = localVibrator.isHdHapticSupported;
-        }
-      }
-      console.info(`[VIBRATION] 高清振动支持: ${this.hdHapticSupported}`);
-    } catch (_) {
-      this.hdHapticSupported = false;
-    }
-  }
 }


### PR DESCRIPTION
## 改了啥呀

- 新增统一机身振动协调器，集中管理按键、游戏和音频对机身马达的写入
- 将虚拟手柄、虚拟键盘、自定义按键和设置滑块接入协调器
- 按键触感固定走本机默认马达，保留原来的 `id 0 + usage: touch + time` 语义和持续时间
- 按键脉冲期间暂缓游戏/音频机身输出，结束后恢复最新有效状态
- USB/手柄 `rumble()` 路径保持不变，不会被按键触感偷偷带跑呀

## 为啥要改

多个调用点各自直写同一机身马达时，连续游戏或音频振动可能覆盖短促的按键触感。现在把这只会吞触感的杂鱼竞态收进统一协调器，按键优先级和恢复时机都有明确边界。

## 验证

- `npm run check`
- `node hvigorw.js default@CompileArkTS --mode module -p module=entry -p product=default -p buildMode=debug --no-daemon`（API 24 SDK + JDK 17）
- `git diff --check`
- 确认业务代码中的 `startVibration` / `stopVibration` 只保留在协调器内

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增统一的设备振动协调机制：在触觉反馈期间独占并完成后恢复来源振动。
  - 根据设备能力自动判断并启用高清振动能力（按需降级）。
- **体验优化**
  - 按键、滑块、虚拟键盘与虚拟控制器的触觉反馈更一致稳定。
  - 触觉与游戏手柄振动的冲突显著减少，停止/恢复流程更可靠（含立即停止与全量停止）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->