### PR TITLE
fix(hdr): reject transient low brightness reports

### DIFF
--- a/entry/src/main/ets/service/streaming/StreamingSession.ets
+++ b/entry/src/main/ets/service/streaming/StreamingSession.ets
@@ -351,17 +351,38 @@ export class StreamingSession {
    */
   private static getBrightnessRange(): number[] {
     const minBrightness = DEFAULT_HDR_MIN_BRIGHTNESS_NITS;
-    let maxBrightness = 500;
-    let maxAverageBrightness = 200;
+    // Keep the invalid-report fallback aligned with Foundation Sunshine's
+    // client_display_capabilities_t safe defaults.
+    const fallbackMaxBrightness = 1000;
+    const fallbackMaxAverageBrightness = 1000;
+    const minimumReliableSdrNits = 50;
+    const minimumReliablePeakNits = 100;
+    let maxBrightness = fallbackMaxBrightness;
+    let maxAverageBrightness = fallbackMaxAverageBrightness;
 
     try {
       const brightnessInfo = display.getBrightnessInfo(0);
       console.info(`[Brightness] sdrNits=${brightnessInfo.sdrNits}, ` +
         `currentHeadroom=${brightnessInfo.currentHeadroom}, maxHeadroom=${brightnessInfo.maxHeadroom}`);
 
-      if (brightnessInfo.sdrNits > 0) {
-        maxBrightness = brightnessInfo.sdrNits * brightnessInfo.maxHeadroom;
-        maxAverageBrightness = brightnessInfo.sdrNits;
+      const sdrNits = brightnessInfo.sdrNits;
+      const maxHeadroom = brightnessInfo.maxHeadroom;
+      const measuredMaxBrightness = sdrNits * maxHeadroom;
+      const hasReliableMeasurement = Number.isFinite(sdrNits) &&
+        Number.isFinite(maxHeadroom) &&
+        Number.isFinite(measuredMaxBrightness) &&
+        sdrNits >= minimumReliableSdrNits &&
+        maxHeadroom > 0 &&
+        measuredMaxBrightness >= minimumReliablePeakNits &&
+        measuredMaxBrightness >= sdrNits;
+
+      if (hasReliableMeasurement) {
+        maxBrightness = measuredMaxBrightness;
+        maxAverageBrightness = sdrNits;
+      } else {
+        console.warn(`[Brightness] measurement is too low or inconsistent, ` +
+          `using defaults: sdrNits=${sdrNits}, maxHeadroom=${maxHeadroom}, ` +
+          `peak=${measuredMaxBrightness}`);
       }
     } catch (err) {
       console.warn(`[Brightness] getBrightnessInfo 不可用，使用默认值: ${err}`);


### PR DESCRIPTION
## 改了啥呀

- 校验 HarmonyOS `BrightnessInfo` 的 `sdrNits`、`maxHeadroom` 和计算出的峰值亮度。
- 对低于可靠范围、非有限或字段不一致的测量，回退到 Foundation Sunshine 的 `1000/0.001/1000 nits` 安全默认值。
- 保留正常亮度会话的自动测量，并记录回退原因。

## 为啥要改

HarmonyOS 的 `sdrNits` 会随当前屏幕亮度变化。暗环境下曾出现 `4.84 nits`，客户端因此上报约 `21.78 nits`，Sunshine 随后用异常低的 nominal display peak 配置 HLG 转换和 HDR Vivid 分析，导致过曝并可能触发 Vivid 启动超时。

这次只拦截明显不可信的低亮度报告，不改变编码格式协商、CUVA 元数据判断或正常测量路径。让这个低亮度小杂鱼别再把整条 HDR 链路拖到 21 nits。

## 验证

- `npm test`
- `npm run check:scripts`
- `git diff --check`

本机 Hvigor 构建仍受环境限制：`DEVECO_SDK_HOME` 配置无效。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 改进亮度范围检测的稳定性，避免异常或无效测量结果导致显示效果异常。
  * 在设备测量值不可靠时使用安全默认值，提升不同设备上的兼容性。
  * 增加亮度与显示余量校验，并记录相关警告以便问题排查。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->