### PR TITLE
feat(input): make three-finger IME gesture optional

### DIFF
--- a/entry/src/main/ets/pages/SettingsPageV2.ets
+++ b/entry/src/main/ets/pages/SettingsPageV2.ets
@@ -216,6 +216,7 @@ struct SettingsPageV2 {
   // 输入 - 鼠标/触控
   @State showLocalCursor: boolean = false;   // 显示本地指针（双光标模式）
   @State touchscreenTrackpad: boolean = false;
+  @State enableThreeFingerIme: boolean = true;
   @State lowLatencyTouch: boolean = false;
   @State enableDoubleClickDrag: boolean = false;
   @State doubleTapTimeThreshold: number = 125;
@@ -568,6 +569,7 @@ struct SettingsPageV2 {
       // 输入 - 鼠标/触控
       this.showLocalCursor = await this.loadBoolean(SettingsKeys.SHOW_LOCAL_CURSOR, false);
       this.touchscreenTrackpad = await this.loadBoolean(SettingsKeys.TOUCHSCREEN_TRACKPAD, false);
+      this.enableThreeFingerIme = await this.loadBoolean(SettingsKeys.ENABLE_THREE_FINGER_IME, true);
       this.lowLatencyTouch = await this.loadBoolean(SettingsKeys.LOW_LATENCY_TOUCH, false);
       this.enableDoubleClickDrag = await this.loadBoolean(SettingsKeys.ENABLE_DOUBLE_CLICK_DRAG, false);
       this.doubleTapTimeThreshold = await PreferencesUtil.get<number>(SettingsKeys.DOUBLE_TAP_TIME_THRESHOLD, 125);
@@ -1751,6 +1753,16 @@ struct SettingsPageV2 {
                   this.saveSetting(SettingsKeys.TOUCHSCREEN_TRACKPAD, this.touchscreenTrackpad);
                   // 清除菜单中选择的触摸模式，使设置页的选项在下次串流时生效
                   this.saveSetting(SettingsKeys.LAST_TOUCH_MODE, '');
+                }
+              },
+              {
+                title: '三指唤出输入法',
+                subtitle: '三指同时触摸时打开系统输入法，关闭后触摸将发送到主机',
+                type: 'toggle',
+                value: this.enableThreeFingerIme,
+                action: () => {
+                  this.enableThreeFingerIme = !this.enableThreeFingerIme;
+                  this.saveSetting(SettingsKeys.ENABLE_THREE_FINGER_IME, this.enableThreeFingerIme);
                 }
               },
               {

--- a/entry/src/main/ets/pages/StreamPage.ets
+++ b/entry/src/main/ets/pages/StreamPage.ets
@@ -1948,11 +1948,14 @@ struct StreamPage {
   /**
    * 处理本地系统触摸手势。
    *
-   * 三指同时触摸用于唤出 HarmonyOS IME，优先于远端触摸输入和双指缩放。
+   * 启用三指输入法手势后，三指同时触摸用于唤出 HarmonyOS IME，
+   * 优先于远端触摸输入和双指缩放。
    * 触发后持续吞掉本组三指，避免远端收到半截多指触摸或鼠标拖拽。
    */
   private handleSystemTouchGesture(event: TouchEvent): boolean {
-    const result = this.threeFingerImeGestureHandler.handleTouchEvent(event, this.viewModel.isConnected);
+    const enableThreeFingerIme = this.viewModel.inputSettings?.enableThreeFingerIme ?? true;
+    const result = this.threeFingerImeGestureHandler.handleTouchEvent(
+      event, enableThreeFingerIme && this.viewModel.isConnected);
     if (result === ThreeFingerImeGestureResult.TRIGGERED) {
       this.touchInputHandler.cancelActiveInput();
       this.panZoomHandler.cancelActiveGesture();

--- a/entry/src/main/ets/service/SettingsService.ets
+++ b/entry/src/main/ets/service/SettingsService.ets
@@ -110,6 +110,7 @@ export class SettingsKeys {
   // 输入 - 鼠标/触控
   static readonly SHOW_LOCAL_CURSOR: string = 'settings_show_local_cursor';
   static readonly TOUCHSCREEN_TRACKPAD: string = 'settings_touchscreen_trackpad';
+  static readonly ENABLE_THREE_FINGER_IME: string = 'settings_enable_three_finger_ime';
   static readonly LOW_LATENCY_TOUCH: string = 'settings_low_latency_touch';
   static readonly ENABLE_DOUBLE_CLICK_DRAG: string = 'settings_enable_double_click_drag';
   static readonly DOUBLE_TAP_TIME_THRESHOLD: string = 'settings_double_tap_time_threshold';
@@ -227,6 +228,7 @@ export interface InputSettings {
   // 鼠标/触控
   showLocalCursor: boolean;
   touchscreenTrackpad: boolean;
+  enableThreeFingerIme: boolean;
   lowLatencyTouch: boolean;
   enableDoubleClickDrag: boolean;
   doubleTapTimeThreshold: number;
@@ -807,6 +809,7 @@ export class SettingsService {
       // 鼠标/触控
       showLocalCursor: await this.getBoolean(SettingsKeys.SHOW_LOCAL_CURSOR, false),
       touchscreenTrackpad: await this.getBoolean(SettingsKeys.TOUCHSCREEN_TRACKPAD, false),
+      enableThreeFingerIme: await this.getBoolean(SettingsKeys.ENABLE_THREE_FINGER_IME, true),
       lowLatencyTouch: await this.getBoolean(SettingsKeys.LOW_LATENCY_TOUCH, false),
       enableDoubleClickDrag: await this.getBoolean(SettingsKeys.ENABLE_DOUBLE_CLICK_DRAG, false),
       doubleTapTimeThreshold: await this.getNumber(SettingsKeys.DOUBLE_TAP_TIME_THRESHOLD, 125),

--- a/nativelib/src/main/cpp/CMakeLists.txt
+++ b/nativelib/src/main/cpp/CMakeLists.txt
@@ -110,6 +110,7 @@ set(SOURCE_FILES
 set(MOONLIGHT_COMMON_SOURCES
     ${MOONLIGHT_COMMON_PATH}/src/Connection.c
     ${MOONLIGHT_COMMON_PATH}/src/ControlStream.c
+    ${MOONLIGHT_COMMON_PATH}/src/CursorStream.c
     ${MOONLIGHT_COMMON_PATH}/src/VideoStream.c
     ${MOONLIGHT_COMMON_PATH}/src/AudioStream.c
     ${MOONLIGHT_COMMON_PATH}/src/InputStream.c


### PR DESCRIPTION
## 改了啥呀

- 在「设置 → 鼠标和触控」增加「三指唤出输入法」开关，默认开启并持久化
- 关闭后不再让本地 IME 手势抢走三指触摸，触摸事件继续交给当前串流输入链路
- 更新 moonlight-common-c 到 `7bfa0c1`，同步 HEVC SEI 保留和本地光标形状协议
- 将新增的 `CursorStream.c` 纳入 HarmonyOS 原生构建，收拾掉漏接源文件导致的杂鱼链接错误

## 为啥要改

三指唤出输入法对需要键盘输入的场景很方便，但也可能与主机端三指操作冲突。现在保留原有默认行为，同时让不需要它的用户可以明确关闭；关闭后不会再吞掉这一组触摸。

common-c 已经增加了本地光标形状协议，主工程又是手工维护源文件列表，所以同步子模块时也必须把新增实现加入构建，不然只更新 gitlink 会在链接阶段缺符号啦。

## 验证

- `npm run check`
- `git diff --check`
- `DEVECO_SDK_HOME=/Applications/DevEco-Studio.app/Contents/sdk JAVA_HOME=/Applications/DevEco-Studio.app/Contents/jbr/Contents/Home PATH=/Applications/DevEco-Studio.app/Contents/jbr/Contents/Home/bin:/Users/mac/.nvm/versions/node/v20.20.1/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin node hvigorw.js assembleApp --mode project -p product=default -p buildMode=debug --no-daemon`
- DevEco Hvigor 完整 Debug 构建成功
- common-c `cursor-protocol-golden-tests`：1/1 通过


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增“三指唤出输入法”设置，默认启用，支持在鼠标/触控设置中随时切换并保存。
  * 三指手势仅在启用设置且已连接串流时生效。
* **改进**
  * 完善光标相关功能支持，提升串流操作体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->