### PR TITLE
fix(input): repair DualSense motion forwarding

### DIFF
--- a/entry/src/main/ets/pages/StreamPage.ets
+++ b/entry/src/main/ets/pages/StreamPage.ets
@@ -477,9 +477,9 @@ struct StreamPage {
       onGamepadInput: (deviceId: number, state: GamepadState) => {
         this.handleGamepadInput(deviceId, state);
       },
-      onGamepadCapabilitiesChanged: (deviceId: number, controllerType: number) => {
-        this.controllerTypes.set(deviceId, controllerType);
-        this.viewModel.refreshGamepadCapabilities(deviceId, controllerType);
+      onGamepadCapabilitiesChanged: (slotId: number, controllerType: number) => {
+        this.controllerTypes.set(slotId, controllerType);
+        this.viewModel.refreshGamepadCapabilities(slotId, controllerType);
       }
     });
 

--- a/entry/src/main/ets/pages/StreamPage.ets
+++ b/entry/src/main/ets/pages/StreamPage.ets
@@ -476,6 +476,10 @@ struct StreamPage {
       },
       onGamepadInput: (deviceId: number, state: GamepadState) => {
         this.handleGamepadInput(deviceId, state);
+      },
+      onGamepadCapabilitiesChanged: (deviceId: number, controllerType: number) => {
+        this.controllerTypes.set(deviceId, controllerType);
+        this.viewModel.refreshGamepadCapabilities(deviceId, controllerType);
       }
     });
 

--- a/entry/src/main/ets/service/input/GamepadManager.ets
+++ b/entry/src/main/ets/service/input/GamepadManager.ets
@@ -1256,6 +1256,8 @@ export class GamepadManager implements UsbDriverListener {
           if (existSlot !== undefined) {
             this.gcDeviceIdToSlot.set(deviceId, existSlot);
             this.gcDeviceStates.set(deviceId, this.gcDeviceStates.get(existingDeviceId) || this.createEmptyState());
+            this.gcDeviceInfoCache.set(deviceId, info);
+            this.refreshUsbControllerMappings();
           }
           return;
         }
@@ -1283,6 +1285,8 @@ export class GamepadManager implements UsbDriverListener {
             console.info(`[GAMEPAD-GC] 跳过重复设备(名称+产品ID): deviceId=${deviceId} -> 已有设备 ${existId} (name=${info?.name}, product=${info?.product})`);
             this.gcDeviceIdToSlot.set(deviceId, existSlot);
             this.gcDeviceStates.set(deviceId, this.gcDeviceStates.get(existId) || this.createEmptyState());
+            this.gcDeviceInfoCache.set(deviceId, info);
+            this.refreshUsbControllerMappings();
             return;
           }
         }
