### PR TITLE
feat(haptics): connect HarmonyOS simulated DualSense feedback

### DIFF
--- a/entry/src/main/ets/service/input/GamepadManager.ets
+++ b/entry/src/main/ets/service/input/GamepadManager.ets
@@ -167,7 +167,11 @@ export class GamepadManager implements UsbDriverListener {
     this.usbDriverService = UsbDriverService.getInstance();
     this.deviceSensorService = DeviceSensorService.getInstance();
     this.mouseEmulationService = new MouseEmulationService();
-    this.vibrationService = new GamepadVibrationService(this.usbDriverService, this.deviceKeyToSlot);
+    this.vibrationService = new GamepadVibrationService(
+      this.usbDriverService,
+      this.deviceKeyToSlot,
+      (): boolean => this.hasConnectedGamepadOutsideUsbDriver()
+    );
     this.loadGCButtonMappingSettings();
     this.loadSensorSettings();
     this.loadUsbDriverSetting();
@@ -480,6 +484,15 @@ export class GamepadManager implements UsbDriverListener {
    */
   hasActiveGcGamepad(): boolean {
     return this.useGameControllerKit && this.gcDeviceIdToSlot.size > 0;
+  }
+
+  private hasConnectedGamepadOutsideUsbDriver(): boolean {
+    if (this.hasActiveGcGamepad()) return true;
+    let connected = false;
+    this.deviceInfoMap.forEach((info: GamepadInfo): void => {
+      if (!info.isUsb) connected = true;
+    });
+    return connected;
   }
 
   // ==================== 鼠标模拟（委托 MouseEmulationService） ====================

--- a/entry/src/main/ets/service/input/GamepadManager.ets
+++ b/entry/src/main/ets/service/input/GamepadManager.ets
@@ -18,7 +18,7 @@ import {
 import { SettingsService, SettingsKeys } from '../SettingsService';
 import { PreferencesUtil } from '../../utils/PreferencesUtil';
 import { DeviceSensorService, LI_MOTION_TYPE_ACCEL, LI_MOTION_TYPE_GYRO } from './DeviceSensorService';
-import { MoonBridge, Ds5HapticsIrV2Frame } from '../streaming/MoonBridge';
+import { MoonBridge, Ds5HapticsIrV2Frame, AdaptiveTriggersFrame } from '../streaming/MoonBridge';
 import { MouseEmulationService, MouseEmulationCallback } from './MouseEmulationService';
 import { GamepadVibrationService } from './GamepadVibrationService';
 import { AudioHapticFrameFlag } from '../AudioHapticFrame';
@@ -2455,6 +2455,11 @@ export class GamepadManager implements UsbDriverListener {
    */
   handleDs5HapticsIrV2(frame: Ds5HapticsIrV2Frame): void {
     this.vibrationService.handleDs5HapticsIrV2(frame);
+  }
+
+  /** Route a raw DualSense adaptive trigger update to its controller slot. */
+  handleAdaptiveTriggers(frame: AdaptiveTriggersFrame): void {
+    this.vibrationService.handleAdaptiveTriggers(frame);
   }
 
   /** 处理扳机震动 */

--- a/entry/src/main/ets/service/input/GamepadVibrationService.ets
+++ b/entry/src/main/ets/service/input/GamepadVibrationService.ets
@@ -70,6 +70,8 @@ export class GamepadVibrationService {
   private static readonly IR_GATE_CLOSE_AMPLITUDE = 0.004;
   private static readonly IR_GATE_CLOSE_FRAMES = 4;
   private static readonly IR_OUTPUT_FLOOR = 0.004;
+  /** Generic USB rumble actuators do not need the authored stream's 200 Hz update rate. */
+  private static readonly IR_USB_RENDER_INTERVAL_MS = 10;
   /** Device vibrator APIs are relatively expensive; coalesce authored IR frames. */
   private static readonly DEVICE_RENDER_INTERVAL_MS = 40;
   private static readonly IR_FLAG_DISCONTINUITY = 0x01;
@@ -79,6 +81,7 @@ export class GamepadVibrationService {
   private static readonly IR_PRIORITY_OVER_GAME = true;
   private usbDriverService: UsbDriverService;
   private deviceVibrationCoordinator: DeviceVibrationCoordinator;
+  private hasExternalGamepad: () => boolean;
   
   // 设置
   private vibrationFeedbackEnabled = true;
@@ -105,6 +108,8 @@ export class GamepadVibrationService {
   private gameUsbRumble = new Map<number, MotorPair>();
   private irUsbRumble = new Map<number, MotorPair>();
   private audioUsbRumble = new Map<number, MotorPair>();
+  private lastIrUsbRenderAtMs = new Map<number, number>();
+  private pendingIrUsbRenderTimers = new Map<number, number>();
   private usbOutputClearedDeviceKeys: Set<string> = new Set();
   private gameDeviceLow: number = 0;
   private gameDeviceHigh: number = 0;
@@ -122,9 +127,11 @@ export class GamepadVibrationService {
   private pendingDeviceRenderTimer: number = -1;
   private pendingDeviceRenderTransient = false;
 
-  constructor(usbDriverService: UsbDriverService, deviceKeyToSlot: Map<string, number>) {
+  constructor(usbDriverService: UsbDriverService, deviceKeyToSlot: Map<string, number>,
+    hasExternalGamepad: () => boolean) {
     this.usbDriverService = usbDriverService;
     this.deviceKeyToSlotLookup = deviceKeyToSlot;
+    this.hasExternalGamepad = hasExternalGamepad;
     this.deviceVibrationCoordinator = DeviceVibrationCoordinator.getInstance();
     this.deviceVibrationCoordinator.setSourceResumeCallback((): void => {
       this.renderMixedDevice(false);
@@ -194,7 +201,8 @@ export class GamepadVibrationService {
     this.submitGameDeviceRumble(lowFreqMotor, highFreqMotor);
 
     // USB 停止确认: 100ms 后重发 stop(0,0)，防止首次 USB 传输被覆盖或丢失
-    if (lowFreqMotor === 0 && highFreqMotor === 0 && hasUsbController) {
+    if (lowFreqMotor === 0 && highFreqMotor === 0 && hasUsbController &&
+        !this.isIrUsbPriorityActive(controllerNumber)) {
       this.scheduleUsbStopConfirm(controllerNumber);
     }
   }
@@ -230,6 +238,7 @@ export class GamepadVibrationService {
       state.hasSequence = false;
       state.gateOpen = false;
       state.quietFrameCount = 0;
+      this.clearIrUsbRenderSchedule(controllerNumber);
     }
     if (state.hasSequence &&
         !this.isIrSequenceNewer(frame.sourceSequenceNumber, state.lastSequence)) {
@@ -271,7 +280,7 @@ export class GamepadVibrationService {
 
     const controllers = this.usbDriverService.getControllers();
     if (controllers.length > 0) {
-      this.renderMixedUsb(controllers, controllerNumber);
+      this.scheduleIrUsbRender(controllerNumber);
     }
     this.renderMixedDevice(false);
   }
@@ -343,7 +352,8 @@ export class GamepadVibrationService {
       high: this.clampRumbleValue(highFreqMotor)
     });
     const controllers = this.usbDriverService.getControllers();
-    if (controllers.length > 0) {
+    if (controllers.length > 0 &&
+        !this.isIrUsbPriorityActive(controllerNumber)) {
       this.renderMixedUsb(controllers, controllerNumber);
     }
   }
@@ -443,6 +453,7 @@ export class GamepadVibrationService {
       this.lastHighFreq = 0;
     }
     this.clearIrTimer(slot);
+    this.clearIrUsbRenderSchedule(slot);
     this.irStreamStates.delete(slot);
 
     const controllers = this.usbDriverService.getControllers();
@@ -536,6 +547,11 @@ export class GamepadVibrationService {
         state.watchdogTimer = -1;
       }
     });
+    this.pendingIrUsbRenderTimers.forEach((timerId: number): void => {
+      clearTimeout(timerId);
+    });
+    this.pendingIrUsbRenderTimers.clear();
+    this.lastIrUsbRenderAtMs.clear();
   }
 
   private getOrCreateIrStreamState(controllerNumber: number): IrStreamState {
@@ -567,6 +583,7 @@ export class GamepadVibrationService {
   }
 
   private clearIrSource(controllerNumber: number, resetSequence: boolean): void {
+    this.clearIrUsbRenderSchedule(controllerNumber);
     const hadUsbOutput = this.irUsbRumble.delete(controllerNumber);
     const hadDeviceOutput = this.irDeviceRumble.delete(controllerNumber);
     this.clearIrTimer(controllerNumber);
@@ -619,7 +636,50 @@ export class GamepadVibrationService {
       low: this.clampRumbleValue(lowFreqMotor),
       high: this.clampRumbleValue(highFreqMotor)
     });
+    if (this.isIrUsbPriorityActive(controllerNumber)) return;
     this.renderMixedUsb(controllers, controllerNumber);
+  }
+
+  private isIrUsbPriorityActive(controllerNumber: number): boolean {
+    return GamepadVibrationService.IR_PRIORITY_OVER_GAME &&
+      this.irUsbRumble.has(controllerNumber);
+  }
+
+  /** Coalesce the 5 ms authored stream into a latest-wins 100 Hz USB motor update. */
+  private scheduleIrUsbRender(controllerNumber: number): void {
+    const nowMs = Date.now();
+    const lastRenderAtMs = this.lastIrUsbRenderAtMs.get(controllerNumber) ?? 0;
+    const elapsedMs = nowMs - lastRenderAtMs;
+    if (elapsedMs >= GamepadVibrationService.IR_USB_RENDER_INTERVAL_MS) {
+      this.clearPendingIrUsbRender(controllerNumber);
+      this.lastIrUsbRenderAtMs.set(controllerNumber, nowMs);
+      this.renderMixedUsb(this.usbDriverService.getControllers(), controllerNumber);
+      return;
+    }
+    if (this.pendingIrUsbRenderTimers.has(controllerNumber)) return;
+
+    const delayMs = GamepadVibrationService.IR_USB_RENDER_INTERVAL_MS - elapsedMs;
+    let timerId: number = -1;
+    timerId = setTimeout((): void => {
+      if (this.pendingIrUsbRenderTimers.get(controllerNumber) !== timerId) return;
+      this.pendingIrUsbRenderTimers.delete(controllerNumber);
+      if (!this.irUsbRumble.has(controllerNumber)) return;
+      this.lastIrUsbRenderAtMs.set(controllerNumber, Date.now());
+      this.renderMixedUsb(this.usbDriverService.getControllers(), controllerNumber);
+    }, delayMs);
+    this.pendingIrUsbRenderTimers.set(controllerNumber, timerId);
+  }
+
+  private clearPendingIrUsbRender(controllerNumber: number): void {
+    const timerId = this.pendingIrUsbRenderTimers.get(controllerNumber);
+    if (timerId === undefined) return;
+    clearTimeout(timerId);
+    this.pendingIrUsbRenderTimers.delete(controllerNumber);
+  }
+
+  private clearIrUsbRenderSchedule(controllerNumber: number): void {
+    this.clearPendingIrUsbRender(controllerNumber);
+    this.lastIrUsbRenderAtMs.delete(controllerNumber);
   }
 
   private renderMixedUsb(controllers: AbstractController[],
@@ -746,7 +806,8 @@ export class GamepadVibrationService {
         return true;
       case '自动':
       default:
-        return this.usbDriverService.getControllers().length === 0;
+        return this.usbDriverService.getControllers().length === 0 &&
+          !this.hasExternalGamepad();
     }
   }
 

--- a/entry/src/main/ets/service/input/GamepadVibrationService.ets
+++ b/entry/src/main/ets/service/input/GamepadVibrationService.ets
@@ -22,7 +22,14 @@ import { UsbDriverService, AbstractController } from '../usbdriver/index';
 import { AudioHapticFrameFlag } from '../AudioHapticFrame';
 import { RUMBLE_MAX } from './GamepadTypes';
 import { DeviceVibrationCoordinator } from './DeviceVibrationCoordinator';
-import { Ds5HapticsIrV2Frame, Ds5HapticsIrLaneV2 } from '../streaming/MoonBridge';
+import {
+  Ds5HapticsIrV2Frame,
+  Ds5HapticsIrLaneV2,
+  AdaptiveTriggersFrame,
+  DS_EFFECT_RIGHT_TRIGGER,
+  DS_EFFECT_LEFT_TRIGGER,
+  DS_EFFECT_PAYLOAD_SIZE
+} from '../streaming/MoonBridge';
 import {
   GAME_VIBRATION_STRENGTH_DEFAULT,
   GAME_VIBRATION_STRENGTH_ORIGINAL,
@@ -268,15 +275,58 @@ export class GamepadVibrationService {
     this.renderMixedDevice(false);
   }
 
+  /** Forward Sunshine's raw adaptive trigger state to the matching USB slot. */
+  handleAdaptiveTriggers(frame: AdaptiveTriggersFrame): void {
+    if (!this.isValidControllerNumber(frame.controllerNumber)) {
+      console.warn('[Vibration] ignoring adaptive trigger frame with invalid controller number');
+      return;
+    }
+
+    const controllers = this.usbDriverService.getControllers();
+    const controllerNumber = Math.floor(frame.controllerNumber);
+    const controller = this.findControllerBySlot(controllers, controllerNumber);
+    if (!controller) return;
+
+    if (!this.vibrationFeedbackEnabled || this.gameVibrationStrength <= 0 ||
+        !this.shouldRenderUsbOutput()) {
+      this.clearAllTriggerEffects(controller);
+      return;
+    }
+
+    if (frame.leftEffect.length !== DS_EFFECT_PAYLOAD_SIZE ||
+        frame.rightEffect.length !== DS_EFFECT_PAYLOAD_SIZE) {
+      console.warn('[Vibration] ignoring adaptive trigger frame with invalid payload size');
+      return;
+    }
+
+    const eventFlags = Math.floor(frame.eventFlags) &
+      (DS_EFFECT_RIGHT_TRIGGER | DS_EFFECT_LEFT_TRIGGER);
+    if (eventFlags === 0) return;
+
+    controller.setAdaptiveTriggers(
+      eventFlags,
+      this.clampProtocolByte(frame.leftEffectType),
+      this.clampProtocolByte(frame.rightEffectType),
+      frame.leftEffect,
+      frame.rightEffect
+    );
+  }
+
   /**
    * 处理扳机震动
    */
   handleRumbleTriggers(controllerNumber: number, leftTrigger: number, rightTrigger: number): void {
-    if (!this.vibrationFeedbackEnabled) return;
-
     const controllers = this.usbDriverService.getControllers();
     const controller = this.findControllerBySlot(controllers, controllerNumber);
-    controller?.rumbleTriggers(
+    if (!controller) return;
+
+    if (!this.vibrationFeedbackEnabled || this.gameVibrationStrength <= 0 ||
+        !this.shouldRenderUsbOutput()) {
+      this.clearAllTriggerEffects(controller);
+      return;
+    }
+
+    controller.rumbleTriggers(
       this.applyGameVibrationStrength(leftTrigger),
       this.applyGameVibrationStrength(rightTrigger)
     );
@@ -364,8 +414,8 @@ export class GamepadVibrationService {
     try {
       const controllers = this.usbDriverService.getControllers();
       for (const controller of controllers) {
+        this.clearAllTriggerEffects(controller);
         controller.rumble(0, 0);
-        controller.rumbleTriggers(0, 0);
       }
       if (controllers.length > 0) {
         this.scheduleUsbStopConfirm(this.lastRumbleControllerNumber);
@@ -392,6 +442,10 @@ export class GamepadVibrationService {
     this.irStreamStates.delete(slot);
 
     const controllers = this.usbDriverService.getControllers();
+    const controller = this.findControllerBySlot(controllers, slot);
+    if (controller) {
+      this.clearAllTriggerEffects(controller);
+    }
     if (controllers.length > 0) {
       this.renderMixedUsb(controllers, slot);
     }
@@ -434,12 +488,12 @@ export class GamepadVibrationService {
     this.lastHighFreq = 0;
 
     const controllers = this.usbDriverService.getControllers();
+    for (const controller of controllers) {
+      this.clearAllTriggerEffects(controller);
+    }
     affectedSlots.forEach((slot: number): void => {
       this.renderMixedUsb(controllers, slot);
     });
-    for (const controller of controllers) {
-      controller.rumbleTriggers(0, 0);
-    }
     this.renderMixedDevice(false);
   }
 
@@ -570,6 +624,7 @@ export class GamepadVibrationService {
     if (!controller) return;
 
     if (!this.shouldRenderUsbOutput()) {
+      this.clearAllTriggerEffects(controller);
       controller.rumble(0, 0);
       return;
     }
@@ -615,6 +670,16 @@ export class GamepadVibrationService {
   private clampRumbleValue(value: number): number {
     if (!Number.isFinite(value)) return 0;
     return Math.max(0, Math.min(RUMBLE_MAX, Math.floor(value)));
+  }
+
+  private clampProtocolByte(value: number): number {
+    if (!Number.isFinite(value)) return 0;
+    return Math.max(0, Math.min(0xFF, Math.floor(value)));
+  }
+
+  /** Clear both the raw adaptive effect and the legacy trigger-rumble state. */
+  private clearAllTriggerEffects(controller: AbstractController): void {
+    controller.clearTriggerEffects();
   }
 
   private clampIntensity(value: number): number {
@@ -686,6 +751,7 @@ export class GamepadVibrationService {
 
     if (!this.shouldRenderUsbOutput()) {
       for (const controller of controllers) {
+        this.clearAllTriggerEffects(controller);
         controller.rumble(0, 0);
       }
     } else {

--- a/entry/src/main/ets/service/input/GamepadVibrationService.ets
+++ b/entry/src/main/ets/service/input/GamepadVibrationService.ets
@@ -105,6 +105,7 @@ export class GamepadVibrationService {
   private gameUsbRumble = new Map<number, MotorPair>();
   private irUsbRumble = new Map<number, MotorPair>();
   private audioUsbRumble = new Map<number, MotorPair>();
+  private usbOutputClearedDeviceKeys: Set<string> = new Set();
   private gameDeviceLow: number = 0;
   private gameDeviceHigh: number = 0;
   private gameDeviceControllerNumber: number = 0;
@@ -303,6 +304,7 @@ export class GamepadVibrationService {
       (DS_EFFECT_RIGHT_TRIGGER | DS_EFFECT_LEFT_TRIGGER);
     if (eventFlags === 0) return;
 
+    this.usbOutputClearedDeviceKeys.delete(controller.getDeviceKey());
     controller.setAdaptiveTriggers(
       eventFlags,
       this.clampProtocolByte(frame.leftEffectType),
@@ -326,6 +328,7 @@ export class GamepadVibrationService {
       return;
     }
 
+    this.usbOutputClearedDeviceKeys.delete(controller.getDeviceKey());
     controller.rumbleTriggers(
       this.applyGameVibrationStrength(leftTrigger),
       this.applyGameVibrationStrength(rightTrigger)
@@ -413,6 +416,7 @@ export class GamepadVibrationService {
 
     try {
       const controllers = this.usbDriverService.getControllers();
+      this.usbOutputClearedDeviceKeys.clear();
       for (const controller of controllers) {
         this.clearAllTriggerEffects(controller);
         controller.rumble(0, 0);
@@ -624,10 +628,11 @@ export class GamepadVibrationService {
     if (!controller) return;
 
     if (!this.shouldRenderUsbOutput()) {
-      this.clearAllTriggerEffects(controller);
-      controller.rumble(0, 0);
+      this.clearUsbOutputOnce(controller);
       return;
     }
+
+    this.usbOutputClearedDeviceKeys.delete(controller.getDeviceKey());
 
     const emptyPair: MotorPair = { low: 0, high: 0 };
     const game = this.gameUsbRumble.get(controllerNumber) ?? emptyPair;
@@ -680,6 +685,16 @@ export class GamepadVibrationService {
   /** Clear both the raw adaptive effect and the legacy trigger-rumble state. */
   private clearAllTriggerEffects(controller: AbstractController): void {
     controller.clearTriggerEffects();
+  }
+
+  private clearUsbOutputOnce(controller: AbstractController): void {
+    const deviceKey = controller.getDeviceKey();
+    if (this.usbOutputClearedDeviceKeys.has(deviceKey)) {
+      return;
+    }
+    this.clearAllTriggerEffects(controller);
+    controller.rumble(0, 0);
+    this.usbOutputClearedDeviceKeys.add(deviceKey);
   }
 
   private clampIntensity(value: number): number {
@@ -751,8 +766,7 @@ export class GamepadVibrationService {
 
     if (!this.shouldRenderUsbOutput()) {
       for (const controller of controllers) {
-        this.clearAllTriggerEffects(controller);
-        controller.rumble(0, 0);
+        this.clearUsbOutputOnce(controller);
       }
     } else {
       slots.forEach((slot: number): void => {

--- a/entry/src/main/ets/service/streaming/MoonBridge.ets
+++ b/entry/src/main/ets/service/streaming/MoonBridge.ets
@@ -114,6 +114,12 @@ export const LI_CCAP_GYRO = 0x20;
 export const LI_CCAP_BATTERY_STATE = 0x40;
 export const LI_CCAP_RGB_LED = 0x80;
 
+// DualSense adaptive trigger update flags and payload shape.
+export const DS_EFFECT_RIGHT_TRIGGER = 0x04;
+export const DS_EFFECT_LEFT_TRIGGER = 0x08;
+export const DS_EFFECT_PAYLOAD_SIZE = 10;
+export const DS_EFFECT_TYPE_OFF = 0x05;
+
 // 运动传感器类型
 export const LI_MOTION_TYPE_ACCEL = 0x01;
 export const LI_MOTION_TYPE_GYRO = 0x02;
@@ -167,6 +173,16 @@ export interface Ds5HapticsIrV2Frame {
   sourceFrameCount: number;
   lanes: Ds5HapticsIrLaneV2[];
   laneCorrelation: number;
+}
+
+/** Raw DualSense adaptive trigger state forwarded by Sunshine. */
+export interface AdaptiveTriggersFrame {
+  controllerNumber: number;
+  eventFlags: number;
+  leftEffectType: number;
+  rightEffectType: number;
+  leftEffect: Uint8Array;
+  rightEffect: Uint8Array;
 }
 
 // 音频配置
@@ -261,6 +277,8 @@ export interface ConnectionListenerCallbacks {
   rumble?: (controllerNumber: number, lowFreqMotor: number, highFreqMotor: number) => void;
   /** Device-independent DualSense IR v2 authored haptics. */
   ds5HapticsIrV2?: (frame: Ds5HapticsIrV2Frame) => void;
+  /** Raw DualSense adaptive trigger state. */
+  setAdaptiveTriggers?: (frame: AdaptiveTriggersFrame) => void;
   /** 连接状态更新 */
   connectionStatusUpdate?: (connectionStatus: number) => void;
   /** 分辨率变更 */

--- a/entry/src/main/ets/service/streaming/StreamingSession.ets
+++ b/entry/src/main/ets/service/streaming/StreamingSession.ets
@@ -1759,6 +1759,7 @@ export class StreamingSession {
 
   private async cleanup(): Promise<void> {
     console.info('清理串流资源');
+    this.isRunning = false;
     // LiStopConnection() suppresses connectionTerminated for an explicit stop,
     // so clear controller output here as well as in the termination callback.
     GamepadManager.getInstance().stopAllVibration();

--- a/entry/src/main/ets/service/streaming/StreamingSession.ets
+++ b/entry/src/main/ets/service/streaming/StreamingSession.ets
@@ -46,7 +46,8 @@ import {
   KEY_ACTION_DOWN,
   KEY_ACTION_UP,
   STAGE_NAME_RESOLUTION,
-  Ds5HapticsIrV2Frame
+  Ds5HapticsIrV2Frame,
+  AdaptiveTriggersFrame
 } from './MoonBridge';
 import nativeLib from 'libmoonlight_nativelib.so';
 
@@ -216,6 +217,7 @@ interface StreamCallbacks {
   setHdrMode?: (enabled: boolean) => void;
   rumble?: (controllerNumber: number, lowFreqMotor: number, highFreqMotor: number) => void;
   ds5HapticsIrV2?: (frame: Ds5HapticsIrV2Frame) => void;
+  setAdaptiveTriggers?: (frame: AdaptiveTriggersFrame) => void;
   rumbleTriggers?: (controllerNumber: number, leftTrigger: number, rightTrigger: number) => void;
   setMotionEventState?: (controllerNumber: number, motionType: number, reportRateHz: number) => void;
   setControllerLED?: (controllerNumber: number, r: number, g: number, b: number) => void;
@@ -1282,6 +1284,10 @@ export class StreamingSession {
         if (this.hdrStateCallback) this.hdrStateCallback(enabled);
       },
       rumble: (cn: number, low: number, high: number): void => {
+        // Rumble callbacks are queued asynchronously and may outlive the
+        // connection that produced them. Do not let a late packet restart
+        // feedback after connectionTerminated has already cleared it.
+        if (!this.isRunning) return;
         GamepadManager.getInstance().handleRumble(cn, low, high);
       },
       ds5HapticsIrV2: (frame: Ds5HapticsIrV2Frame): void => {
@@ -1290,7 +1296,14 @@ export class StreamingSession {
         if (!this.isRunning) return;
         GamepadManager.getInstance().handleDs5HapticsIrV2(frame);
       },
+      setAdaptiveTriggers: (frame: AdaptiveTriggersFrame): void => {
+        // This callback owns a separate TSFN and may already be queued when the
+        // session ends. Never apply stale trigger state to the next session.
+        if (!this.isRunning) return;
+        GamepadManager.getInstance().handleAdaptiveTriggers(frame);
+      },
       rumbleTriggers: (cn: number, lt: number, rt: number): void => {
+        if (!this.isRunning) return;
         GamepadManager.getInstance().handleRumbleTriggers(cn, lt, rt);
       },
       setMotionEventState: (cn: number, motionType: number, rateHz: number): void => {
@@ -1746,6 +1759,9 @@ export class StreamingSession {
 
   private async cleanup(): Promise<void> {
     console.info('清理串流资源');
+    // LiStopConnection() suppresses connectionTerminated for an explicit stop,
+    // so clear controller output here as well as in the termination callback.
+    GamepadManager.getInstance().stopAllVibration();
     this.stopMicrophone();
     await this.stopAbr();
     this.nativeModule.setPerformanceModeEnabled(false);

--- a/entry/src/main/ets/service/usbdriver/AbstractController.ets
+++ b/entry/src/main/ets/service/usbdriver/AbstractController.ets
@@ -284,6 +284,13 @@ export abstract class AbstractController {
    * 停止控制器
    */
   abstract stop(): void;
+
+  /**
+   * 等待控制器完成异步停机。默认控制器的 stop() 是同步的。
+   */
+  waitForStop(): Promise<void> {
+    return Promise.resolve();
+  }
   
   /**
    * 检查控制器是否已连接
@@ -323,4 +330,18 @@ export abstract class AbstractController {
    * @param rightTrigger 右扳机震动强度 (0-65535)
    */
   abstract rumbleTriggers(leftTrigger: number, rightTrigger: number): void;
+
+  /** Raw DualSense adaptive trigger update. Unsupported controllers ignore it. */
+  setAdaptiveTriggers(
+    _eventFlags: number,
+    _leftEffectType: number,
+    _rightEffectType: number,
+    _leftEffect: Uint8Array,
+    _rightEffect: Uint8Array
+  ): void {}
+
+  /** Clear all trigger feedback. Raw-effect controllers should override this atomically. */
+  clearTriggerEffects(): void {
+    this.rumbleTriggers(0, 0);
+  }
 }

--- a/entry/src/main/ets/service/usbdriver/AbstractDualSenseController.ets
+++ b/entry/src/main/ets/service/usbdriver/AbstractDualSenseController.ets
@@ -37,6 +37,7 @@ export abstract class AbstractDualSenseController extends AbstractController {
   // DDK 高速轮询器 (绕过 usbManager IPC)
   private ddkPoller: DdkUsbPoller | null = null;
   private useDdkPolling: boolean = false;
+  private stopPromise: Promise<void> | null = null;
   
   // IMU 数据
   protected gyroX: number = 0;
@@ -510,11 +511,33 @@ export abstract class AbstractDualSenseController extends AbstractController {
     this.stopped = true;
     this.markStopped();
 
-    // 先发送振动停止命令（必须在 DDK 释放前，否则无法发送）
-    this.rumble(0, 0);
-
-    // 保存 DDK 状态，再停止 DDK 轮询器
+    // Keep the transport alive until the final feedback report has completed.
+    // USB bulkTransfer is asynchronous, so closing the pipe here can cancel the
+    // Off report before it reaches the controller.
     const wasDdkPolling = this.useDdkPolling;
+    this.stopPromise = this.stopAndRelease(wasDdkPolling);
+  }
+
+  waitForStop(): Promise<void> {
+    return this.stopPromise ?? Promise.resolve();
+  }
+
+  private async stopAndRelease(wasDdkPolling: boolean): Promise<void> {
+    try {
+      await this.stopFeedback();
+    } catch (err) {
+      console.warn(`${TAG} 停止反馈失败，继续释放控制器:`, err);
+    }
+
+    try {
+      this.releaseTransport(wasDdkPolling);
+    } catch (err) {
+      console.error(`${TAG} 释放控制器资源异常:`, err);
+    }
+  }
+
+  private releaseTransport(wasDdkPolling: boolean): void {
+    // 停止 DDK 轮询器
     if (this.ddkPoller) {
       this.ddkPoller.stop();
       this.ddkPoller = null;
@@ -542,6 +565,14 @@ export abstract class AbstractDualSenseController extends AbstractController {
     
     // 通知设备已移除
     this.notifyDeviceRemoved();
+  }
+
+  /**
+   * 停止设备反馈。DualSense 可覆盖此方法，用一份输出报告原子清理马达和扳机。
+   */
+  protected async stopFeedback(): Promise<void> {
+    this.rumble(0, 0);
+    this.rumbleTriggers(0, 0);
   }
   
   /**

--- a/entry/src/main/ets/service/usbdriver/DualSenseController.ets
+++ b/entry/src/main/ets/service/usbdriver/DualSenseController.ets
@@ -25,6 +25,7 @@ const TAG = '[USB-DS5]';
 const OUTPUT_REPORT_SIZE = 48;
 const OUTPUT_REPORT_ID = 0x02;
 const OUTPUT_WRITE_TIMEOUT_MS = 500;
+const OUTPUT_STOP_RETRY_LIMIT = 1;
 const VALID_COMPATIBLE_RUMBLE = 0x01;
 const VALID_DISABLE_AUDIO_HAPTICS = 0x02;
 const VALID_RIGHT_TRIGGER = 0x04;
@@ -69,6 +70,7 @@ export class DualSenseController extends AbstractDualSenseController {
   private outputWriteInFlight: boolean = false;
   private outputDrainPromise: Promise<void> | null = null;
   private outputStopping: boolean = false;
+  private outputStopRetriesRemaining: number = 0;
   
   constructor(
     device: usbManager.USBDevice,
@@ -322,6 +324,7 @@ const gyrox = readShortLE(buffer, imuOffset);
   /** Stop both motor and trigger feedback with one coherent device report. */
   protected async stopFeedback(): Promise<void> {
     this.outputStopping = true;
+    this.outputStopRetriesRemaining = OUTPUT_STOP_RETRY_LIMIT;
     this.rumbleLow = 0;
     this.rumbleHigh = 0;
     this.resetTriggerEffects();
@@ -434,10 +437,22 @@ const gyrox = readShortLE(buffer, imuOffset);
       while (this.outputWritePending) {
         this.outputWritePending = false;
         const report = this.buildOutputReport();
-        const result = await this.bulkWrite(report, OUTPUT_WRITE_TIMEOUT_MS);
-        if (result !== report.length) {
-          console.warn(TAG + ' output report failed: expected=' +
-            report.length.toString() + ', actual=' + result.toString());
+        const stoppingReport = this.outputStopping;
+        let writeSucceeded = false;
+        try {
+          const result = await this.bulkWrite(report, OUTPUT_WRITE_TIMEOUT_MS);
+          writeSucceeded = result === report.length;
+          if (!writeSucceeded) {
+            console.warn(TAG + ' output report failed: expected=' +
+              report.length.toString() + ', actual=' + result.toString());
+          }
+        } catch (writeErr) {
+          console.error(TAG + ' output report exception: ' + String(writeErr));
+        }
+        if (!writeSucceeded && stoppingReport &&
+            this.outputStopRetriesRemaining > 0) {
+          this.outputStopRetriesRemaining--;
+          this.outputWritePending = true;
         }
       }
     } catch (err) {

--- a/entry/src/main/ets/service/usbdriver/DualSenseController.ets
+++ b/entry/src/main/ets/service/usbdriver/DualSenseController.ets
@@ -22,10 +22,53 @@ import { readShortLE, TRIGGER_MAX } from '../input/GamepadTypes';
 
 const TAG = '[USB-DS5]';
 
+const OUTPUT_REPORT_SIZE = 48;
+const OUTPUT_REPORT_ID = 0x02;
+const OUTPUT_WRITE_TIMEOUT_MS = 500;
+const VALID_COMPATIBLE_RUMBLE = 0x01;
+const VALID_DISABLE_AUDIO_HAPTICS = 0x02;
+const VALID_RIGHT_TRIGGER = 0x04;
+const VALID_LEFT_TRIGGER = 0x08;
+const TRIGGER_EFFECT_PAYLOAD_SIZE = 10;
+// DualSense's USB clear-effect command (the 0x05 mode is not the same as a
+// zero-valued payload with a zero mode).
+const TRIGGER_EFFECT_OFF = 0x05;
+const TRIGGER_EFFECT_FEEDBACK = 0x01;
+
+const OFFSET_VALID_FLAG0 = 1;
+const OFFSET_VALID_FLAG1 = 2;
+const OFFSET_RUMBLE_RIGHT = 3;
+const OFFSET_RUMBLE_LEFT = 4;
+const OFFSET_RIGHT_TRIGGER_TYPE = 11;
+const OFFSET_RIGHT_TRIGGER_PAYLOAD = 12;
+const OFFSET_LEFT_TRIGGER_TYPE = 22;
+const OFFSET_LEFT_TRIGGER_PAYLOAD = 23;
+
 export class DualSenseController extends AbstractDualSenseController {
-  // 去重: 记录上次发送的振动值
-  private lastRumbleLow: number = -1;
-  private lastRumbleHigh: number = -1;
+  // DualSense output fields share one HID report. Keep motor, legacy trigger,
+  // and raw adaptive-trigger state separately, then merge them when the report
+  // is built. A legacy trigger update must not overwrite a raw effect that is
+  // currently active; once the raw effect is turned off, the last legacy state
+  // becomes effective again.
+  private rumbleLow: number = 0;
+  private rumbleHigh: number = 0;
+  private rightLegacyTriggerEffectType: number = TRIGGER_EFFECT_OFF;
+  private leftLegacyTriggerEffectType: number = TRIGGER_EFFECT_OFF;
+  private rightLegacyTriggerEffect: Uint8Array = new Uint8Array(TRIGGER_EFFECT_PAYLOAD_SIZE);
+  private leftLegacyTriggerEffect: Uint8Array = new Uint8Array(TRIGGER_EFFECT_PAYLOAD_SIZE);
+  private rightAdaptiveTriggerEffectType: number = TRIGGER_EFFECT_OFF;
+  private leftAdaptiveTriggerEffectType: number = TRIGGER_EFFECT_OFF;
+  private rightAdaptiveTriggerEffect: Uint8Array = new Uint8Array(TRIGGER_EFFECT_PAYLOAD_SIZE);
+  private leftAdaptiveTriggerEffect: Uint8Array = new Uint8Array(TRIGGER_EFFECT_PAYLOAD_SIZE);
+  private rightAdaptiveTriggerActive: boolean = false;
+  private leftAdaptiveTriggerActive: boolean = false;
+
+  // USB writes are asynchronous. Coalesce updates that arrive while a write is
+  // active, then send the latest complete state after the active write finishes.
+  private outputWritePending: boolean = false;
+  private outputWriteInFlight: boolean = false;
+  private outputDrainPromise: Promise<void> | null = null;
+  private outputStopping: boolean = false;
   
   constructor(
     device: usbManager.USBDevice,
@@ -215,59 +258,196 @@ const gyrox = readShortLE(buffer, imuOffset);
    * 震动反馈 (去重: 跳过相同非零值, 零值始终发送)
    */
   rumble(lowFreqMotor: number, highFreqMotor: number): void {
+    if (this.outputStopping) return;
+
+    const nextLow = this.rumbleToByte(lowFreqMotor);
+    const nextHigh = this.rumbleToByte(highFreqMotor);
+
     // 零值(停止振动)始终发送, 非零重复值跳过
-    if (lowFreqMotor !== 0 || highFreqMotor !== 0) {
-      if (lowFreqMotor === this.lastRumbleLow && highFreqMotor === this.lastRumbleHigh) {
+    if (nextLow !== 0 || nextHigh !== 0) {
+      if (nextLow === this.rumbleLow && nextHigh === this.rumbleHigh) {
         return;
       }
     }
-    this.lastRumbleLow = lowFreqMotor;
-    this.lastRumbleHigh = highFreqMotor;
-
-    // DualSense 震动命令 (USB 模式)
-    const data = new Uint8Array(48);
-    data[0] = 0x02;  // 报告 ID
-    data[1] = 0xFF;  // 有效字段标志
-    data[2] = 0xF7;  // 有效字段标志 2
-    
-    // 震动强度
-    data[3] = (highFreqMotor >> 8) & 0xFF;  // 右马达 (高频)
-    data[4] = (lowFreqMotor >> 8) & 0xFF;   // 左马达 (低频)
-    
-    // 扳机效果（可选，设为默认）
-    data[11] = 0x00;  // 右扳机模式
-    data[22] = 0x00;  // 左扳机模式
-    
-    // 灯光（可选）
-    data[45] = 0x02;  // 玩家指示灯
-    data[46] = 0x00;  // R
-    data[47] = 0x00;  // G
-    // data[48] = 0xFF;  // B - 超出数组范围，移除
-    
-    this.bulkWrite(data);
+    this.rumbleLow = nextLow;
+    this.rumbleHigh = nextHigh;
+    this.queueOutputReport();
   }
   
   /**
    * 扳机震动反馈
    */
   rumbleTriggers(leftTrigger: number, rightTrigger: number): void {
-    // DualSense 支持自适应扳机效果
-    // 这里简化为震动模式
-    const data = new Uint8Array(48);
-    data[0] = 0x02;
-    data[1] = 0x04;  // 只更新扳机
-    data[2] = 0x00;
-    
-    // 右扳机效果
-    data[11] = 0x01;  // 连续阻力模式
-    data[12] = 0x00;  // 起始位置
-    data[13] = (rightTrigger >> 8) & 0xFF;  // 强度
-    
-    // 左扳机效果
-    data[22] = 0x01;
-    data[23] = 0x00;
-    data[24] = (leftTrigger >> 8) & 0xFF;
-    
-    this.bulkWrite(data);
+    if (this.outputStopping) return;
+
+    this.setLegacyTriggerRumbleState(true, this.rumbleToByte(leftTrigger));
+    this.setLegacyTriggerRumbleState(false, this.rumbleToByte(rightTrigger));
+    this.queueOutputReport();
+  }
+
+  /** Apply the raw DualSense type + 10-byte effect supplied by Sunshine. */
+  setAdaptiveTriggers(eventFlags: number,
+    leftEffectType: number, rightEffectType: number,
+    leftEffect: Uint8Array, rightEffect: Uint8Array): void {
+    if (this.outputStopping) return;
+
+    let updated = false;
+    if ((eventFlags & VALID_RIGHT_TRIGGER) !== 0) {
+      this.rightAdaptiveTriggerEffectType = this.clampByte(rightEffectType);
+      this.copyTriggerEffect(this.rightAdaptiveTriggerEffect, rightEffect);
+      this.rightAdaptiveTriggerActive =
+        this.rightAdaptiveTriggerEffectType !== TRIGGER_EFFECT_OFF;
+      updated = true;
+    }
+    if ((eventFlags & VALID_LEFT_TRIGGER) !== 0) {
+      this.leftAdaptiveTriggerEffectType = this.clampByte(leftEffectType);
+      this.copyTriggerEffect(this.leftAdaptiveTriggerEffect, leftEffect);
+      this.leftAdaptiveTriggerActive =
+        this.leftAdaptiveTriggerEffectType !== TRIGGER_EFFECT_OFF;
+      updated = true;
+    }
+    if (updated) {
+      this.queueOutputReport();
+    }
+  }
+
+  /** Clear legacy and raw trigger sources in a single output-state update. */
+  clearTriggerEffects(): void {
+    if (this.outputStopping) return;
+
+    this.resetTriggerEffects();
+    this.queueOutputReport();
+  }
+
+  /** Stop both motor and trigger feedback with one coherent device report. */
+  protected async stopFeedback(): Promise<void> {
+    this.outputStopping = true;
+    this.rumbleLow = 0;
+    this.rumbleHigh = 0;
+    this.resetTriggerEffects();
+    this.queueOutputReport();
+    await this.waitForOutputDrain();
+  }
+
+  private resetTriggerEffects(): void {
+    this.setLegacyTriggerRumbleState(true, 0);
+    this.setLegacyTriggerRumbleState(false, 0);
+    this.clearAdaptiveTriggerState(true);
+    this.clearAdaptiveTriggerState(false);
+  }
+
+  private setLegacyTriggerRumbleState(left: boolean, strength: number): void {
+    const effect = left ? this.leftLegacyTriggerEffect : this.rightLegacyTriggerEffect;
+    effect.fill(0);
+    const effectType = strength === 0 ? TRIGGER_EFFECT_OFF : TRIGGER_EFFECT_FEEDBACK;
+    if (strength !== 0) {
+      effect[0] = 0; // Start position
+      effect[1] = strength;
+    }
+    if (left) {
+      this.leftLegacyTriggerEffectType = effectType;
+    } else {
+      this.rightLegacyTriggerEffectType = effectType;
+    }
+  }
+
+  private clearAdaptiveTriggerState(left: boolean): void {
+    const effect = left ? this.leftAdaptiveTriggerEffect : this.rightAdaptiveTriggerEffect;
+    effect.fill(0);
+    if (left) {
+      this.leftAdaptiveTriggerEffectType = TRIGGER_EFFECT_OFF;
+      this.leftAdaptiveTriggerActive = false;
+    } else {
+      this.rightAdaptiveTriggerEffectType = TRIGGER_EFFECT_OFF;
+      this.rightAdaptiveTriggerActive = false;
+    }
+  }
+
+  private copyTriggerEffect(target: Uint8Array, source: Uint8Array): void {
+    target.fill(0);
+    const length = Math.min(TRIGGER_EFFECT_PAYLOAD_SIZE, source.length);
+    for (let index = 0; index < length; index++) {
+      target[index] = source[index];
+    }
+  }
+
+  private clampByte(value: number): number {
+    if (!Number.isFinite(value)) return 0;
+    return Math.max(0, Math.min(0xFF, Math.floor(value)));
+  }
+
+  private rumbleToByte(value: number): number {
+    if (!Number.isFinite(value)) return 0;
+    const clamped = Math.max(0, Math.min(0xFFFF, Math.floor(value)));
+    return (clamped >> 8) & 0xFF;
+  }
+
+  private buildOutputReport(): Uint8Array {
+    const data = new Uint8Array(OUTPUT_REPORT_SIZE);
+    data[0] = OUTPUT_REPORT_ID;
+    data[OFFSET_VALID_FLAG0] = VALID_COMPATIBLE_RUMBLE |
+      VALID_DISABLE_AUDIO_HAPTICS | VALID_RIGHT_TRIGGER | VALID_LEFT_TRIGGER;
+    // Leave validFlag1 at zero so rumble/trigger updates do not modify LEDs,
+    // power saving, microphone state, or audio controls.
+    data[OFFSET_VALID_FLAG1] = 0;
+    data[OFFSET_RUMBLE_RIGHT] = this.rumbleHigh;
+    data[OFFSET_RUMBLE_LEFT] = this.rumbleLow;
+    const rightType = this.rightAdaptiveTriggerActive
+      ? this.rightAdaptiveTriggerEffectType
+      : this.rightLegacyTriggerEffectType;
+    const leftType = this.leftAdaptiveTriggerActive
+      ? this.leftAdaptiveTriggerEffectType
+      : this.leftLegacyTriggerEffectType;
+    const rightEffect = this.rightAdaptiveTriggerActive
+      ? this.rightAdaptiveTriggerEffect
+      : this.rightLegacyTriggerEffect;
+    const leftEffect = this.leftAdaptiveTriggerActive
+      ? this.leftAdaptiveTriggerEffect
+      : this.leftLegacyTriggerEffect;
+    data[OFFSET_RIGHT_TRIGGER_TYPE] = rightType;
+    data[OFFSET_LEFT_TRIGGER_TYPE] = leftType;
+    for (let index = 0; index < TRIGGER_EFFECT_PAYLOAD_SIZE; index++) {
+      data[OFFSET_RIGHT_TRIGGER_PAYLOAD + index] = rightEffect[index];
+      data[OFFSET_LEFT_TRIGGER_PAYLOAD + index] = leftEffect[index];
+    }
+    return data;
+  }
+
+  private queueOutputReport(): void {
+    this.outputWritePending = true;
+    if (!this.outputWriteInFlight) {
+      this.outputDrainPromise = this.drainOutputReports();
+    }
+  }
+
+  private async waitForOutputDrain(): Promise<void> {
+    while (this.outputDrainPromise !== null) {
+      const drain = this.outputDrainPromise;
+      await drain;
+    }
+  }
+
+  private async drainOutputReports(): Promise<void> {
+    if (this.outputWriteInFlight) return;
+    this.outputWriteInFlight = true;
+    try {
+      while (this.outputWritePending) {
+        this.outputWritePending = false;
+        const report = this.buildOutputReport();
+        const result = await this.bulkWrite(report, OUTPUT_WRITE_TIMEOUT_MS);
+        if (result !== report.length) {
+          console.warn(TAG + ' output report failed: expected=' +
+            report.length.toString() + ', actual=' + result.toString());
+        }
+      }
+    } catch (err) {
+      console.error(TAG + ' output report exception: ' + String(err));
+    } finally {
+      this.outputWriteInFlight = false;
+      this.outputDrainPromise = null;
+      if (this.outputWritePending) {
+        this.queueOutputReport();
+      }
+    }
   }
 }

--- a/entry/src/main/ets/service/usbdriver/UsbDriverService.ets
+++ b/entry/src/main/ets/service/usbdriver/UsbDriverService.ets
@@ -66,6 +66,10 @@ export class UsbDriverService implements UsbDriverListener {
   private static instance: UsbDriverService;
   
   private started: boolean = false;
+  // start()/stop() may overlap while USB teardown or event subscription awaits.
+  private startRequested: boolean = false;
+  private lifecycleGeneration: number = 0;
+  private pendingStart: Promise<void> | null = null;
   private controllers: AbstractController[] = [];
   private listener: UsbDriverListener | null = null;
   private stateListener: UsbDriverStateListener | null = null;
@@ -90,6 +94,8 @@ export class UsbDriverService implements UsbDriverListener {
   private resetTimerId: number | null = null;
   // stop() keeps DualSense transports alive while the final Off report drains.
   private pendingControllerStops: Promise<void> | null = null;
+  // Device keys awaiting kernel HID rebind after a controller release.
+  private pendingResetDeviceKeys: Set<string> = new Set();
   
   private constructor() {
     console.info(`${TAG} 创建 USB 驱动服务实例`);
@@ -149,58 +155,109 @@ export class UsbDriverService implements UsbDriverListener {
    * 可用于在设备空闲断开后手动重连
    */
   async rescanDevices(): Promise<void> {
+    const requestGeneration: number = this.lifecycleGeneration;
+    if (!this.isLifecycleActive(requestGeneration)) {
+      return;
+    }
     console.info(`${TAG} 手动触发设备重新扫描`);
     // 清空已处理设备列表，强制重新枚举所有设备
     this.processedDevices.clear();
-    await this.enumerateDevices();
+    await this.enumerateDevices(requestGeneration);
   }
   
   /**
    * 启动服务
    */
   async start(): Promise<void> {
+    if (!this.startRequested) {
+      this.startRequested = true;
+      this.lifecycleGeneration++;
+    }
+    const requestGeneration = this.lifecycleGeneration;
+
+    // All callers share the active transition. If stop() cancels it and a later
+    // start() requests a new generation, that generation starts after this one.
+    while (this.pendingStart !== null) {
+      const activeStart = this.pendingStart;
+      await activeStart;
+      if (!this.isStartRequestCurrent(requestGeneration)) {
+        return;
+      }
+    }
+
+    if (!this.isStartRequestCurrent(requestGeneration)) {
+      return;
+    }
     if (this.started) {
       console.info(`${TAG} 服务已启动`);
       return;
     }
 
+    const activeStart = this.startInternal(requestGeneration);
+    this.pendingStart = activeStart;
+    try {
+      await activeStart;
+    } finally {
+      if (this.pendingStart === activeStart) {
+        this.pendingStart = null;
+      }
+    }
+  }
+
+  private isStartRequestCurrent(requestGeneration: number): boolean {
+    return this.startRequested && this.lifecycleGeneration === requestGeneration;
+  }
+
+  private isLifecycleActive(requestGeneration: number): boolean {
+    return this.started && this.isStartRequestCurrent(requestGeneration);
+  }
+
+  private async startInternal(requestGeneration: number): Promise<void> {
     if (this.pendingControllerStops !== null) {
-      await this.pendingControllerStops;
-      this.pendingControllerStops = null;
+      const pendingStops = this.pendingControllerStops;
+      await pendingStops;
+      if (this.pendingControllerStops === pendingStops) {
+        this.pendingControllerStops = null;
+      }
     }
-    
+
+    if (!this.isStartRequestCurrent(requestGeneration)) {
+      return;
+    }
+
     console.info(`${TAG} 启动 USB 驱动服务`);
-    this.started = true;
-    
-    // 取消上一次 stop() 调度的内核驱动重绑定（避免干扰新会话）
-    if (this.resetTimerId !== null) {
-      clearTimeout(this.resetTimerId);
-      this.resetTimerId = null;
-      console.info(`${TAG} 已取消待执行的内核驱动重绑定`);
-    }
     
     // 订阅 USB 设备插拔事件
-    await this.subscribeUsbEvents();
-    
+    await this.subscribeUsbEvents(requestGeneration);
+    if (!this.isStartRequestCurrent(requestGeneration)) {
+      this.unsubscribeUsbEvents();
+      return;
+    }
+
+    this.started = true;
+
     // 枚举已连接的设备
-    await this.enumerateDevices();
-    
+    await this.enumerateDevices(requestGeneration);
+    if (!this.isLifecycleActive(requestGeneration)) {
+      return;
+    }
+
     // 启动定期重新扫描定时器
-    this.startRescanTimer();
+    this.startRescanTimer(requestGeneration);
   }
   
   /**
    * 启动定期重新扫描定时器
    * 用于检测从省电模式唤醒或重新连接的设备
    */
-  private startRescanTimer(): void {
+  private startRescanTimer(requestGeneration: number): void {
     if (this.rescanTimerId !== null) {
       return;
     }
     
     console.info(`${TAG} 启动设备重新扫描定时器，间隔 ${UsbDriverService.RESCAN_INTERVAL_MS}ms`);
     this.rescanTimerId = setInterval(() => {
-      this.checkAndRescanDevices();
+      this.checkAndRescanDevices(requestGeneration);
     }, UsbDriverService.RESCAN_INTERVAL_MS);
   }
   
@@ -219,7 +276,11 @@ export class UsbDriverService implements UsbDriverListener {
    * 检查并重新扫描设备
    * 如果有控制器断开但设备仍然连接，尝试重新初始化
    */
-  private async checkAndRescanDevices(): Promise<void> {
+  private async checkAndRescanDevices(requestGeneration: number): Promise<void> {
+    if (!this.isLifecycleActive(requestGeneration)) {
+      return;
+    }
+
     // 检查是否有断开的控制器但设备仍然存在
     try {
       const currentDevices = usbManager.getDevices();
@@ -252,7 +313,7 @@ export class UsbDriverService implements UsbDriverListener {
       
       if (hasUnprocessedDevices) {
         console.info(`${TAG} 检测到未处理的设备，执行重新枚举`);
-        await this.enumerateDevices();
+        await this.enumerateDevices(requestGeneration);
       }
     } catch (err) {
       console.error(`${TAG} 检查设备状态失败:`, err);
@@ -262,17 +323,30 @@ export class UsbDriverService implements UsbDriverListener {
   /**
    * 订阅 USB 设备插拔事件
    */
-  private async subscribeUsbEvents(): Promise<void> {
+  private async subscribeUsbEvents(requestGeneration: number): Promise<void> {
     try {
       const subscribeInfo: commonEventManager.CommonEventSubscribeInfo = {
         events: [USB_DEVICE_ATTACHED, USB_DEVICE_DETACHED]
       };
       
-      this.usbSubscriber = await commonEventManager.createSubscriber(subscribeInfo);
+      const subscriber: commonEventManager.CommonEventSubscriber =
+        await commonEventManager.createSubscriber(subscribeInfo);
+      if (!this.isStartRequestCurrent(requestGeneration)) {
+        try {
+          commonEventManager.unsubscribe(subscriber);
+        } catch (err) {
+          console.warn(`${TAG} 取消过期 USB 订阅失败:`, err);
+        }
+        return;
+      }
+      this.usbSubscriber = subscriber;
       
-      commonEventManager.subscribe(this.usbSubscriber, (err, data) => {
+      commonEventManager.subscribe(subscriber, (err, data) => {
         if (err) {
           console.error(`${TAG} USB 事件接收错误:`, err);
+          return;
+        }
+        if (!this.isLifecycleActive(requestGeneration)) {
           return;
         }
         
@@ -282,12 +356,12 @@ export class UsbDriverService implements UsbDriverListener {
           // 设备插入，延迟处理以等待系统稳定
           console.info(`${TAG} USB 设备已插入，延迟 500ms 后枚举设备`);
           setTimeout(() => {
-            this.enumerateDevices();
+            this.enumerateDevices(requestGeneration);
           }, 500);
         } else if (data.event === USB_DEVICE_DETACHED) {
           // 设备拔出，检查控制器状态
           console.info(`${TAG} USB 设备已拔出，检查控制器状态`);
-          this.checkDetachedControllers();
+          this.checkDetachedControllers(requestGeneration);
         }
       });
       
@@ -315,7 +389,11 @@ export class UsbDriverService implements UsbDriverListener {
   /**
    * 检查已断开的控制器
    */
-  private checkDetachedControllers(): void {
+  private checkDetachedControllers(requestGeneration: number): void {
+    if (!this.isLifecycleActive(requestGeneration)) {
+      return;
+    }
+
     // 获取当前已连接的 USB 设备列表
     try {
       const currentDevices = usbManager.getDevices();
@@ -350,7 +428,11 @@ export class UsbDriverService implements UsbDriverListener {
    * 停止服务
    */
   stop(): void {
+    this.startRequested = false;
+    this.lifecycleGeneration++;
+
     if (!this.started) {
+      this.schedulePendingReset();
       return;
     }
     
@@ -366,6 +448,9 @@ export class UsbDriverService implements UsbDriverListener {
     
     // 保存已处理设备的键值，用于后续内核驱动重绑定
     const releasedDeviceKeys = new Set(this.processedDevices);
+    releasedDeviceKeys.forEach((deviceKey: string): void => {
+      this.pendingResetDeviceKeys.add(deviceKey);
+    });
     
     // 停止所有控制器（释放 USB 接口独占 + 关闭管道）。DualSense 的
     // stop() 会异步等待最终 Off 报告，因此保存完成 Promise 供下一次 start() 等待。
@@ -385,21 +470,34 @@ export class UsbDriverService implements UsbDriverListener {
     this.processedDevices.clear();
     console.info(`${TAG} USB 驱动服务已停止，已释放 ${stoppedCount} 个控制器的 USB 独占`);
     
-    // 尝试触发内核 HID 驱动重新绑定
-    // 背景：claimInterface(force=true) 会解绑内核 HID 驱动，
-    // 但 releaseInterface() + closePipe() 后内核不会自动重新绑定。
-    // 策略：重新打开设备，通过 native ioctl (USBDEVFS_CONNECT) 显式通知内核重绑定。
-    // 注意：DDK 模式下跳过重绑定，避免下次启动时 ClaimInterface 竞争
-    if (stoppedCount > 0 && !this.ddkEnabled) {
-      this.resetTimerId = setTimeout(() => {
-        this.resetTimerId = null;
-        this.resetReleasedUsbDevices(releasedDeviceKeys);
-      }, UsbDriverService.USB_RESET_DELAY_MS);
-    } else if (this.ddkEnabled) {
+    // 尝试触发内核 HID 驱动重新绑定。DDK 模式下跳过重绑定，避免下次
+    // 启动时 ClaimInterface 竞争；待后续非 DDK 停止时再处理保留的 key。
+    if (!this.ddkEnabled) {
+      this.schedulePendingReset();
+    } else {
       console.info(`${TAG} DDK 模式，跳过内核 HID 驱动重绑定`);
     }
     
     this.ddkEnabled = false;
+  }
+
+  private schedulePendingReset(): void {
+    if (this.resetTimerId !== null) {
+      clearTimeout(this.resetTimerId);
+      this.resetTimerId = null;
+    }
+    if (this.ddkEnabled || this.pendingResetDeviceKeys.size === 0) {
+      return;
+    }
+
+    const releasedKeys: Set<string> = new Set(this.pendingResetDeviceKeys);
+    this.resetTimerId = setTimeout(() => {
+      this.resetTimerId = null;
+      const completedKeys: Set<string> = this.resetReleasedUsbDevices(releasedKeys);
+      completedKeys.forEach((deviceKey: string): void => {
+        this.pendingResetDeviceKeys.delete(deviceKey);
+      });
+    }, UsbDriverService.USB_RESET_DELAY_MS);
   }
   
   /**
@@ -411,15 +509,11 @@ export class UsbDriverService implements UsbDriverListener {
    *    等价于 libusb_attach_kernel_driver()
    * 3. 如果 CONNECT 失败，后备方案使用 USBDEVFS_RESET 重置设备
    */
-  private resetReleasedUsbDevices(releasedKeys: Set<string>): void {
-    // 如果服务已重新启动，跳过重置（避免干扰新会话的 USB 接口声明）
-    if (this.started) {
-      console.info(`${TAG} 服务已重新启动，跳过 USB 设备内核驱动重绑定`);
-      return;
-    }
+  private resetReleasedUsbDevices(releasedKeys: Set<string>): Set<string> {
+    const completedKeys: Set<string> = new Set();
     if (!usbHelper) {
       console.warn(`${TAG} UsbHelper native 模块不可用，无法重绑定内核驱动`);
-      return;
+      return completedKeys;
     }
     
     try {
@@ -432,6 +526,17 @@ export class UsbDriverService implements UsbDriverListener {
         
         if (!releasedKeys.has(key)) continue;
         if (!this.deviceHasHidInterface(device)) continue;
+
+        // A new lifecycle may already own this device. Rebinding it here would
+        // race the active controller, so only finish the pending bookkeeping.
+        const activeController = this.controllers.find(
+          (controller: AbstractController): boolean =>
+            controller.getDeviceKey() === key && controller.isConnected()
+        );
+        if (activeController) {
+          completedKeys.add(key);
+          continue;
+        }
         
         try {
           // 检查权限（之前已授权，应该仍然有效）
@@ -463,6 +568,7 @@ export class UsbDriverService implements UsbDriverListener {
           // 关闭连接
           usbManager.closePipe(pipe);
           resetCount++;
+          completedKeys.add(key);
           console.info(`${TAG} USB 设备内核驱动重绑定完成: ${device.name}`);
         } catch (e) {
           console.warn(`${TAG} USB 设备重置失败 (${device.name}):`, e);
@@ -475,6 +581,7 @@ export class UsbDriverService implements UsbDriverListener {
     } catch (e) {
       console.warn(`${TAG} resetReleasedUsbDevices 异常:`, e);
     }
+    return completedKeys;
   }
   
   /**
@@ -495,14 +602,21 @@ export class UsbDriverService implements UsbDriverListener {
   /**
    * 枚举 USB 设备
    */
-  private async enumerateDevices(): Promise<void> {
+  private async enumerateDevices(requestGeneration: number): Promise<void> {
+    if (!this.isLifecycleActive(requestGeneration)) {
+      return;
+    }
+
     try {
       const devices: usbManager.USBDevice[] = usbManager.getDevices();
       console.info(`${TAG} 发现 ${devices.length} 个 USB 设备`);
       
       for (let i: number = 0; i < devices.length; i++) {
+        if (!this.isLifecycleActive(requestGeneration)) {
+          return;
+        }
         const device: usbManager.USBDevice = devices[i];
-        await this.handleUsbDevice(device);
+        await this.handleUsbDevice(device, requestGeneration);
       }
     } catch (err) {
       console.error(`${TAG} 枚举设备失败:`, err);
@@ -512,7 +626,11 @@ export class UsbDriverService implements UsbDriverListener {
   /**
    * 处理 USB 设备
    */
-  private async handleUsbDevice(device: usbManager.USBDevice): Promise<void> {
+  private async handleUsbDevice(device: usbManager.USBDevice, requestGeneration: number): Promise<void> {
+    if (!this.isLifecycleActive(requestGeneration)) {
+      return;
+    }
+
     // 使用 busNum:devAddress 作为物理位置唯一标识
     const deviceKey = `${device.vendorId}:${device.productId}:${device.busNum}:${device.devAddress}`;
     
@@ -536,7 +654,7 @@ export class UsbDriverService implements UsbDriverListener {
         console.info(`${TAG} 检测到旧控制器已断开，等待释放后重新创建: ${deviceKey}`);
         existingController.stop();
         await existingController.waitForStop();
-        if (!this.started) return;
+        if (!this.isLifecycleActive(requestGeneration)) return;
       }
     }
     
@@ -563,6 +681,10 @@ export class UsbDriverService implements UsbDriverListener {
         if (this.stateListener) {
           this.stateListener.onUsbPermissionPromptCompleted();
         }
+
+        if (!this.isLifecycleActive(requestGeneration)) {
+          return;
+        }
         
         if (!granted) {
           console.warn(`${TAG} 用户拒绝了 USB 权限: ${device.name}`);
@@ -580,8 +702,15 @@ export class UsbDriverService implements UsbDriverListener {
     }
     
     // 异步操作后检查服务是否已停止（权限弹窗期间用户可能退出）
-    if (!this.started) {
+    if (!this.isLifecycleActive(requestGeneration)) {
       console.info(`${TAG} 服务已停止，放弃处理设备: ${device.name}`);
+      return;
+    }
+
+    // Read settings before opening the pipe so cancellation or a settings error
+    // cannot strand a locally owned USB transport.
+    const inputSettings = await SettingsService.getInstance().getInputSettings();
+    if (!this.isLifecycleActive(requestGeneration)) {
       return;
     }
     
@@ -625,7 +754,6 @@ export class UsbDriverService implements UsbDriverListener {
       controller.setDeviceLocation(device.busNum, device.devAddress, device.serial || '');
 
       // 应用 DDK 高速轮询设置
-      const inputSettings = await SettingsService.getInstance().getInputSettings();
       console.info(`${TAG} DDK 高速轮询设置: ${inputSettings.ddkHighSpeedPolling}`);
       if (inputSettings.ddkHighSpeedPolling) {
         this.ddkEnabled = true;
@@ -652,6 +780,8 @@ export class UsbDriverService implements UsbDriverListener {
       usbManager.closePipe(pipe);
       return;
     }
+
+    this.pendingResetDeviceKeys.delete(deviceKey);
     
     console.info(`${TAG} 控制器已启动: ID=${controller.getControllerId()}, Key=${deviceKey}`);
   }
@@ -723,12 +853,13 @@ export class UsbDriverService implements UsbDriverListener {
    * 刷新设备列表
    */
   async refreshDevices(): Promise<void> {
-    if (!this.started) {
+    const requestGeneration: number = this.lifecycleGeneration;
+    if (!this.isLifecycleActive(requestGeneration)) {
       return;
     }
     
     console.info(`${TAG} 刷新 USB 设备列表`);
-    await this.enumerateDevices();
+    await this.enumerateDevices(requestGeneration);
   }
   
   /**

--- a/entry/src/main/ets/service/usbdriver/UsbDriverService.ets
+++ b/entry/src/main/ets/service/usbdriver/UsbDriverService.ets
@@ -81,10 +81,15 @@ export class UsbDriverService implements UsbDriverListener {
   private rescanTimerId: number | null = null;
   // 重新扫描间隔（毫秒）- 每 5 秒检查一次
   private static readonly RESCAN_INTERVAL_MS: number = 5000;
+  // DualSense output teardown may wait for an in-flight USB report (bounded by
+  // its 500ms transfer timeout, plus the final coalesced report).
+  private static readonly USB_RESET_DELAY_MS: number = 1500;
   // DDK 高速轮询是否启用（缓存，用于 stop() 决定是否重绑内核驱动）
   private ddkEnabled: boolean = false;
   // 内核驱动重绑定定时器 ID（用于在重新启动时取消）
   private resetTimerId: number | null = null;
+  // stop() keeps DualSense transports alive while the final Off report drains.
+  private pendingControllerStops: Promise<void> | null = null;
   
   private constructor() {
     console.info(`${TAG} 创建 USB 驱动服务实例`);
@@ -157,6 +162,11 @@ export class UsbDriverService implements UsbDriverListener {
     if (this.started) {
       console.info(`${TAG} 服务已启动`);
       return;
+    }
+
+    if (this.pendingControllerStops !== null) {
+      await this.pendingControllerStops;
+      this.pendingControllerStops = null;
     }
     
     console.info(`${TAG} 启动 USB 驱动服务`);
@@ -357,16 +367,20 @@ export class UsbDriverService implements UsbDriverListener {
     // 保存已处理设备的键值，用于后续内核驱动重绑定
     const releasedDeviceKeys = new Set(this.processedDevices);
     
-    // 停止所有控制器（释放 USB 接口独占 + 关闭管道）
+    // 停止所有控制器（释放 USB 接口独占 + 关闭管道）。DualSense 的
+    // stop() 会异步等待最终 Off 报告，因此保存完成 Promise 供下一次 start() 等待。
     let stoppedCount = 0;
+    const stopPromises: Promise<void>[] = [];
     while (this.controllers.length > 0) {
       const controller = this.controllers.shift();
       if (controller) {
         console.info(`${TAG} 释放控制器: ${controller.getName()} (VID=0x${controller.getVendorId().toString(16)}, PID=0x${controller.getProductId().toString(16)})`);
         controller.stop();
+        stopPromises.push(controller.waitForStop());
         stoppedCount++;
       }
     }
+    this.pendingControllerStops = Promise.all(stopPromises).then((): void => {});
     
     this.processedDevices.clear();
     console.info(`${TAG} USB 驱动服务已停止，已释放 ${stoppedCount} 个控制器的 USB 独占`);
@@ -380,7 +394,7 @@ export class UsbDriverService implements UsbDriverListener {
       this.resetTimerId = setTimeout(() => {
         this.resetTimerId = null;
         this.resetReleasedUsbDevices(releasedDeviceKeys);
-      }, 300);  // 等待 300ms 确保管道完全关闭
+      }, UsbDriverService.USB_RESET_DELAY_MS);
     } else if (this.ddkEnabled) {
       console.info(`${TAG} DDK 模式，跳过内核 HID 驱动重绑定`);
     }
@@ -518,10 +532,11 @@ export class UsbDriverService implements UsbDriverListener {
         console.info(`${TAG} 设备已有活跃控制器，跳过: ${deviceKey}`);
         return;
       } else {
-        // 控制器已断开，移除旧控制器
-        console.info(`${TAG} 检测到旧控制器已断开，移除后重新创建: ${deviceKey}`);
+        // 控制器已断开；等待异步输出复位和 pipe 释放后再重建。
+        console.info(`${TAG} 检测到旧控制器已断开，等待释放后重新创建: ${deviceKey}`);
         existingController.stop();
-        // deviceRemoved 会在 stop 时被调用
+        await existingController.waitForStop();
+        if (!this.started) return;
       }
     }
     

--- a/entry/src/main/ets/service/usbdriver/UsbDriverService.ets
+++ b/entry/src/main/ets/service/usbdriver/UsbDriverService.ets
@@ -94,6 +94,7 @@ export class UsbDriverService implements UsbDriverListener {
   private resetTimerId: number | null = null;
   // stop() keeps DualSense transports alive while the final Off report drains.
   private pendingControllerStops: Promise<void> | null = null;
+  private pendingResetWait: Promise<void> | null = null;
   // Device keys awaiting kernel HID rebind after a controller release.
   private pendingResetDeviceKeys: Set<string> = new Set();
   
@@ -242,6 +243,10 @@ export class UsbDriverService implements UsbDriverListener {
       return;
     }
 
+    if (this.pendingResetDeviceKeys.size === 0) {
+      this.cancelResetTimer();
+    }
+
     // 启动定期重新扫描定时器
     this.startRescanTimer(requestGeneration);
   }
@@ -332,11 +337,6 @@ export class UsbDriverService implements UsbDriverListener {
       const subscriber: commonEventManager.CommonEventSubscriber =
         await commonEventManager.createSubscriber(subscribeInfo);
       if (!this.isStartRequestCurrent(requestGeneration)) {
-        try {
-          commonEventManager.unsubscribe(subscriber);
-        } catch (err) {
-          console.warn(`${TAG} 取消过期 USB 订阅失败:`, err);
-        }
         return;
       }
       this.usbSubscriber = subscriber;
@@ -430,6 +430,7 @@ export class UsbDriverService implements UsbDriverListener {
   stop(): void {
     this.startRequested = false;
     this.lifecycleGeneration++;
+    this.cancelResetTimer();
 
     if (!this.started) {
       this.schedulePendingReset();
@@ -482,10 +483,25 @@ export class UsbDriverService implements UsbDriverListener {
   }
 
   private schedulePendingReset(): void {
-    if (this.resetTimerId !== null) {
-      clearTimeout(this.resetTimerId);
-      this.resetTimerId = null;
+    const pendingStops: Promise<void> | null = this.pendingControllerStops;
+    if (pendingStops !== null) {
+      if (this.pendingResetWait === pendingStops) {
+        return;
+      }
+      this.pendingResetWait = pendingStops;
+      pendingStops.then((): void => {
+        if (this.pendingControllerStops === pendingStops) {
+          this.pendingControllerStops = null;
+        }
+        if (this.pendingResetWait === pendingStops) {
+          this.pendingResetWait = null;
+        }
+        this.schedulePendingReset();
+      });
+      return;
     }
+
+    this.cancelResetTimer();
     if (this.ddkEnabled || this.pendingResetDeviceKeys.size === 0) {
       return;
     }
@@ -498,6 +514,13 @@ export class UsbDriverService implements UsbDriverListener {
         this.pendingResetDeviceKeys.delete(deviceKey);
       });
     }, UsbDriverService.USB_RESET_DELAY_MS);
+  }
+
+  private cancelResetTimer(): void {
+    if (this.resetTimerId !== null) {
+      clearTimeout(this.resetTimerId);
+      this.resetTimerId = null;
+    }
   }
   
   /**
@@ -518,11 +541,13 @@ export class UsbDriverService implements UsbDriverListener {
     
     try {
       const devices: usbManager.USBDevice[] = usbManager.getDevices();
+      const presentKeys: Set<string> = new Set();
       let resetCount = 0;
       
       for (let i = 0; i < devices.length; i++) {
         const device = devices[i];
         const key = `${device.vendorId}:${device.productId}:${device.busNum}:${device.devAddress}`;
+        presentKeys.add(key);
         
         if (!releasedKeys.has(key)) continue;
         if (!this.deviceHasHidInterface(device)) continue;
@@ -578,6 +603,11 @@ export class UsbDriverService implements UsbDriverListener {
       if (resetCount > 0) {
         console.info(`${TAG} 已尝试重绑定 ${resetCount} 个 USB 设备的内核 HID 驱动`);
       }
+      releasedKeys.forEach((deviceKey: string): void => {
+        if (!presentKeys.has(deviceKey)) {
+          completedKeys.add(deviceKey);
+        }
+      });
     } catch (e) {
       console.warn(`${TAG} resetReleasedUsbDevices 异常:`, e);
     }

--- a/nativelib/src/main/cpp/callbacks.cpp
+++ b/nativelib/src/main/cpp/callbacks.cpp
@@ -168,6 +168,15 @@ struct Ds5HapticsIrFrameData {
     LI_DS5_HAPTICS_IR_FRAME_V2 frame{};
 };
 
+struct AdaptiveTriggerCallbackData {
+    uint16_t controllerNumber = 0;
+    uint8_t eventFlags = 0;
+    uint8_t typeLeft = 0;
+    uint8_t typeRight = 0;
+    std::array<uint8_t, DS_EFFECT_PAYLOAD_SIZE> left{};
+    std::array<uint8_t, DS_EFFECT_PAYLOAD_SIZE> right{};
+};
+
 static constexpr size_t DS5_IR_QUEUE_CAPACITY = 4;
 static std::deque<LI_DS5_HAPTICS_IR_FRAME_V2> g_ds5IrQueue;
 static bool g_ds5IrPumpQueued = false;
@@ -470,6 +479,55 @@ static void SetObjectDouble(napi_env env,
     napi_set_named_property(env, object, name, property);
 }
 
+static bool SetObjectUint8Array(napi_env env,
+                                napi_value object,
+                                const char* name,
+                                const uint8_t* data,
+                                size_t length) {
+    void* bufferData = nullptr;
+    napi_value arrayBuffer;
+    if (napi_create_arraybuffer(env, length, &bufferData, &arrayBuffer) != napi_ok) {
+        return false;
+    }
+    if (length > 0) {
+        memcpy(bufferData, data, length);
+    }
+
+    napi_value typedArray;
+    if (napi_create_typedarray(env, napi_uint8_array, length,
+                               arrayBuffer, 0, &typedArray) != napi_ok) {
+        return false;
+    }
+    return napi_set_named_property(env, object, name, typedArray) == napi_ok;
+}
+
+static void CallJs_SetAdaptiveTriggers(napi_env env,
+                                       napi_value js_callback,
+                                       void* context,
+                                       void* data) {
+    auto* callbackData = static_cast<AdaptiveTriggerCallbackData*>(data);
+    if (env != nullptr && js_callback != nullptr && callbackData != nullptr) {
+        napi_value triggerObject;
+        if (napi_create_object(env, &triggerObject) == napi_ok) {
+            SetObjectUint32(env, triggerObject, "controllerNumber", callbackData->controllerNumber);
+            SetObjectUint32(env, triggerObject, "eventFlags", callbackData->eventFlags);
+            SetObjectUint32(env, triggerObject, "leftEffectType", callbackData->typeLeft);
+            SetObjectUint32(env, triggerObject, "rightEffectType", callbackData->typeRight);
+
+            const bool hasLeft = SetObjectUint8Array(
+                env, triggerObject, "leftEffect", callbackData->left.data(), callbackData->left.size());
+            const bool hasRight = SetObjectUint8Array(
+                env, triggerObject, "rightEffect", callbackData->right.data(), callbackData->right.size());
+            if (hasLeft && hasRight) {
+                napi_value undefined;
+                napi_get_undefined(env, &undefined);
+                napi_call_function(env, undefined, js_callback, 1, &triggerObject, nullptr);
+            }
+        }
+    }
+    delete callbackData;
+}
+
 static void SetDs5HapticsIrLane(napi_env env,
                                 napi_value laneObject,
                                 const LI_DS5_HAPTICS_IR_LANE_V2& lane) {
@@ -736,6 +794,11 @@ void Callbacks_Init(napi_env env, napi_value callbacks) {
     if (napi_get_named_property(env, callbacks, "setControllerLED", &callback) == napi_ok) {
         CreateThreadsafeFunction(env, callback, "setControllerLED", CallJs_SetControllerLED, &g_connCallbacks.tsfn_setControllerLED);
     }
+    if (napi_get_named_property(env, callbacks, "setAdaptiveTriggers", &callback) == napi_ok) {
+        CreateThreadsafeFunction(env, callback, "setAdaptiveTriggers",
+                                 CallJs_SetAdaptiveTriggers,
+                                 &g_connCallbacks.tsfn_setAdaptiveTriggers);
+    }
     if (napi_get_named_property(env, callbacks, "rumbleTriggers", &callback) == napi_ok) {
         CreateThreadsafeFunction(env, callback, "rumbleTriggers", CallJs_RumbleTriggers, &g_connCallbacks.tsfn_rumbleTriggers);
     }
@@ -783,6 +846,7 @@ void Callbacks_Cleanup(void) {
     if (g_connCallbacks.tsfn_setHdrMode) napi_release_threadsafe_function(g_connCallbacks.tsfn_setHdrMode, napi_tsfn_release);
     if (g_connCallbacks.tsfn_setMotionEventState) napi_release_threadsafe_function(g_connCallbacks.tsfn_setMotionEventState, napi_tsfn_release);
     if (g_connCallbacks.tsfn_setControllerLED) napi_release_threadsafe_function(g_connCallbacks.tsfn_setControllerLED, napi_tsfn_release);
+    if (g_connCallbacks.tsfn_setAdaptiveTriggers) napi_release_threadsafe_function(g_connCallbacks.tsfn_setAdaptiveTriggers, napi_tsfn_release);
     if (g_connCallbacks.tsfn_rumbleTriggers) napi_release_threadsafe_function(g_connCallbacks.tsfn_rumbleTriggers, napi_tsfn_release);
     if (g_connCallbacks.tsfn_resolutionChanged) napi_release_threadsafe_function(g_connCallbacks.tsfn_resolutionChanged, napi_tsfn_release);
     if (g_connCallbacks.tsfn_clipboardData) napi_release_threadsafe_function(g_connCallbacks.tsfn_clipboardData, napi_tsfn_release);
@@ -1429,6 +1493,45 @@ void BridgeClSetControllerLED(unsigned short controllerNumber, unsigned char r, 
         napi_status st = napi_call_threadsafe_function(g_connCallbacks.tsfn_setControllerLED, data, napi_tsfn_nonblocking);
         if (st != napi_ok) delete data;
     }
+}
+
+void BridgeClSetAdaptiveTriggers(unsigned short controllerNumber, unsigned char eventFlags,
+                                 unsigned char typeLeft, unsigned char typeRight,
+                                 unsigned char* left, unsigned char* right) {
+    if (left == nullptr || right == nullptr) {
+        return;
+    }
+
+    // Keep the TSFN alive across cleanup while the common-c callback is in
+    // flight. Callbacks_Cleanup() uses the same mutex before releasing and
+    // clearing the global handle, so no stale handle can be called here.
+    napi_threadsafe_function tsfn = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(g_mutex);
+        if (g_ds5IrShuttingDown ||
+            g_connCallbacks.tsfn_setAdaptiveTriggers == nullptr) {
+            return;
+        }
+        tsfn = g_connCallbacks.tsfn_setAdaptiveTriggers;
+        if (napi_acquire_threadsafe_function(tsfn) != napi_ok) {
+            return;
+        }
+    }
+
+    auto* data = new AdaptiveTriggerCallbackData();
+    data->controllerNumber = controllerNumber;
+    data->eventFlags = eventFlags;
+    data->typeLeft = typeLeft;
+    data->typeRight = typeRight;
+    std::copy_n(left, data->left.size(), data->left.begin());
+    std::copy_n(right, data->right.size(), data->right.begin());
+
+    const napi_status status = napi_call_threadsafe_function(
+        tsfn, data, napi_tsfn_nonblocking);
+    if (status != napi_ok) {
+        delete data;
+    }
+    napi_release_threadsafe_function(tsfn, napi_tsfn_release);
 }
 
 void BridgeClResolutionChanged(unsigned int width, unsigned int height) {

--- a/nativelib/src/main/cpp/callbacks.cpp
+++ b/nativelib/src/main/cpp/callbacks.cpp
@@ -1445,7 +1445,7 @@ void BridgeArDecodeAndPlaySample(char* sampleData, int sampleLength) {
             "plcFrames=%{public}llu "
             "hapticMaxUs=%{public}lld hapticOver2ms=%{public}llu "
             "hapticQueueDrops=%{public}llu "
-            "audioUnderruns=%{public}u audioDropped=%{public}llu audioBufferedMs=%.2f",
+            "audioUnderruns=%{public}u audioDropped=%{public}llu audioBufferedMs=%{public}.2f",
             (unsigned long long)s_arvFrameSeq, kFramesPerLog,
             s_arvSampleCount, s_arvMaxAbs, meanAbs, satPct,
             s_arvHapticFrames, s_arvHapticAmplitudeMax,

--- a/nativelib/src/main/cpp/callbacks.cpp
+++ b/nativelib/src/main/cpp/callbacks.cpp
@@ -39,6 +39,7 @@ extern void MicCapturerUpdatePacketLossPercent(int percent);
 #include <sched.h>
 #include <unistd.h>
 #include <fstream>
+#include <utility>
 #include <vector>
 
 extern "C" {
@@ -178,9 +179,15 @@ struct AdaptiveTriggerCallbackData {
 };
 
 static constexpr size_t DS5_IR_QUEUE_CAPACITY = 4;
+// The common-c input path supports sixteen controller slots. Keep one pending
+// adaptive-trigger state per slot so a busy ArkTS thread cannot accumulate
+// stale reports or drop the newest Off state behind an unbounded TSFN queue.
+static constexpr size_t ADAPTIVE_TRIGGER_QUEUE_CAPACITY = 16;
 static std::deque<LI_DS5_HAPTICS_IR_FRAME_V2> g_ds5IrQueue;
 static bool g_ds5IrPumpQueued = false;
 static bool g_ds5IrShuttingDown = false;
+static std::deque<AdaptiveTriggerCallbackData> g_adaptiveTriggerQueue;
+static bool g_adaptiveTriggerPumpQueued = false;
 
 static bool IsDs5IrBoundary(const LI_DS5_HAPTICS_IR_FRAME_V2& frame) {
     return (frame.flags & (LI_DS5_HAPTICS_IR_FLAG_DISCONTINUITY |
@@ -189,6 +196,7 @@ static bool IsDs5IrBoundary(const LI_DS5_HAPTICS_IR_FRAME_V2& frame) {
 }
 
 static void QueueDs5IrPump();
+static void QueueAdaptiveTriggerPump();
 
 static void CallJs_StageStarting(napi_env env, napi_value js_callback, void* context, void* data) {
     CallbackData* cbData = (CallbackData*)data;
@@ -501,31 +509,71 @@ static bool SetObjectUint8Array(napi_env env,
     return napi_set_named_property(env, object, name, typedArray) == napi_ok;
 }
 
+static void MergeAdaptiveTriggerUpdate(AdaptiveTriggerCallbackData& target,
+                                       const AdaptiveTriggerCallbackData& update) {
+    const uint8_t triggerFlags = static_cast<uint8_t>(
+        update.eventFlags & (DS_EFFECT_RIGHT_TRIGGER | DS_EFFECT_LEFT_TRIGGER));
+    target.eventFlags = static_cast<uint8_t>(target.eventFlags | triggerFlags);
+    if ((triggerFlags & DS_EFFECT_RIGHT_TRIGGER) != 0U) {
+        target.typeRight = update.typeRight;
+        target.right = update.right;
+    }
+    if ((triggerFlags & DS_EFFECT_LEFT_TRIGGER) != 0U) {
+        target.typeLeft = update.typeLeft;
+        target.left = update.left;
+    }
+}
+
 static void CallJs_SetAdaptiveTriggers(napi_env env,
                                        napi_value js_callback,
                                        void* context,
                                        void* data) {
-    auto* callbackData = static_cast<AdaptiveTriggerCallbackData*>(data);
-    if (env != nullptr && js_callback != nullptr && callbackData != nullptr) {
-        napi_value triggerObject;
-        if (napi_create_object(env, &triggerObject) == napi_ok) {
-            SetObjectUint32(env, triggerObject, "controllerNumber", callbackData->controllerNumber);
-            SetObjectUint32(env, triggerObject, "eventFlags", callbackData->eventFlags);
-            SetObjectUint32(env, triggerObject, "leftEffectType", callbackData->typeLeft);
-            SetObjectUint32(env, triggerObject, "rightEffectType", callbackData->typeRight);
+    (void)context;
+    (void)data;
+    for (size_t processed = 0;
+         processed < ADAPTIVE_TRIGGER_QUEUE_CAPACITY;
+         ++processed) {
+        AdaptiveTriggerCallbackData callbackData{};
+        bool hasFrame = false;
+        {
+            std::lock_guard<std::mutex> lock(g_mutex);
+            // The pump callback is no longer pending once it starts running.
+            // Reset before checking state so an empty callback cannot strand a
+            // later update behind a stale queued flag.
+            g_adaptiveTriggerPumpQueued = false;
+            if (!g_ds5IrShuttingDown && !g_adaptiveTriggerQueue.empty()) {
+                callbackData = std::move(g_adaptiveTriggerQueue.front());
+                g_adaptiveTriggerQueue.pop_front();
+                hasFrame = true;
+            }
+        }
 
-            const bool hasLeft = SetObjectUint8Array(
-                env, triggerObject, "leftEffect", callbackData->left.data(), callbackData->left.size());
-            const bool hasRight = SetObjectUint8Array(
-                env, triggerObject, "rightEffect", callbackData->right.data(), callbackData->right.size());
-            if (hasLeft && hasRight) {
-                napi_value undefined;
-                napi_get_undefined(env, &undefined);
-                napi_call_function(env, undefined, js_callback, 1, &triggerObject, nullptr);
+        if (!hasFrame) {
+            break;
+        }
+
+        if (env != nullptr && js_callback != nullptr) {
+            napi_value triggerObject;
+            if (napi_create_object(env, &triggerObject) == napi_ok) {
+                SetObjectUint32(env, triggerObject, "controllerNumber", callbackData.controllerNumber);
+                SetObjectUint32(env, triggerObject, "eventFlags", callbackData.eventFlags);
+                SetObjectUint32(env, triggerObject, "leftEffectType", callbackData.typeLeft);
+                SetObjectUint32(env, triggerObject, "rightEffectType", callbackData.typeRight);
+
+                const bool hasLeft = SetObjectUint8Array(
+                    env, triggerObject, "leftEffect", callbackData.left.data(), callbackData.left.size());
+                const bool hasRight = SetObjectUint8Array(
+                    env, triggerObject, "rightEffect", callbackData.right.data(), callbackData.right.size());
+                if (hasLeft && hasRight) {
+                    napi_value undefined;
+                    napi_get_undefined(env, &undefined);
+                    napi_call_function(env, undefined, js_callback, 1, &triggerObject, nullptr);
+                }
             }
         }
     }
-    delete callbackData;
+
+    QueueAdaptiveTriggerPump();
 }
 
 static void SetDs5HapticsIrLane(napi_env env,
@@ -627,6 +675,64 @@ static void QueueDs5IrPump() {
     }
 }
 
+static void QueueAdaptiveTriggerPump() {
+    napi_threadsafe_function triggerTsfn = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(g_mutex);
+        if (g_ds5IrShuttingDown || g_adaptiveTriggerPumpQueued ||
+            g_adaptiveTriggerQueue.empty()) {
+            return;
+        }
+        triggerTsfn = g_connCallbacks.tsfn_setAdaptiveTriggers;
+        if (triggerTsfn == nullptr ||
+            napi_acquire_threadsafe_function(triggerTsfn) != napi_ok) {
+            return;
+        }
+        g_adaptiveTriggerPumpQueued = true;
+    }
+
+    const napi_status status = napi_call_threadsafe_function(
+        triggerTsfn, nullptr, napi_tsfn_nonblocking);
+    napi_release_threadsafe_function(triggerTsfn, napi_tsfn_release);
+    if (status != napi_ok) {
+        std::lock_guard<std::mutex> lock(g_mutex);
+        g_adaptiveTriggerPumpQueued = false;
+    }
+}
+
+static void EnqueueAdaptiveTriggerUpdate(const AdaptiveTriggerCallbackData& update) {
+    const uint8_t triggerFlags = static_cast<uint8_t>(
+        update.eventFlags & (DS_EFFECT_RIGHT_TRIGGER | DS_EFFECT_LEFT_TRIGGER));
+    if (triggerFlags == 0U ||
+        update.controllerNumber >= ADAPTIVE_TRIGGER_QUEUE_CAPACITY) {
+        return;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(g_mutex);
+        if (g_ds5IrShuttingDown ||
+            g_connCallbacks.tsfn_setAdaptiveTriggers == nullptr) {
+            return;
+        }
+
+        auto pending = std::find_if(
+            g_adaptiveTriggerQueue.begin(), g_adaptiveTriggerQueue.end(),
+            [&update](const AdaptiveTriggerCallbackData& queued) {
+                return queued.controllerNumber == update.controllerNumber;
+            });
+        if (pending != g_adaptiveTriggerQueue.end()) {
+            MergeAdaptiveTriggerUpdate(*pending, update);
+        } else if (g_adaptiveTriggerQueue.size() < ADAPTIVE_TRIGGER_QUEUE_CAPACITY) {
+            g_adaptiveTriggerQueue.push_back(update);
+        } else {
+            // Valid controller numbers are limited to the same sixteen slots,
+            // so this is only a defensive fallback for malformed input.
+            g_adaptiveTriggerQueue.front() = update;
+        }
+    }
+    QueueAdaptiveTriggerPump();
+}
+
 static void EnqueueDs5IrFrame(const LI_DS5_HAPTICS_IR_FRAME_V2& frame) {
     {
         std::lock_guard<std::mutex> lock(g_mutex);
@@ -714,6 +820,8 @@ void Callbacks_Init(napi_env env, napi_value callbacks) {
     g_env = env;
     g_ds5IrQueue.clear();
     g_ds5IrPumpQueued = false;
+    g_adaptiveTriggerQueue.clear();
+    g_adaptiveTriggerPumpQueued = false;
     g_ds5IrShuttingDown = false;
     
     napi_value callback;
@@ -797,7 +905,8 @@ void Callbacks_Init(napi_env env, napi_value callbacks) {
     if (napi_get_named_property(env, callbacks, "setAdaptiveTriggers", &callback) == napi_ok) {
         CreateThreadsafeFunction(env, callback, "setAdaptiveTriggers",
                                  CallJs_SetAdaptiveTriggers,
-                                 &g_connCallbacks.tsfn_setAdaptiveTriggers);
+                                 &g_connCallbacks.tsfn_setAdaptiveTriggers,
+                                 1);
     }
     if (napi_get_named_property(env, callbacks, "rumbleTriggers", &callback) == napi_ok) {
         CreateThreadsafeFunction(env, callback, "rumbleTriggers", CallJs_RumbleTriggers, &g_connCallbacks.tsfn_rumbleTriggers);
@@ -817,6 +926,8 @@ void Callbacks_Cleanup(void) {
     g_ds5IrShuttingDown = true;
     g_ds5IrQueue.clear();
     g_ds5IrPumpQueued = false;
+    g_adaptiveTriggerQueue.clear();
+    g_adaptiveTriggerPumpQueued = false;
     
     // 释放线程安全函数
     if (g_videoCallbacks.tsfn_setup) napi_release_threadsafe_function(g_videoCallbacks.tsfn_setup, napi_tsfn_release);
@@ -1502,36 +1613,14 @@ void BridgeClSetAdaptiveTriggers(unsigned short controllerNumber, unsigned char 
         return;
     }
 
-    // Keep the TSFN alive across cleanup while the common-c callback is in
-    // flight. Callbacks_Cleanup() uses the same mutex before releasing and
-    // clearing the global handle, so no stale handle can be called here.
-    napi_threadsafe_function tsfn = nullptr;
-    {
-        std::lock_guard<std::mutex> lock(g_mutex);
-        if (g_ds5IrShuttingDown ||
-            g_connCallbacks.tsfn_setAdaptiveTriggers == nullptr) {
-            return;
-        }
-        tsfn = g_connCallbacks.tsfn_setAdaptiveTriggers;
-        if (napi_acquire_threadsafe_function(tsfn) != napi_ok) {
-            return;
-        }
-    }
-
-    auto* data = new AdaptiveTriggerCallbackData();
-    data->controllerNumber = controllerNumber;
-    data->eventFlags = eventFlags;
-    data->typeLeft = typeLeft;
-    data->typeRight = typeRight;
-    std::copy_n(left, data->left.size(), data->left.begin());
-    std::copy_n(right, data->right.size(), data->right.begin());
-
-    const napi_status status = napi_call_threadsafe_function(
-        tsfn, data, napi_tsfn_nonblocking);
-    if (status != napi_ok) {
-        delete data;
-    }
-    napi_release_threadsafe_function(tsfn, napi_tsfn_release);
+    AdaptiveTriggerCallbackData data{};
+    data.controllerNumber = controllerNumber;
+    data.eventFlags = eventFlags;
+    data.typeLeft = typeLeft;
+    data.typeRight = typeRight;
+    std::copy_n(left, data.left.size(), data.left.begin());
+    std::copy_n(right, data.right.size(), data.right.begin());
+    EnqueueAdaptiveTriggerUpdate(data);
 }
 
 void BridgeClResolutionChanged(unsigned int width, unsigned int height) {

--- a/nativelib/src/main/cpp/callbacks.cpp
+++ b/nativelib/src/main/cpp/callbacks.cpp
@@ -862,7 +862,8 @@ void Callbacks_Init(napi_env env, napi_value callbacks) {
     if (napi_get_named_property(env, callbacks, "audioHapticFrame", &callback) == napi_ok) {
         CreateThreadsafeFunction(env, callback, "audioHapticFrame",
                                  CallJs_AudioHapticFrame,
-                                 &g_audioCallbacks.tsfn_audioHapticFrame);
+                                 &g_audioCallbacks.tsfn_audioHapticFrame,
+                                 16);
     }
     
     // 连接监听器回调
@@ -1288,6 +1289,7 @@ void BridgeArDecodeAndPlaySample(char* sampleData, int sampleLength) {
     
     // 使用 HarmonyOS AVCodec Opus 解码器
     // 注意：sampleData 可能为 NULL（丢包补偿 PLC），MoonlightOpusDecoder::Decode 内部会处理
+    const bool isPlcFrame = sampleData == nullptr || sampleLength <= 0;
     int decodeLen = MoonlightOpusDecoder::Decode(
         (const unsigned char*)sampleData,
         sampleLength,
@@ -1300,6 +1302,7 @@ void BridgeArDecodeAndPlaySample(char* sampleData, int sampleLength) {
     // sequence 关联：BridgeArInit/Cleanup 已有 INFO 日志，便于按时间轴对位
     static thread_local uint64_t s_arvFrameSeq = 0;
     static thread_local uint64_t s_arvDecodeFailCount = 0;
+    static thread_local uint64_t s_arvPlcFrameCount = 0;
     static thread_local int64_t  s_arvSatSum = 0;        // saturated sample 累计
     static thread_local int64_t  s_arvAbsSum = 0;
     static thread_local int      s_arvMaxAbs = 0;
@@ -1307,10 +1310,16 @@ void BridgeArDecodeAndPlaySample(char* sampleData, int sampleLength) {
     static thread_local int      s_arvHapticFrames = 0;
     static thread_local int      s_arvHapticAmplitudeMax = 0;
     static thread_local uint64_t s_arvHapticErrors = 0;
+    static thread_local int64_t  s_arvHapticProcessMaxUs = 0;
+    static thread_local uint64_t s_arvHapticProcessOverBudget = 0;
+    static thread_local uint64_t s_arvHapticQueueDrops = 0;
     constexpr int kSatThreshold = 30000;
     constexpr int kFramesPerLog = 200;  // ~1s @5ms/frame
 
     s_arvFrameSeq++;
+    if (isPlcFrame) {
+        ++s_arvPlcFrameCount;
+    }
     if (decodeLen <= 0) {
         s_arvDecodeFailCount++;
         if (s_arvDecodeFailCount <= 3 || (s_arvDecodeFailCount % 50) == 0) {
@@ -1350,9 +1359,12 @@ void BridgeArDecodeAndPlaySample(char* sampleData, int sampleLength) {
                         frameMaxAbs, totalSamples);
         }
 
-        // Portable SDK: decoded PCM -> sparse haptic IR.
+        // Portable SDK: decoded PCM -> sparse haptic IR. This runs after the
+        // PCM has been queued, so it must never be allowed to build an
+        // unbounded ArkTS backlog or hide an audio underrun in diagnostics.
         std::array<AhHapticFrame, 32> hapticFrames{};
         uint32_t hapticFrameCount = 0;
+        const auto hapticProcessStart = std::chrono::steady_clock::now();
         if (!g_audioHapticsEngine.ProcessFrame(
                 g_decodedAudioBuffer,
                 static_cast<uint32_t>(decodeLen),
@@ -1405,6 +1417,7 @@ void BridgeArDecodeAndPlaySample(char* sampleData, int sampleLength) {
                     const napi_status status = napi_call_threadsafe_function(
                         hapticTsfn, data, napi_tsfn_nonblocking);
                     if (status != napi_ok) {
+                        ++s_arvHapticQueueDrops;
                         delete data;
                     }
                 }
@@ -1412,27 +1425,48 @@ void BridgeArDecodeAndPlaySample(char* sampleData, int sampleLength) {
                     hapticTsfn, napi_tsfn_release);
             }
         }
+        const int64_t hapticProcessUs = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::steady_clock::now() - hapticProcessStart).count();
+        s_arvHapticProcessMaxUs = std::max(s_arvHapticProcessMaxUs, hapticProcessUs);
+        if (hapticProcessUs > 2000) {
+            ++s_arvHapticProcessOverBudget;
+        }
     }
 
     if ((s_arvFrameSeq % kFramesPerLog) == 0 && s_arvSampleCount > 0) {
         const int satPct = (int)(s_arvSatSum * 100 / s_arvSampleCount);
         const int meanAbs = (int)(s_arvAbsSum / s_arvSampleCount);
+        const AudioRendererStats audioStats = AudioRendererInstance::GetStats();
         OH_LOG_INFO(LOG_APP,
             "[AUDIO_DIAG] window seq=%{public}llu frames=%{public}d samples=%{public}d "
             "maxAbs=%{public}d meanAbs=%{public}d satPct=%{public}d%% "
             "hapticFrames=%{public}d amplitudeMax=%{public}d "
-            "hapticErrors=%{public}llu decodeFails=%{public}llu",
+            "hapticErrors=%{public}llu decodeFails=%{public}llu "
+            "plcFrames=%{public}llu "
+            "hapticMaxUs=%{public}lld hapticOver2ms=%{public}llu "
+            "hapticQueueDrops=%{public}llu "
+            "audioUnderruns=%{public}u audioDropped=%{public}llu audioBufferedMs=%.2f",
             (unsigned long long)s_arvFrameSeq, kFramesPerLog,
             s_arvSampleCount, s_arvMaxAbs, meanAbs, satPct,
             s_arvHapticFrames, s_arvHapticAmplitudeMax,
             static_cast<unsigned long long>(s_arvHapticErrors),
-            (unsigned long long)s_arvDecodeFailCount);
+            (unsigned long long)s_arvDecodeFailCount,
+            static_cast<unsigned long long>(s_arvPlcFrameCount),
+            static_cast<long long>(s_arvHapticProcessMaxUs),
+            static_cast<unsigned long long>(s_arvHapticProcessOverBudget),
+            static_cast<unsigned long long>(s_arvHapticQueueDrops),
+            audioStats.underruns,
+            static_cast<unsigned long long>(audioStats.droppedSamples),
+            audioStats.latencyMs);
         s_arvSatSum = 0;
         s_arvAbsSum = 0;
         s_arvSampleCount = 0;
         s_arvMaxAbs = 0;
         s_arvHapticFrames = 0;
         s_arvHapticAmplitudeMax = 0;
+        s_arvHapticProcessMaxUs = 0;
+        s_arvHapticProcessOverBudget = 0;
+        s_arvHapticQueueDrops = 0;
         // decodeFails 不清零，便于看累计
     }
 }

--- a/nativelib/src/main/cpp/callbacks.h
+++ b/nativelib/src/main/cpp/callbacks.h
@@ -89,6 +89,7 @@ typedef struct {
     napi_threadsafe_function tsfn_rumbleTriggers;
     napi_threadsafe_function tsfn_setMotionEventState;
     napi_threadsafe_function tsfn_setControllerLED;
+    napi_threadsafe_function tsfn_setAdaptiveTriggers;
     napi_threadsafe_function tsfn_resolutionChanged;
     napi_threadsafe_function tsfn_clipboardData;
 } ConnectionListenerCallbacks;
@@ -131,6 +132,9 @@ void BridgeClSetHdrMode(bool enabled, void* hdrMetadata);
 void BridgeClRumbleTriggers(unsigned short controllerNumber, unsigned short leftTrigger, unsigned short rightTrigger);
 void BridgeClSetMotionEventState(unsigned short controllerNumber, unsigned char motionType, unsigned short reportRateHz);
 void BridgeClSetControllerLED(unsigned short controllerNumber, unsigned char r, unsigned char g, unsigned char b);
+void BridgeClSetAdaptiveTriggers(unsigned short controllerNumber, unsigned char eventFlags,
+                                 unsigned char typeLeft, unsigned char typeRight,
+                                 unsigned char* left, unsigned char* right);
 void BridgeClResolutionChanged(unsigned int width, unsigned int height);
 void BridgeClClipboardData(const char* data, int length);
 void BridgeClDs5HapticsIrV2(const LI_DS5_HAPTICS_IR_FRAME_V2* frame);

--- a/nativelib/src/main/cpp/moonlight_bridge.cpp
+++ b/nativelib/src/main/cpp/moonlight_bridge.cpp
@@ -147,7 +147,7 @@ static CONNECTION_LISTENER_CALLBACKS g_connCallbacksStruct = {
     .rumbleTriggers = BridgeClRumbleTriggers,
     .setMotionEventState = BridgeClSetMotionEventState,
     .setControllerLED = BridgeClSetControllerLED,
-    .setAdaptiveTriggers = nullptr,
+    .setAdaptiveTriggers = BridgeClSetAdaptiveTriggers,
     .resolutionChanged = (void (*)(uint32_t, uint32_t))BridgeClResolutionChanged,
     .clipboardData = BridgeClClipboardData,
     // HarmonyOS accepts the device-independent IR stream and renders it in the


### PR DESCRIPTION
## 改了啥呀

- 接通 HarmonyOS 侧 DualSense 自适应扳机与 USB 输出报告。
- 将 DS5 IR authored haptics 降级到普通 USB 双马达时改为 100 Hz latest-wins 调度，避免 200 Hz 输出压力造成杂音和音频欠载。
- IR 活跃时抑制普通 rumble、音频来源和 stop-confirm 的重复 USB 写入；静音、断流、watchdog 和断开仍立即清理并恢复普通 rumble。
- 自动振动路由识别 GCK/InputKit 外接手柄，避免错误回退到设备马达。
- 增加 `[AUDIO_DIAG]` 的 PLC、欠载、队列丢弃和缓冲区诊断计数。

## 为啥要改

实测发现，主机开启 DS5 模拟后，战斗场景会持续产生 authored haptics。鸿蒙此前按原始约 200 Hz 频率向普通 USB 手柄写 rumble，容易造成输出调度压力和马达机械杂音。IR 与传统 rumble 在鸿蒙侧本来就是优先级关系，不应重复写入。

## 验证

- `npm run check`
- `git diff --check`
- `DEVECO_SDK_HOME=/Applications/DevEco-Studio.app/Contents/sdk JAVA_HOME=/Applications/DevEco-Studio.app/Contents/jbr/Contents/Home bash hvigorw --mode module -p product=default assembleHap`
- HAP 打包成功，输出 `entry/build/default/outputs/default/entry-default-unsigned.hap`

这次把那只 200 Hz 乱撞的触觉小怪兽关进笼子啦，review 可以继续抓真正的问题。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 支持 DualSense 自适应扳机效果，将串流中的左右扳机反馈传递至手柄。
  - 支持自适应扳机与传统震动协同工作，并可清除当前反馈效果。
  - 优化高频触觉反馈处理，减少重复输出并提升响应稳定性。

- **问题修复**
  - 优化手柄停止、断开及重新连接流程，确保残留震动和扳机效果正确清除。
  - 避免串流会话结束后继续处理延迟到达的反馈事件。
  - 提升 USB 输出异常、超时及短写入情况下的稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->