@@ -1360,12 +1364,21 @@ export class GamepadManager implements UsbDriverListener {
       this.gcDpadAxisActive.delete(deviceId);
       this.gcAxisFlushPending.delete(slot);
       this.gcDeviceIdToSlot.delete(deviceId);
-      this.refreshUsbControllerMappings();
       
       if (isSharedSlotDevice) {
+        // 主接口断开时，将物理地址索引提升到仍占用该槽位的接口。
+        this.gcDeviceIdToSlot.forEach((survivorSlot: number, survivorId: string) => {
+          if (survivorSlot !== slot) return;
+          const survivorAddress = this.gcDeviceInfoCache.get(survivorId)?.physicalAddress || '';
+          if (survivorAddress.length > 0) {
+            this.gcPhysicalAddressToDeviceId.set(survivorAddress, survivorId);
+          }
+        });
+        this.refreshUsbControllerMappings();
         console.info(`[GAMEPAD-GC] 副本设备断开: deviceId=${deviceId}, 主设备仍在，不通知断开`);
         return;
       }
+      this.refreshUsbControllerMappings();
       
       // 释放槽位：此时 deviceId 映射已移除，使用断开前保存的 slot 显式释放。
       this.releaseKnownSlot(deviceId, slot, this.gcDeviceIdToSlot, 'GAMEPAD-GC');
@@ -1858,18 +1871,24 @@ export class GamepadManager implements UsbDriverListener {
         if (normalized.length > 0) identifiers.add(normalized);
       }
 
-      const matches: string[] = [];
+      const matchingSlots = new Set<number>();
+      const representativeBySlot = new Map<number, string>();
       this.gcDeviceInfoCache.forEach((info: GameControllerDeviceInfo, gcDeviceId: string) => {
         const physicalAddress = this.normalizePhysicalDeviceIdentifier(info.physicalAddress || '');
-        if (physicalAddress.length > 0 && identifiers.has(physicalAddress) &&
-          this.gcDeviceIdToSlot.has(gcDeviceId)) {
-          matches.push(gcDeviceId);
+        const slot = this.gcDeviceIdToSlot.get(gcDeviceId);
+        if (physicalAddress.length > 0 && identifiers.has(physicalAddress) && slot !== undefined) {
+          matchingSlots.add(slot);
+          if (!representativeBySlot.has(slot)) representativeBySlot.set(slot, gcDeviceId);
         }
       });
 
-      if (matches.length === 1) {
-        this.usbControllerIdToGcDeviceId.set(controller.getControllerId(), matches[0]);
-      } else if (matches.length > 1) {
+      if (matchingSlots.size === 1) {
+        const slot = Array.from(matchingSlots)[0];
+        const representative = representativeBySlot.get(slot);
+        if (representative !== undefined) {
+          this.usbControllerIdToGcDeviceId.set(controller.getControllerId(), representative);
+        }
+      } else if (matchingSlots.size > 1) {
         console.warn(`[GAMEPAD-USB] 物理设备映射不唯一，忽略附加输入: ID=${controller.getControllerId()}`);
       }
     }
@@ -2434,6 +2453,11 @@ export class GamepadManager implements UsbDriverListener {
       this.usbDeviceKeyToId.set(deviceKey, controllerId);
       this.controllerIdToDeviceKey.set(controllerId, deviceKey);
       this.refreshUsbControllerMappings();
+      const slot = this.getUsbControllerSlot(controller);
+      if (slot !== undefined) {
+        const controllerType = MoonlightControllerType.fromVendorProduct(vendorId, productId);
+        this.listener?.onGamepadCapabilitiesChanged?.(slot, controllerType);
+      }
       this.vibrationService.rerenderAllSources();
       console.info(`[GAMEPAD-USB] 混合模式: 记录 USB 设备用于震动: ${name} (ID=${controllerId})`);
       return;

--- a/entry/src/main/ets/service/input/GamepadManager.ets
+++ b/entry/src/main/ets/service/input/GamepadManager.ets
@@ -9,7 +9,10 @@
  */
 
 import { inputDevice } from '@kit.InputKit';
-import { UsbDriverService, UsbDriverListener, AbstractController, ButtonFlags, KnownUsbGamepadInfo } from '../usbdriver/index';
+import {
+  UsbDriverService, UsbDriverListener, AbstractController, ButtonFlags,
+  ControllerCapabilities, KnownUsbGamepadInfo
+} from '../usbdriver/index';
 import {
   gameControllerService, 
   AxisType, 
@@ -91,6 +94,8 @@ export class GamepadManager implements UsbDriverListener {
   
   // 传感器数据发送回调（由 StreamingSession 设置）
   private sensorDataCallback: ((controllerNumber: number, motionType: number, x: number, y: number, z: number) => void) | null = null;
+  /** 主机当前请求的物理手柄传感器，key 为 "controllerNumber:motionType"。 */
+  private requestedPhysicalMotion = new Set<string>();
 
   // 触摸板鼠标模拟
   private touchpadMouseEnabled: boolean = false;
@@ -2046,8 +2051,10 @@ export class GamepadManager implements UsbDriverListener {
     y: number,
     z: number
   ): void {
+    if (!this.gamepadMotionSensorsEnabled) return;
+
     const slot = this.getControllerSlot(controllerId);
-    if (this.sensorDataCallback) {
+    if (this.requestedPhysicalMotion.has(`${slot}:${motionType}`) && this.sensorDataCallback) {
       this.sensorDataCallback(slot, motionType, x, y, z);
     }
   }
@@ -2196,8 +2203,32 @@ export class GamepadManager implements UsbDriverListener {
       return;
     }
 
-    // DS4 等自带 IMU 的手柄已在驱动层（如 Dualshock4Controller）主动推送运动数据，
-    // 无需在此处查询；Xbox/Switch 等无 IMU 手柄则依赖下方设备传感器回退。
+    const requestedCapability = motionType === LI_MOTION_TYPE_ACCEL
+      ? ControllerCapabilities.ACCEL
+      : motionType === LI_MOTION_TYPE_GYRO
+        ? ControllerCapabilities.GYRO
+        : 0;
+    if (requestedCapability === 0) {
+      console.warn(`[GAMEPAD] 未知传感器类型: ${motionType}`);
+      return;
+    }
+
+    const requestKey = `${controllerNumber}:${motionType}`;
+    const physicalCapabilities = this.getPhysicalSensorCapabilities(controllerNumber);
+    if ((physicalCapabilities & requestedCapability) !== 0) {
+      if (reportRateHz > 0) {
+        this.requestedPhysicalMotion.add(requestKey);
+      } else {
+        this.requestedPhysicalMotion.delete(requestKey);
+      }
+      // 真实手柄 IMU 优先，避免与设备传感器回退同时向同一槽位发送。
+      this.deviceSensorService.setMotionEventState(motionType, 0);
+      this.usingDeviceSensorFallback = false;
+      console.info(`[GAMEPAD] 物理手柄传感器: ${reportRateHz > 0 ? '启用' : '禁用'}`);
+      return;
+    }
+
+    this.requestedPhysicalMotion.delete(requestKey);
 
     // 回退到设备传感器
     if (!this.sensorFallbackEnabled) {
@@ -2235,17 +2266,15 @@ export class GamepadManager implements UsbDriverListener {
    * 检查是否需要在控制器到达事件中报告传感器能力
    * @returns 传感器能力标志位 (LI_CCAP_ACCEL | LI_CCAP_GYRO)
    */
-  getSensorCapabilities(): number {
+  getSensorCapabilities(controllerNumber: number = 0): number {
     if (!this.gamepadMotionSensorsEnabled) {
       return 0;
     }
 
-    let capabilities = 0;
-
-    // USB 手柄传感器能力由驱动层（如 DS4）自行上报，此处仅处理设备传感器回退
+    let capabilities = this.getPhysicalSensorCapabilities(controllerNumber);
 
     // 检查设备传感器回退
-    if (this.sensorFallbackEnabled) {
+    if (this.sensorFallbackEnabled && controllerNumber === 0) {
       if (this.deviceSensorService.hasAccelerometer()) {
         capabilities |= 0x10;  // LI_CCAP_ACCEL
       }
@@ -2257,11 +2286,23 @@ export class GamepadManager implements UsbDriverListener {
     return capabilities;
   }
 
+  /** 获取指定串流槽位上由 USB 驱动提供的运动传感器能力。 */
+  private getPhysicalSensorCapabilities(controllerNumber: number): number {
+    let capabilities = 0;
+    for (const controller of this.usbDriverService.getControllers()) {
+      if (this.getControllerSlot(controller.getControllerId()) !== controllerNumber) continue;
+      capabilities |= controller.getCapabilities() &
+        (ControllerCapabilities.ACCEL | ControllerCapabilities.GYRO);
+    }
+    return capabilities;
+  }
+
   /**
    * 停止所有传感器（串流断开时调用）
    */
   stopAllSensors(): void {
     this.deviceSensorService.disableAll();
+    this.requestedPhysicalMotion.clear();
     this.usingDeviceSensorFallback = false;
     this.sensorDataCallback = null;
     console.info('[GAMEPAD] 所有传感器已停止');

--- a/entry/src/main/ets/service/input/GamepadManager.ets
+++ b/entry/src/main/ets/service/input/GamepadManager.ets
@@ -80,6 +80,7 @@ export class GamepadManager implements UsbDriverListener {
   private gcPhysicalAddressToDeviceId = new Map<string, string>();  // 物理地址→主设备ID，用于去重同一物理手柄的多个HID接口
   private gcDeviceInfoCache = new Map<string, GameControllerDeviceInfo>();  // 设备信息缓存，用于后备去重
   private usbControllerIdToGcDeviceId = new Map<number, string>();  // USB controllerId→同一物理设备的 GCK deviceId
+  private usbControllerIdToSlot = new Map<number, number>();  // USB controllerId→串流槽位，供高频 IMU 路由
   
   // 槽位管理（统一 GC Kit、InputKit 和 USB 驱动的槽位分配）
   private deviceKeyToSlot = new Map<string, number>();
@@ -436,6 +437,7 @@ export class GamepadManager implements UsbDriverListener {
       this.gcPhysicalAddressToDeviceId.clear();
       this.gcDeviceInfoCache.clear();
       this.usbControllerIdToGcDeviceId.clear();
+      this.usbControllerIdToSlot.clear();
       
       console.info('[GAMEPAD] Game Controller Kit 已停止');
     } catch (err) {
@@ -1245,7 +1247,7 @@ export class GamepadManager implements UsbDriverListener {
       }
 
       // 去重检查 1：同一物理地址的设备只注册一次
-      const physAddr = info?.physicalAddress || '';
+      const physAddr = this.normalizePhysicalDeviceIdentifier(info?.physicalAddress || '');
       if (physAddr && physAddr.length > 0) {
         const existingDeviceId = this.gcPhysicalAddressToDeviceId.get(physAddr);
         if (existingDeviceId && existingDeviceId !== deviceId) {
@@ -1278,7 +1280,7 @@ export class GamepadManager implements UsbDriverListener {
           const existInfo = this.getGCDeviceInfoCached(existId);
           if (existInfo && existInfo.name === info?.name && existInfo.product === info?.product) {
             // 如果两个设备都有非空物理地址且不同，则视为独立设备，不去重
-            const existPhysAddr = existInfo.physicalAddress || '';
+            const existPhysAddr = this.normalizePhysicalDeviceIdentifier(existInfo.physicalAddress || '');
             if (physAddr.length > 0 && existPhysAddr.length > 0 && physAddr !== existPhysAddr) {
               continue;  // 不同物理地址 = 不同物理设备
             }
@@ -1369,7 +1371,9 @@ export class GamepadManager implements UsbDriverListener {
         // 主接口断开时，将物理地址索引提升到仍占用该槽位的接口。
         this.gcDeviceIdToSlot.forEach((survivorSlot: number, survivorId: string) => {
           if (survivorSlot !== slot) return;
-          const survivorAddress = this.gcDeviceInfoCache.get(survivorId)?.physicalAddress || '';
+          const survivorAddress = this.normalizePhysicalDeviceIdentifier(
+            this.gcDeviceInfoCache.get(survivorId)?.physicalAddress || ''
+          );
           if (survivorAddress.length > 0) {
             this.gcPhysicalAddressToDeviceId.set(survivorAddress, survivorId);
           }
@@ -1862,6 +1866,7 @@ export class GamepadManager implements UsbDriverListener {
    */
   private refreshUsbControllerMappings(): void {
     this.usbControllerIdToGcDeviceId.clear();
+    this.usbControllerIdToSlot.clear();
     if (!this.useGameControllerKit) return;
 
     for (const controller of this.usbDriverService.getControllers()) {
@@ -1887,6 +1892,7 @@ export class GamepadManager implements UsbDriverListener {
         const representative = representativeBySlot.get(slot);
         if (representative !== undefined) {
           this.usbControllerIdToGcDeviceId.set(controller.getControllerId(), representative);
+          this.usbControllerIdToSlot.set(controller.getControllerId(), slot);
         }
       } else if (matchingSlots.size > 1) {
         console.warn(`[GAMEPAD-USB] 物理设备映射不唯一，忽略附加输入: ID=${controller.getControllerId()}`);
@@ -1896,6 +1902,8 @@ export class GamepadManager implements UsbDriverListener {
 
   /** 获取 USB 控制器实际对应的串流槽位；无法可靠关联时返回 undefined。 */
   private getUsbControllerSlot(controller: AbstractController): number | undefined {
+    const cachedSlot = this.usbControllerIdToSlot.get(controller.getControllerId());
+    if (cachedSlot !== undefined) return cachedSlot;
     if (!this.useGameControllerKit) {
       return this.deviceKeyToSlot.get(controller.getDeviceKey());
     }
@@ -1987,6 +1995,7 @@ export class GamepadManager implements UsbDriverListener {
     this.gcPhysicalAddressToDeviceId.clear();
     this.gcDeviceInfoCache.clear();
     this.usbControllerIdToGcDeviceId.clear();
+    this.usbControllerIdToSlot.clear();
     this.controllerIdToDeviceKey.clear();
     this.usbDeviceKeyToId.clear();
     
@@ -2043,6 +2052,7 @@ export class GamepadManager implements UsbDriverListener {
       this.gcPhysicalAddressToDeviceId.clear();
       this.gcDeviceInfoCache.clear();
       this.usbControllerIdToGcDeviceId.clear();
+      this.usbControllerIdToSlot.clear();
       this.gcDpadAxisActive.clear();
     }
     
@@ -2061,6 +2071,7 @@ export class GamepadManager implements UsbDriverListener {
     this.deviceInfoMap.clear();
     this.dpadAxisActive.clear();
     this.usbDeviceKeyToId.clear();
+    this.usbControllerIdToSlot.clear();
     this.deviceKeyToSlot.clear();
     this.controllerIdToDeviceKey.clear();
     this.slotOccupied = [false, false, false, false];
@@ -2125,11 +2136,7 @@ export class GamepadManager implements UsbDriverListener {
   ): void {
     if (!this.gamepadMotionSensorsEnabled) return;
 
-    const controller = this.usbDriverService.getControllers()
-      .find((candidate: AbstractController) => candidate.getControllerId() === controllerId);
-    if (!controller) return;
-
-    const slot = this.getUsbControllerSlot(controller);
+    const slot = this.usbControllerIdToSlot.get(controllerId);
     if (slot === undefined) return;
     if (this.requestedPhysicalMotion.has(`${slot}:${motionType}`) && this.sensorDataCallback) {
       this.sensorDataCallback(slot, motionType, x, y, z);
@@ -2401,6 +2408,7 @@ export class GamepadManager implements UsbDriverListener {
       this.usbDeviceKeyToId.delete(deviceKey);
       this.controllerIdToDeviceKey.delete(controllerId);
       this.usbControllerIdToGcDeviceId.delete(controllerId);
+      this.usbControllerIdToSlot.delete(controllerId);
       if (slot !== undefined) {
         this.vibrationService.clearControllerSource(slot);
       }
@@ -2428,6 +2436,7 @@ export class GamepadManager implements UsbDriverListener {
       this.deviceInfoMap.delete(controllerId);
       this.usbDeviceKeyToId.delete(deviceKey);
       this.controllerIdToDeviceKey.delete(controllerId);
+      this.usbControllerIdToSlot.delete(controllerId);
       this.releaseSlotForDevice(deviceKey);
       this.dpadAxisActive.delete(controllerId);
       this.vibrationService.clearControllerSource(slot);
@@ -2519,6 +2528,7 @@ export class GamepadManager implements UsbDriverListener {
       this.deviceStates.delete(existingControllerId);
       this.deviceInfoMap.delete(existingControllerId);
       this.controllerIdToDeviceKey.delete(existingControllerId);
+      this.usbControllerIdToSlot.delete(existingControllerId);
     }
   }
   
@@ -2558,6 +2568,8 @@ export class GamepadManager implements UsbDriverListener {
     this.deviceStates.set(controllerId, this.createEmptyState());
     this.usbDeviceKeyToId.set(deviceKey, controllerId);
     this.controllerIdToDeviceKey.set(controllerId, deviceKey);
+    const slot = this.deviceKeyToSlot.get(deviceKey);
+    if (slot !== undefined) this.usbControllerIdToSlot.set(controllerId, slot);
     
     this.deviceInfoMap.set(controllerId, {
       id: controllerId,

--- a/entry/src/main/ets/service/input/GamepadManager.ets
+++ b/entry/src/main/ets/service/input/GamepadManager.ets
@@ -79,6 +79,7 @@ export class GamepadManager implements UsbDriverListener {
   private gcDeviceStates = new Map<string, GamepadState>();
   private gcPhysicalAddressToDeviceId = new Map<string, string>();  // 物理地址→主设备ID，用于去重同一物理手柄的多个HID接口
   private gcDeviceInfoCache = new Map<string, GameControllerDeviceInfo>();  // 设备信息缓存，用于后备去重
+  private usbControllerIdToGcDeviceId = new Map<number, string>();  // USB controllerId→同一物理设备的 GCK deviceId
   
   // 槽位管理（统一 GC Kit、InputKit 和 USB 驱动的槽位分配）
   private deviceKeyToSlot = new Map<string, number>();
@@ -434,6 +435,7 @@ export class GamepadManager implements UsbDriverListener {
       this.gcAxisFlushPending.clear();
       this.gcPhysicalAddressToDeviceId.clear();
       this.gcDeviceInfoCache.clear();
+      this.usbControllerIdToGcDeviceId.clear();
       
       console.info('[GAMEPAD] Game Controller Kit 已停止');
     } catch (err) {
@@ -1300,6 +1302,7 @@ export class GamepadManager implements UsbDriverListener {
       if (info) {
         this.gcDeviceInfoCache.set(deviceId, info);
       }
+      this.refreshUsbControllerMappings();
       
       // 创建设备状态
       this.gcDeviceStates.set(deviceId, this.createEmptyState());
@@ -1357,6 +1360,7 @@ export class GamepadManager implements UsbDriverListener {
       this.gcDpadAxisActive.delete(deviceId);
       this.gcAxisFlushPending.delete(slot);
       this.gcDeviceIdToSlot.delete(deviceId);
+      this.refreshUsbControllerMappings();
       
       if (isSharedSlotDevice) {
         console.info(`[GAMEPAD-GC] 副本设备断开: deviceId=${deviceId}, 主设备仍在，不通知断开`);
@@ -1443,6 +1447,7 @@ export class GamepadManager implements UsbDriverListener {
     if (info) {
       this.gcDeviceInfoCache.set(deviceId, info);
     }
+    this.refreshUsbControllerMappings();
 
     this.gcDeviceStates.set(deviceId, this.createEmptyState());
 
@@ -1833,6 +1838,52 @@ export class GamepadManager implements UsbDriverListener {
     // 回退：钳位到 0，避免原始 controllerId (可能 ≥1000) 溢出
     return 0;
   }
+
+  private normalizePhysicalDeviceIdentifier(identifier: string): string {
+    return identifier.trim().toLowerCase().replace(/\\/g, '/').replace(/\/+$/, '');
+  }
+
+  /**
+   * 关联 USB 驱动和 GCK 对同一物理设备使用的独立运行时 ID。
+   * 只接受唯一的物理标识匹配，避免多手柄或混合模式下错误回退到槽位 0。
+   */
+  private refreshUsbControllerMappings(): void {
+    this.usbControllerIdToGcDeviceId.clear();
+    if (!this.useGameControllerKit) return;
+
+    for (const controller of this.usbDriverService.getControllers()) {
+      const identifiers = new Set<string>();
+      for (const identifier of controller.getPhysicalDeviceIdentifiers()) {
+        const normalized = this.normalizePhysicalDeviceIdentifier(identifier);
+        if (normalized.length > 0) identifiers.add(normalized);
+      }
+
+      const matches: string[] = [];
+      this.gcDeviceInfoCache.forEach((info: GameControllerDeviceInfo, gcDeviceId: string) => {
+        const physicalAddress = this.normalizePhysicalDeviceIdentifier(info.physicalAddress || '');
+        if (physicalAddress.length > 0 && identifiers.has(physicalAddress) &&
+          this.gcDeviceIdToSlot.has(gcDeviceId)) {
+          matches.push(gcDeviceId);
+        }
+      });
+
+      if (matches.length === 1) {
+        this.usbControllerIdToGcDeviceId.set(controller.getControllerId(), matches[0]);
+      } else if (matches.length > 1) {
+        console.warn(`[GAMEPAD-USB] 物理设备映射不唯一，忽略附加输入: ID=${controller.getControllerId()}`);
+      }
+    }
+  }
+
+  /** 获取 USB 控制器实际对应的串流槽位；无法可靠关联时返回 undefined。 */
+  private getUsbControllerSlot(controller: AbstractController): number | undefined {
+    if (!this.useGameControllerKit) {
+      return this.deviceKeyToSlot.get(controller.getDeviceKey());
+    }
+
+    const gcDeviceId = this.usbControllerIdToGcDeviceId.get(controller.getControllerId());
+    return gcDeviceId === undefined ? undefined : this.gcDeviceIdToSlot.get(gcDeviceId);
+  }
   
   /**
    * 通知监听器状态变化
@@ -1916,6 +1967,7 @@ export class GamepadManager implements UsbDriverListener {
     this.gcDeviceIdToSlot.clear();
     this.gcPhysicalAddressToDeviceId.clear();
     this.gcDeviceInfoCache.clear();
+    this.usbControllerIdToGcDeviceId.clear();
     this.controllerIdToDeviceKey.clear();
     this.usbDeviceKeyToId.clear();
     
@@ -1971,6 +2023,7 @@ export class GamepadManager implements UsbDriverListener {
       this.gcDeviceIdToSlot.clear();
       this.gcPhysicalAddressToDeviceId.clear();
       this.gcDeviceInfoCache.clear();
+      this.usbControllerIdToGcDeviceId.clear();
       this.gcDpadAxisActive.clear();
     }
     
@@ -2053,7 +2106,12 @@ export class GamepadManager implements UsbDriverListener {
   ): void {
     if (!this.gamepadMotionSensorsEnabled) return;
 
-    const slot = this.getControllerSlot(controllerId);
+    const controller = this.usbDriverService.getControllers()
+      .find((candidate: AbstractController) => candidate.getControllerId() === controllerId);
+    if (!controller) return;
+
+    const slot = this.getUsbControllerSlot(controller);
+    if (slot === undefined) return;
     if (this.requestedPhysicalMotion.has(`${slot}:${motionType}`) && this.sensorDataCallback) {
       this.sensorDataCallback(slot, motionType, x, y, z);
     }
@@ -2221,9 +2279,11 @@ export class GamepadManager implements UsbDriverListener {
       } else {
         this.requestedPhysicalMotion.delete(requestKey);
       }
-      // 真实手柄 IMU 优先，避免与设备传感器回退同时向同一槽位发送。
-      this.deviceSensorService.setMotionEventState(motionType, 0);
-      this.usingDeviceSensorFallback = false;
+      // 设备传感器只服务控制器 0；其他槽位的物理 IMU 不应改变其全局状态。
+      if (controllerNumber === 0) {
+        this.deviceSensorService.setMotionEventState(motionType, 0);
+        this.usingDeviceSensorFallback = false;
+      }
       console.info(`[GAMEPAD] 物理手柄传感器: ${reportRateHz > 0 ? '启用' : '禁用'}`);
       return;
     }
@@ -2276,10 +2336,10 @@ export class GamepadManager implements UsbDriverListener {
     // 检查设备传感器回退
     if (this.sensorFallbackEnabled && controllerNumber === 0) {
       if (this.deviceSensorService.hasAccelerometer()) {
-        capabilities |= 0x10;  // LI_CCAP_ACCEL
+        capabilities |= ControllerCapabilities.ACCEL;
       }
       if (this.deviceSensorService.hasGyroscope()) {
-        capabilities |= 0x20;  // LI_CCAP_GYRO
+        capabilities |= ControllerCapabilities.GYRO;
       }
     }
 
@@ -2290,7 +2350,7 @@ export class GamepadManager implements UsbDriverListener {
   private getPhysicalSensorCapabilities(controllerNumber: number): number {
     let capabilities = 0;
     for (const controller of this.usbDriverService.getControllers()) {
-      if (this.getControllerSlot(controller.getControllerId()) !== controllerNumber) continue;
+      if (this.getUsbControllerSlot(controller) !== controllerNumber) continue;
       capabilities |= controller.getCapabilities() &
         (ControllerCapabilities.ACCEL | ControllerCapabilities.GYRO);
     }
@@ -2318,10 +2378,13 @@ export class GamepadManager implements UsbDriverListener {
 
     // 混合模式：GCK 管理设备生命周期，这里只清理震动路由记录
     if (this.useGameControllerKit) {
-      const slot = this.getControllerSlot(controllerId);
+      const slot = this.getUsbControllerSlot(controller);
       this.usbDeviceKeyToId.delete(deviceKey);
       this.controllerIdToDeviceKey.delete(controllerId);
-      this.vibrationService.clearControllerSource(slot);
+      this.usbControllerIdToGcDeviceId.delete(controllerId);
+      if (slot !== undefined) {
+        this.vibrationService.clearControllerSource(slot);
+      }
       console.info(`[GAMEPAD-USB] 混合模式: 清理震动路由记录`);
       return;
     }
@@ -2370,6 +2433,7 @@ export class GamepadManager implements UsbDriverListener {
       // 仅记录 USB 设备 key → 用于震动路由
       this.usbDeviceKeyToId.set(deviceKey, controllerId);
       this.controllerIdToDeviceKey.set(controllerId, deviceKey);
+      this.refreshUsbControllerMappings();
       this.vibrationService.rerenderAllSources();
       console.info(`[GAMEPAD-USB] 混合模式: 记录 USB 设备用于震动: ${name} (ID=${controllerId})`);
       return;

--- a/entry/src/main/ets/service/input/GamepadTypes.ets
+++ b/entry/src/main/ets/service/input/GamepadTypes.ets
@@ -54,7 +54,8 @@ export interface GamepadInputListener {
   onGamepadConnected: (deviceId: number, name: string, controllerType: number) => void;
   onGamepadDisconnected: (deviceId: number) => void;
   onGamepadInput: (deviceId: number, state: GamepadState) => void;
-  onGamepadCapabilitiesChanged?: (deviceId: number, controllerType: number) => void;
+  /** 已连接手柄的能力变化（第一个参数为串流槽位 ID）。 */
+  onGamepadCapabilitiesChanged?: (slotId: number, controllerType: number) => void;
 }
 
 // ==================== 常量定义 ====================

--- a/entry/src/main/ets/service/input/GamepadTypes.ets
+++ b/entry/src/main/ets/service/input/GamepadTypes.ets
@@ -54,6 +54,7 @@ export interface GamepadInputListener {
   onGamepadConnected: (deviceId: number, name: string, controllerType: number) => void;
   onGamepadDisconnected: (deviceId: number) => void;
   onGamepadInput: (deviceId: number, state: GamepadState) => void;
+  onGamepadCapabilitiesChanged?: (deviceId: number, controllerType: number) => void;
 }
 
 // ==================== 常量定义 ====================

--- a/entry/src/main/ets/service/streaming/StreamingSession.ets
+++ b/entry/src/main/ets/service/streaming/StreamingSession.ets
@@ -1633,7 +1633,7 @@ export class StreamingSession {
     if (this.physicalControllerArrived.has(controllerIndex)) return;
 
     let capabilities = LI_CCAP_ANALOG_TRIGGERS | LI_CCAP_RUMBLE;
-    capabilities |= GamepadManager.getInstance().getSensorCapabilities();
+    capabilities |= GamepadManager.getInstance().getSensorCapabilities(controllerIndex);
 
     let reportedType = controllerType;
     if ((capabilities & (LI_CCAP_ACCEL | LI_CCAP_GYRO)) && controllerType !== CONTROLLER_TYPE_PS) {

--- a/entry/src/main/ets/service/streaming/StreamingSession.ets
+++ b/entry/src/main/ets/service/streaming/StreamingSession.ets
@@ -912,6 +912,19 @@ export class StreamingSession {
     );
   }
 
+  /**
+   * 物理 USB 附加驱动可能晚于 GCK 输入设备到达。
+   * 对已声明的槽位重发 arrival，使主机重新读取新增的 IMU 能力。
+   */
+  refreshPhysicalControllerCapabilities(
+    controllerIndex: number,
+    controllerType: number = CONTROLLER_TYPE_XBOX
+  ): void {
+    if (!this.isRunning || !this.physicalControllerArrived.has(controllerIndex)) return;
+    this.physicalControllerArrived.delete(controllerIndex);
+    this.ensurePhysicalControllerArrival(controllerIndex, controllerType);
+  }
+
   // ---------------------------------------------------------------------------
   // 性能统计
   // ---------------------------------------------------------------------------

--- a/entry/src/main/ets/service/usbdriver/AbstractController.ets
+++ b/entry/src/main/ets/service/usbdriver/AbstractController.ets
@@ -45,6 +45,7 @@ export abstract class AbstractController {
   protected busNum: number = 0;
   protected devAddress: number = 0;
   protected serial: string = '';
+  protected physicalDeviceName: string = '';
   
   // 配置选项
   protected ddkActive: boolean = false;  // DDK 高速轮询是否启用
@@ -82,10 +83,27 @@ export abstract class AbstractController {
   /**
    * 设置设备物理位置信息（用于唯一标识）
    */
-  setDeviceLocation(busNum: number, devAddress: number, serial: string): void {
+  setDeviceLocation(busNum: number, devAddress: number, serial: string, physicalDeviceName: string = ''): void {
     this.busNum = busNum;
     this.devAddress = devAddress;
     this.serial = serial;
+    this.physicalDeviceName = physicalDeviceName;
+  }
+
+  /**
+   * 返回可用于与其他输入 API 关联同一物理 USB 设备的稳定标识。
+   * 不包含运行时 controllerId，避免不同输入栈的独立 ID 被错误关联。
+   */
+  getPhysicalDeviceIdentifiers(): string[] {
+    const identifiers = [
+      this.serial,
+      this.physicalDeviceName,
+      `${this.busNum}:${this.devAddress}`,
+      `${this.busNum}/${this.devAddress}`,
+      `${this.busNum}-${this.devAddress}`,
+      `/dev/bus/usb/${this.busNum.toString().padStart(3, '0')}/${this.devAddress.toString().padStart(3, '0')}`
+    ];
+    return identifiers.filter((identifier: string) => identifier.length > 0);
   }
   
   /**

--- a/entry/src/main/ets/service/usbdriver/AbstractDualSenseController.ets
+++ b/entry/src/main/ets/service/usbdriver/AbstractDualSenseController.ets
@@ -276,18 +276,7 @@ export abstract class AbstractDualSenseController extends AbstractController {
               console.info(`${TAG} 输入状态: buttons=0x${this.buttonFlags.toString(16)}, LX=${this.leftStickX.toFixed(2)}, LY=${this.leftStickY.toFixed(2)}`);
             }
             
-            // 报告 IMU 数据
-            if (this.capabilities & ControllerCapabilities.GYRO) {
-              this.notifyControllerMotion(MotionType.GYRO, this.gyroX, this.gyroY, this.gyroZ);
-            }
-            if (this.capabilities & ControllerCapabilities.ACCEL) {
-              this.notifyControllerMotion(MotionType.ACCEL, this.accelX, this.accelY, this.accelZ);
-            }
-            
-            // 报告触摸板数据
-            if (this.capabilities & ControllerCapabilities.TOUCHPAD) {
-              this.notifyTouchpadInput(this.touchpadActive, this.touchpadX, this.touchpadY);
-            }
+            this.reportExtendedInput();
           }
         } else if (readCount % 100 === 0) {
           console.warn(`${TAG} 读取空数据，已尝试 ${readCount} 次`);
@@ -443,10 +432,7 @@ export abstract class AbstractDualSenseController extends AbstractController {
         if (this.stopped) return;
         if (this.handleRead(data)) {
           this.reportInput();
-          // DDK 路径也报告触摸板数据
-          if (this.capabilities & ControllerCapabilities.TOUCHPAD) {
-            this.notifyTouchpadInput(this.touchpadActive, this.touchpadX, this.touchpadY);
-          }
+          this.reportExtendedInput();
         }
       },
       (errorCode: number) => {
@@ -496,6 +482,22 @@ export abstract class AbstractDualSenseController extends AbstractController {
     this.notifyDeviceAdded();
     console.info(`${TAG} 控制器已启动 (DDK 高速轮询)`);
     return true;
+  }
+
+  /**
+   * 上报主报告中的扩展输入。
+   * 普通 usbManager 轮询和 DDK 轮询必须经过同一条路径，避免高性能路径漏报 IMU。
+   */
+  private reportExtendedInput(): void {
+    if (this.capabilities & ControllerCapabilities.GYRO) {
+      this.notifyControllerMotion(MotionType.GYRO, this.gyroX, this.gyroY, this.gyroZ);
+    }
+    if (this.capabilities & ControllerCapabilities.ACCEL) {
+      this.notifyControllerMotion(MotionType.ACCEL, this.accelX, this.accelY, this.accelZ);
+    }
+    if (this.capabilities & ControllerCapabilities.TOUCHPAD) {
+      this.notifyTouchpadInput(this.touchpadActive, this.touchpadX, this.touchpadY);
+    }
   }
   
   /**

--- a/entry/src/main/ets/service/usbdriver/ControllerConstants.ets
+++ b/entry/src/main/ets/service/usbdriver/ControllerConstants.ets
@@ -62,8 +62,9 @@ export class ControllerCapabilities {
 
 // 运动数据类型
 export class MotionType {
-  static readonly GYRO: number = 1;
-  static readonly ACCEL: number = 2;
+  // Keep these values in sync with moonlight-common-c's LI_MOTION_TYPE_* ABI.
+  static readonly ACCEL: number = 0x01;
+  static readonly GYRO: number = 0x02;
 }
 
 // D-Pad 方向值（用于 DualShock 风格的 D-Pad）

--- a/entry/src/main/ets/service/usbdriver/DualSenseController.ets
+++ b/entry/src/main/ets/service/usbdriver/DualSenseController.ets
@@ -159,33 +159,30 @@ export class DualSenseController extends AbstractDualSenseController {
       }
     }
     
-    // IMU 数据 (从 offset 开始)
-    if (buffer.length >= offset + 12) {
-      const GYRO_SCALE = 2000.0 / 32768.0;
+    // The common DualSense USB input report starts after report ID 0x01.
+    // Its 15-byte buttons/reserved prefix is followed by gyro[3] and accel[3].
+    const imuOffset = 16;
+    const imuLength = 12;
+    if (buffer.length >= imuOffset + imuLength) {
+      // Nominal uncalibrated ranges from Sony's DualSense report format.
+      // Moonlight expects gyro in deg/s and acceleration in m/s^2.
+      const GYRO_SCALE = 2048.0 / 32768.0;
       const ACCEL_SCALE = 4.0 / 32768.0;
-      const G_TO_MS2 = 9.81;
-      
-      // 跳过一些字节到 IMU 数据位置
-      // DualSense IMU 数据在不同的偏移量
-      const imuOffset = 16;  // 根据实际报告格式调整
-      
-      if (buffer.length >= imuOffset + 12) {
-const gyrox = readShortLE(buffer, imuOffset);
-        const gyroy = readShortLE(buffer, imuOffset + 2);
-        const gyroz = readShortLE(buffer, imuOffset + 4);
+      const STANDARD_GRAVITY = 9.80665;
 
-        const accelx = readShortLE(buffer, imuOffset + 6);
-        const accely = readShortLE(buffer, imuOffset + 8);
-        const accelz = readShortLE(buffer, imuOffset + 10);
-        
-        this.gyroX = gyrox * GYRO_SCALE;
-        this.gyroY = gyroy * GYRO_SCALE;
-        this.gyroZ = gyroz * GYRO_SCALE;
-        
-        this.accelX = accelx * ACCEL_SCALE * G_TO_MS2;
-        this.accelY = accely * ACCEL_SCALE * G_TO_MS2;
-        this.accelZ = accelz * ACCEL_SCALE * G_TO_MS2;
-      }
+      const gyroX = readShortLE(buffer, imuOffset);
+      const gyroY = readShortLE(buffer, imuOffset + 2);
+      const gyroZ = readShortLE(buffer, imuOffset + 4);
+      const accelX = readShortLE(buffer, imuOffset + 6);
+      const accelY = readShortLE(buffer, imuOffset + 8);
+      const accelZ = readShortLE(buffer, imuOffset + 10);
+
+      this.gyroX = gyroX * GYRO_SCALE;
+      this.gyroY = gyroY * GYRO_SCALE;
+      this.gyroZ = gyroZ * GYRO_SCALE;
+      this.accelX = accelX * ACCEL_SCALE * STANDARD_GRAVITY;
+      this.accelY = accelY * ACCEL_SCALE * STANDARD_GRAVITY;
+      this.accelZ = accelZ * ACCEL_SCALE * STANDARD_GRAVITY;
     }
     
     return true;

--- a/entry/src/main/ets/service/usbdriver/UsbDriverService.ets
+++ b/entry/src/main/ets/service/usbdriver/UsbDriverService.ets
@@ -607,7 +607,7 @@ export class UsbDriverService implements UsbDriverListener {
     
     if (controller) {
       // 设置设备物理位置信息（用于唯一标识）
-      controller.setDeviceLocation(device.busNum, device.devAddress, device.serial || '');
+      controller.setDeviceLocation(device.busNum, device.devAddress, device.serial || '', device.name || '');
 
       // 应用 DDK 高速轮询设置
       const inputSettings = await SettingsService.getInstance().getInputSettings();

--- a/entry/src/main/ets/viewmodel/StreamViewModel.ets
+++ b/entry/src/main/ets/viewmodel/StreamViewModel.ets
@@ -516,6 +516,11 @@ export class StreamViewModel {
       controllerType
     );
   }
+
+  /** USB 附加驱动晚于 GCK 到达时，刷新主机侧已声明的手柄能力。 */
+  refreshGamepadCapabilities(controllerIndex: number, controllerType: number): void {
+    this.streamingSession?.refreshPhysicalControllerCapabilities(controllerIndex, controllerType);
+  }
   
   /**
    * 获取串流会话


### PR DESCRIPTION
## 改了啥呀

- 修正 USB 手柄运动事件类型：`ACCEL=0x01`、`GYRO=0x02`，不再让陀螺仪和加速度互相串台
- 让 usbManager 与 DDK 高速轮询共用扩展输入上报路径，补齐 DDK 漏掉的 IMU 数据
- 按控制器槽位声明真实 USB 手柄的运动传感器能力，并只在主机请求后转发
- 真实手柄 IMU 优先于设备传感器回退；设备回退只为控制器 0 声明
- 按 DualSense 官方报告布局明确 USB IMU 偏移，并使用协议要求的 deg/s、m/s² 单位

## 为啥要改

原来的杂鱼状态有三处会破坏 DualSense 运动输入：运动类型常量与 Moonlight ABI 相反、DDK 路径没有上报 IMU、控制器到达事件没有包含真实 USB DS5 的传感器能力。结果可能是两类数据交叉解释，或高性能轮询时完全收不到陀螺仪。

这次把能力协商、主机请求和两条 USB 读取路径串成同一套生命周期，同时保留手机传感器回退。

## 验证

- `git diff --check`
- `C:\Program Files\Huawei\DevEco Studio\tools\hvigor\bin\hvigorw.bat --mode module -p module=entry@default -p product=default assembleHap`
- DevEco Hvigor：`BUILD SUCCESSFUL`

实体 DualSense 的轴向与静态漂移仍建议在真机上做最终体验确认。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 支持按物理手柄分别查询、管理并刷新运动传感器能力。
  - 多个手柄连接时，可准确匹配各自的陀螺仪与加速度计。
  - 支持根据手柄实际能力转发运动数据，并改进振动控制的设备匹配。

- **问题修复**
  - 优化 USB 手柄运动数据上报，减少重复或错误转发。
  - 改进 DualSense 运动传感器数据解析与单位转换，提升输入准确性。
  - 修复手柄连接、断开及重置时设备能力匹配不准确的问题。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->