### PR TITLE
fix(input): release stuck keys on focus loss

### DIFF
--- a/entry/src/main/ets/pages/StreamPage.ets
+++ b/entry/src/main/ets/pages/StreamPage.ets
@@ -332,6 +332,9 @@ struct StreamPage {
     this.windowManager.setOnWindowFocusChanged((focused: boolean) => {
       if (!this.viewModel.isConnected) return;
       if (!focused) {
+        // 失焦（Alt+Tab 切走 / 弹系统对话框）：释放所有按键，
+        // 防止 KEY_UP 丢失导致主机端修饰键/普通键卡住
+        this.inputHandler.releaseAllKeys();
         this.inputHandler.stopMouseInterceptor();
         this.stopMouseKeepAlive();
       } else if (!this.mouseInputSuspended) {
@@ -433,6 +436,9 @@ struct StreamPage {
       },
       reconnectStreaming: () => {
         this.reconnectStreaming();
+      },
+      releaseAllKeys: () => {
+        this.inputHandler.releaseAllKeys();
       }
     });
     

--- a/entry/src/main/ets/pages/StreamPage.ets
+++ b/entry/src/main/ets/pages/StreamPage.ets
@@ -337,8 +337,12 @@ struct StreamPage {
         this.inputHandler.releaseAllKeys();
         this.inputHandler.stopMouseInterceptor();
         this.stopMouseKeepAlive();
-      } else if (!this.mouseInputSuspended) {
-        this.resumeMouseInterceptor();
+      } else {
+        // 焦点恢复：对账仍被物理按住的按键（补发差量事件），再恢复鼠标
+        this.inputHandler.reconcileKeyState();
+        if (!this.mouseInputSuspended) {
+          this.resumeMouseInterceptor();
+        }
       }
     });
 
@@ -439,6 +443,9 @@ struct StreamPage {
       },
       releaseAllKeys: () => {
         this.inputHandler.releaseAllKeys();
+      },
+      reconcileKeyState: () => {
+        this.inputHandler.reconcileKeyState();
       }
     });
     
@@ -986,6 +993,8 @@ struct StreamPage {
     this.gameMenuDialogController = null;
     if (!this.mouseInputSuspended) return;
     this.mouseInputSuspended = false;
+    // 菜单打开期间按键被强制释放过，恢复前对账仍按下的键
+    this.inputHandler.reconcileKeyState();
     this.resumeMouseInterceptor();
   }
 

--- a/entry/src/main/ets/service/input/InputInterceptorService.ets
+++ b/entry/src/main/ets/service/input/InputInterceptorService.ets
@@ -42,6 +42,7 @@ interface InputInterceptorNative {
   removeKeyInterceptor(): number;
   isKeyInterceptorActive(): boolean;
   isInjectApiAvailable(): boolean;
+  queryKeyStates(keyCodes: number[]): number[] | null;
 }
 
 interface MouseInterceptorNative {
@@ -133,6 +134,18 @@ export class InputInterceptorService {
       return this.native.isInjectApiAvailable();
     }
     return false;
+  }
+
+  /**
+   * 查询一组按键当前物理按下状态（焦点恢复时对账用）
+   * @param keyCodes HarmonyOS KeyCode 数组
+   * @returns 与入参等长的数组（1=按下 0=松开 -1=查询失败）；API 不可用返回 null
+   */
+  queryKeyStates(keyCodes: number[]): number[] | null {
+    if (this.native && keyCodes.length > 0) {
+      return this.native.queryKeyStates(keyCodes);
+    }
+    return null;
   }
 }
 

--- a/entry/src/main/ets/service/input/KeyboardTranslator.ets
+++ b/entry/src/main/ets/service/input/KeyboardTranslator.ets
@@ -209,6 +209,18 @@ export class KeyboardTranslator {
   /** VK → HarmonyOS 反向映射（懒加载，焦点恢复对账时反查物理键码用） */
   private static reverseMap: Map<number, number> | null = null;
 
+  // 多个 HarmonyOS 键码映射到同一 VK 时的优先键码（否则反查会命中
+  // 键码更小的来源，如 0x0D 命中 DPAD_CENTER 2016 而非主键盘 Enter 2054）
+  private static readonly REVERSE_OVERRIDES: Map<number, number> =
+    KeyboardTranslator.buildReverseOverrides();
+
+  private static buildReverseOverrides(): Map<number, number> {
+    const map = new Map<number, number>();
+    map.set(0x0D, 2054); // VK_RETURN   ← ENTER（非 DPAD_CENTER 2016 / NUMPAD_ENTER 2119）
+    map.set(0xBB, 2058); // VK_OEM_PLUS ← EQUALS（非 PLUS 2066）
+    return map;
+  }
+
   /**
    * 将 Windows 虚拟键码反查为 HarmonyOS KeyCode
    *
@@ -217,13 +229,17 @@ export class KeyboardTranslator {
    */
   static reverseTranslate(vkCode: number): number {
     if (!KeyboardTranslator.reverseMap) {
+      const overrides = KeyboardTranslator.REVERSE_OVERRIDES;
       const map = new Map<number, number>();
       for (let keyCode = 2000; keyCode <= 2120; keyCode++) {
         const vk = KeyboardTranslator.translate(keyCode);
-        if (vk > 0 && !map.has(vk)) {
+        if (vk > 0 && !map.has(vk) && !overrides.has(vk)) {
           map.set(vk, keyCode);
         }
       }
+      overrides.forEach((keyCode: number, vk: number) => {
+        map.set(vk, keyCode);
+      });
       KeyboardTranslator.reverseMap = map;
     }
     return KeyboardTranslator.reverseMap.get(vkCode) ?? 0;

--- a/entry/src/main/ets/service/input/KeyboardTranslator.ets
+++ b/entry/src/main/ets/service/input/KeyboardTranslator.ets
@@ -205,4 +205,27 @@ export class KeyboardTranslator {
       default: return 0;
     }
   }
+
+  /** VK → HarmonyOS 反向映射（懒加载，焦点恢复对账时反查物理键码用） */
+  private static reverseMap: Map<number, number> | null = null;
+
+  /**
+   * 将 Windows 虚拟键码反查为 HarmonyOS KeyCode
+   *
+   * @param vkCode Windows 虚拟键码
+   * @returns HarmonyOS KeyCode，无对应返回 0
+   */
+  static reverseTranslate(vkCode: number): number {
+    if (!KeyboardTranslator.reverseMap) {
+      const map = new Map<number, number>();
+      for (let keyCode = 2000; keyCode <= 2120; keyCode++) {
+        const vk = KeyboardTranslator.translate(keyCode);
+        if (vk > 0 && !map.has(vk)) {
+          map.set(vk, keyCode);
+        }
+      }
+      KeyboardTranslator.reverseMap = map;
+    }
+    return KeyboardTranslator.reverseMap.get(vkCode) ?? 0;
+  }
 }

--- a/entry/src/main/ets/service/streaming/StreamInputHandler.ets
+++ b/entry/src/main/ets/service/streaming/StreamInputHandler.ets
@@ -144,6 +144,18 @@ export class StreamInputHandler {
     0x5B, 0x5C  // VK_LWIN, VK_RWIN
   ];
 
+  // ── 焦点恢复对账：修饰键 HarmonyOS KeyCode ↔ Windows VK（下标一一对应）──
+  // ALT_L/R, SHIFT_L/R, CTRL_L/R, META_L/R
+  private static readonly RECONCILE_KEY_CODES: number[] = [
+    2045, 2046, 2047, 2048, 2072, 2073, 2076, 2077
+  ];
+  private static readonly RECONCILE_VK_CODES: number[] = [
+    0xA4, 0xA5, 0xA0, 0xA1, 0xA2, 0xA3, 0x5B, 0x5C
+  ];
+
+  // ── 失焦释放时被强制抬起的普通键，恢复焦点时需复核是否仍物理按下 ──
+  private releasedVkKeys: Set<number> = new Set<number>();
+
   /**
    * 释放所有按下但未释放的键（含修饰键），并清空本地修饰键状态。
    *
@@ -171,9 +183,64 @@ export class StreamInputHandler {
         session.sendKeyboardInput(vkCode, KEY_ACTION_UP, 0);
       });
     }
+    // 记录被强制抬起的键，焦点恢复时对账用（见 reconcileKeyState）
+    this.releasedVkKeys = new Set<number>(this.activeVkKeys);
     this.activeVkKeys.clear();
     // 2. 清空本地修饰键位掩码，防止后续按键被错误拼上残留的 Alt/Ctrl 位
     this.modifierFlags = 0;
+  }
+
+  /**
+   * 焦点恢复时对账按键状态
+   *
+   * 失焦边界 releaseAllKeys() 把主机端按键全部抬起，但用户可能仍物理按着
+   * 部分键（典型：Alt+Tab 的 Alt、游戏中按住的方向键）。事件通道在失焦期间
+   * 收不到任何信息，无法凭事件推断，因此通过 OH_Input_GetKeyState 查询系统
+   * 权威按键状态，与本地追踪做差量同步：
+   *   - 物理按下但本地认为松开 → 补发 KEY_DOWN（用户还按着，主机端应恢复）
+   *   - 物理松开但本地认为按下 → 补发 KEY_UP（兜底 UP 被系统吞掉的情况）
+   *
+   * 低版本设备无该 API 时静默跳过（保持 releaseAllKeys 后的干净状态）。
+   */
+  reconcileKeyState(): void {
+    const session = this.viewModel?.getSession();
+    if (!session) return;
+
+    // 1. 组装待查询的 HarmonyOS 键码：8 个修饰键 + 失焦时被强制释放的普通键
+    const harmonyCodes: number[] = StreamInputHandler.RECONCILE_KEY_CODES.slice(0);
+    const vkCodes: number[] = StreamInputHandler.RECONCILE_VK_CODES.slice(0);
+    this.releasedVkKeys.forEach((vkCode: number) => {
+      const harmony = KeyboardTranslator.reverseTranslate(vkCode);
+      if (harmony > 0) {
+        harmonyCodes.push(harmony);
+        vkCodes.push(vkCode);
+      }
+    });
+
+    // 2. 查询真实物理状态（null = API 不可用，维持现状）
+    const states = InputInterceptorService.getInstance().queryKeyStates(harmonyCodes);
+    if (states === null || states.length !== harmonyCodes.length) return;
+
+    // 3. 差量同步：只对与本地状态不一致的键补发事件
+    let resynced = 0;
+    for (let i = 0; i < vkCodes.length; i++) {
+      if (states[i] < 0) continue; // 单键查询失败，保守跳过
+      const vkCode = vkCodes[i];
+      const pressed = states[i] === 1;
+      if (pressed === this.activeVkKeys.has(vkCode)) continue;
+      this.updateModifierFlags(vkCode, pressed);
+      session.sendKeyboardInput(vkCode, pressed ? KEY_ACTION_DOWN : KEY_ACTION_UP, this.modifierFlags);
+      if (pressed) {
+        this.activeVkKeys.add(vkCode);
+      } else {
+        this.activeVkKeys.delete(vkCode);
+      }
+      resynced++;
+    }
+    this.releasedVkKeys.clear();
+    if (resynced > 0) {
+      console.info(`[INPUT] 焦点恢复对账: ${resynced} 个按键状态已重新同步`);
+    }
   }
 
   // ==================== 鼠标高速轮询 ====================

--- a/entry/src/main/ets/service/streaming/StreamInputHandler.ets
+++ b/entry/src/main/ets/service/streaming/StreamInputHandler.ets
@@ -129,6 +129,8 @@ export class StreamInputHandler {
    */
   resetState(): void {
     this.releaseAllKeys();
+    // 对账记录不跨串流残留：新串流主机端状态全新，旧记录无意义
+    this.releasedVkKeys.clear();
     this.modifierFlags = 0;
     this.lastEscUpTime = 0;
     this.hasShownEscHint = false;
@@ -183,8 +185,11 @@ export class StreamInputHandler {
         session.sendKeyboardInput(vkCode, KEY_ACTION_UP, 0);
       });
     }
-    // 记录被强制抬起的键，焦点恢复时对账用（见 reconcileKeyState）
-    this.releasedVkKeys = new Set<number>(this.activeVkKeys);
+    // 累积记录被强制抬起的键（失焦与退后台可能连续触发，第二次
+    // activeVkKeys 已为空，覆盖赋值会丢掉记录），由 reconcileKeyState 消费后清空
+    this.activeVkKeys.forEach((vkCode: number) => {
+      this.releasedVkKeys.add(vkCode);
+    });
     this.activeVkKeys.clear();
     // 2. 清空本地修饰键位掩码，防止后续按键被错误拼上残留的 Alt/Ctrl 位
     this.modifierFlags = 0;
@@ -203,13 +208,18 @@ export class StreamInputHandler {
    * 低版本设备无该 API 时静默跳过（保持 releaseAllKeys 后的干净状态）。
    */
   reconcileKeyState(): void {
-    const session = this.viewModel?.getSession();
+    // 未连接（如后台断连等待重连）时不消费记录，
+    // 留给重连完成后窗口焦点恢复时再对账
+    if (!this.viewModel?.isConnected) return;
+    const session = this.viewModel.getSession();
     if (!session) return;
 
     // 1. 组装待查询的 HarmonyOS 键码：8 个修饰键 + 失焦时被强制释放的普通键
+    //    （修饰键已在 RECONCILE 列表中，跳过避免重复查询）
     const harmonyCodes: number[] = StreamInputHandler.RECONCILE_KEY_CODES.slice(0);
     const vkCodes: number[] = StreamInputHandler.RECONCILE_VK_CODES.slice(0);
     this.releasedVkKeys.forEach((vkCode: number) => {
+      if (StreamInputHandler.RECONCILE_VK_CODES.indexOf(vkCode) >= 0) return;
       const harmony = KeyboardTranslator.reverseTranslate(vkCode);
       if (harmony > 0) {
         harmonyCodes.push(harmony);

--- a/entry/src/main/ets/service/streaming/StreamInputHandler.ets
+++ b/entry/src/main/ets/service/streaming/StreamInputHandler.ets
@@ -136,19 +136,44 @@ export class StreamInputHandler {
     this.stopMouseInterceptor();
   }
 
+  // ── Windows 修饰键 VK 码（用于失焦时补发 KEY_UP，防止主机端修饰键卡住）──
+  private static readonly MODIFIER_VK_CODES: number[] = [
+    0xA0, 0xA1, // VK_LSHIFT, VK_RSHIFT
+    0xA2, 0xA3, // VK_LCONTROL, VK_RCONTROL
+    0xA4, 0xA5, // VK_LMENU, VK_RMENU (Alt)
+    0x5B, 0x5C  // VK_LWIN, VK_RWIN
+  ];
+
   /**
-   * 释放所有通过 ArkUI onKeyEvent 按下但未释放的键
-   * 在焦点丢失（如 onBackPress 弹出对话框）时调用，防止键卡住
+   * 释放所有按下但未释放的键（含修饰键），并清空本地修饰键状态。
+   *
+   * 调用时机：
+   * - onBackPress 弹出对话框（焦点丢失）
+   * - 应用退后台 / 窗口失焦（Alt+Tab 切走）
+   * - 双击菜单键打开串流菜单
+   * - 串流停止 resetState
+   *
+   * 对齐 Android Game.onWindowFocusChanged → KeyboardInputHandler.clearModifierState()：
+   * 切后台期间 KEY_UP 不会送达应用，若不清除，Windows 端 Alt/Ctrl 会永久按下，
+   * 导致返回串流后无法打字、Blender 鼠标选择异常（Alt+左键=旋转视图）。
    */
   releaseAllKeys(): void {
-    if (this.activeVkKeys.size === 0) return;
     const session = this.viewModel?.getSession();
     if (session) {
-      this.activeVkKeys.forEach((vkCode: number) => {
+      // 1. 释放所有追踪到的按键，并补齐 8 个 Windows 修饰键：覆盖按键拦截器路径
+      //    （该路径不进 activeVkKeys）以及其他漏追踪的边缘情况。
+      //    对未按下的键补发 KEY_UP 在 Windows 端是安全的 no-op。
+      const keysToRelease = new Set<number>(this.activeVkKeys);
+      StreamInputHandler.MODIFIER_VK_CODES.forEach((vkCode: number) => {
+        keysToRelease.add(vkCode);
+      });
+      keysToRelease.forEach((vkCode: number) => {
         session.sendKeyboardInput(vkCode, KEY_ACTION_UP, 0);
       });
     }
     this.activeVkKeys.clear();
+    // 2. 清空本地修饰键位掩码，防止后续按键被错误拼上残留的 Alt/Ctrl 位
+    this.modifierFlags = 0;
   }
 
   // ==================== 鼠标高速轮询 ====================

--- a/entry/src/main/ets/service/streaming/StreamInputHandler.ets
+++ b/entry/src/main/ets/service/streaming/StreamInputHandler.ets
@@ -160,8 +160,8 @@ export class StreamInputHandler {
   releaseAllKeys(): void {
     const session = this.viewModel?.getSession();
     if (session) {
-      // 1. 释放所有追踪到的按键，并补齐 8 个 Windows 修饰键：覆盖按键拦截器路径
-      //    （该路径不进 activeVkKeys）以及其他漏追踪的边缘情况。
+      // 1. 释放所有追踪到的按键，并补齐 8 个 Windows 修饰键，兜底处理
+      //    修饰键状态与按键追踪状态不一致的边缘情况。
       //    对未按下的键补发 KEY_UP 在 Windows 端是安全的 no-op。
       const keysToRelease = new Set<number>(this.activeVkKeys);
       StreamInputHandler.MODIFIER_VK_CODES.forEach((vkCode: number) => {
@@ -525,6 +525,12 @@ export class StreamInputHandler {
           if (session) {
             const keyAction = isPressed ? KEY_ACTION_DOWN : KEY_ACTION_UP;
             session.sendKeyboardInput(vkCode, keyAction, this.modifierFlags);
+            // 拦截器路径同样需要跟踪按键，否则失焦时无法补发普通键 KEY_UP
+            if (isPressed) {
+              this.activeVkKeys.add(vkCode);
+            } else {
+              this.activeVkKeys.delete(vkCode);
+            }
           }
         }
         return;
@@ -546,6 +552,11 @@ export class StreamInputHandler {
           if (vkCode > 0) {
             const keyAction = isPressed ? 0x03 : 0x04; // KEY_DOWN : KEY_UP
             session.sendKeyboardInput(vkCode, keyAction, this.modifierFlags);
+            if (isPressed) {
+              this.activeVkKeys.add(vkCode);
+            } else {
+              this.activeVkKeys.delete(vkCode);
+            }
           }
         }
       }

--- a/entry/src/main/ets/service/streaming/StreamLifecycleManager.ets
+++ b/entry/src/main/ets/service/streaming/StreamLifecycleManager.ets
@@ -36,6 +36,8 @@ export interface LifecycleCallbacks {
   stopStreaming: () => void;
   /** 重连串流（无后台保活时从后台恢复） */
   reconnectStreaming: () => void;
+  /** 释放所有按键状态（退后台/失焦时调用，防止修饰键卡住） */
+  releaseAllKeys: () => void;
 }
 
 export class StreamLifecycleManager {
@@ -104,6 +106,9 @@ export class StreamLifecycleManager {
       if (state === AppState.BACKGROUND) {
         console.info('[StreamPage] 应用进入后台');
         this.wasInBackground = true;
+        // 退后台时 KEY_UP 不会再送达应用，立即释放所有按键状态，
+        // 防止 Windows 端 Alt/Ctrl 卡住（切回后无法打字、鼠标操作异常）
+        this.callbacks?.releaseAllKeys();
       } else if (state === AppState.FOREGROUND && this.wasInBackground) {
         console.info('[StreamPage] 应用从后台恢复');
         this.wasInBackground = false;

--- a/entry/src/main/ets/service/streaming/StreamLifecycleManager.ets
+++ b/entry/src/main/ets/service/streaming/StreamLifecycleManager.ets
@@ -114,7 +114,8 @@ export class StreamLifecycleManager {
       } else if (state === AppState.FOREGROUND && this.wasInBackground) {
         console.info('[StreamPage] 应用从后台恢复');
         this.wasInBackground = false;
-        // 回前台先对账按键状态（窗口焦点回调可能已触发过，此处幂等）
+        // 回前台对账按键状态；与窗口焦点恢复回调先后到达时均可安全重复调用
+        // （未连接时 reconcileKeyState 不消费记录，留给重连后的焦点恢复）
         this.callbacks?.reconcileKeyState();
         this.handleAppResume();
       }

--- a/entry/src/main/ets/service/streaming/StreamLifecycleManager.ets
+++ b/entry/src/main/ets/service/streaming/StreamLifecycleManager.ets
@@ -38,6 +38,8 @@ export interface LifecycleCallbacks {
   reconnectStreaming: () => void;
   /** 释放所有按键状态（退后台/失焦时调用，防止修饰键卡住） */
   releaseAllKeys: () => void;
+  /** 对账按键状态（回前台时调用，补发仍物理按住的键） */
+  reconcileKeyState: () => void;
 }
 
 export class StreamLifecycleManager {
@@ -112,6 +114,8 @@ export class StreamLifecycleManager {
       } else if (state === AppState.FOREGROUND && this.wasInBackground) {
         console.info('[StreamPage] 应用从后台恢复');
         this.wasInBackground = false;
+        // 回前台先对账按键状态（窗口焦点回调可能已触发过，此处幂等）
+        this.callbacks?.reconcileKeyState();
         this.handleAppResume();
       }
     };

--- a/nativelib/src/main/cpp/input_interceptor.cpp
+++ b/nativelib/src/main/cpp/input_interceptor.cpp
@@ -110,9 +110,69 @@ static bool CheckAndLoadInjectApi()
     // 尝试加载 deviceId 获取函数（可选，API 14+）
     g_pfnGetKeyEventDeviceId = (PFN_GetKeyEventDeviceId)dlsym(handle, "OH_Input_GetKeyEventDeviceId");
     LOGI("GetKeyEventDeviceId: %{public}s", g_pfnGetKeyEventDeviceId ? "available" : "not available");
-    
+
     // 不 dlclose，保持库加载
     return g_injectApiAvailable;
+}
+
+// ==================== 按键状态查询 API 动态加载 ====================
+// OH_Input_GetKeyState 族函数：查询按键当前物理按下状态。
+// 用于焦点恢复时对账——失焦边界统一释放按键后，用户可能仍物理按着
+// 某些键（典型：Alt+Tab 的 Alt），事件通道无法感知，只能查询权威状态。
+// 与注入 API 同理走 dlsym 运行时检测，低版本设备上静默禁用。
+
+typedef void *KeyStateHandle;  // Input_KeyState*（对本文件不透明）
+typedef KeyStateHandle (*PFN_CreateKeyState)(void);
+typedef void (*PFN_DestroyKeyState)(KeyStateHandle *);
+typedef void (*PFN_SetKeyCode)(KeyStateHandle, int32_t);
+typedef int32_t (*PFN_GetKeyPressed)(KeyStateHandle);  // 返回 Input_KeyStateAction
+typedef int32_t (*PFN_GetKeyState)(KeyStateHandle);    // 返回 Input_Result
+
+static PFN_CreateKeyState g_pfnCreateKeyState = nullptr;
+static PFN_DestroyKeyState g_pfnDestroyKeyState = nullptr;
+static PFN_SetKeyCode g_pfnSetKeyStateKeyCode = nullptr;
+static PFN_GetKeyPressed g_pfnGetKeyPressed = nullptr;
+static PFN_GetKeyState g_pfnGetKeyState = nullptr;
+static bool g_keyStateApiChecked = false;
+static bool g_keyStateApiAvailable = false;
+
+/**
+ * 检查并加载按键状态查询 API
+ */
+static bool CheckAndLoadKeyStateApi()
+{
+    if (g_keyStateApiChecked) {
+        return g_keyStateApiAvailable;
+    }
+    g_keyStateApiChecked = true;
+
+    void *handle = dlopen("libohinput.so", RTLD_NOW);
+    if (!handle) {
+        LOGW("Failed to dlopen libohinput.so for key state API");
+        return false;
+    }
+
+    g_pfnCreateKeyState      = (PFN_CreateKeyState)dlsym(handle, "OH_Input_CreateKeyState");
+    g_pfnDestroyKeyState     = (PFN_DestroyKeyState)dlsym(handle, "OH_Input_DestroyKeyState");
+    g_pfnSetKeyStateKeyCode  = (PFN_SetKeyCode)dlsym(handle, "OH_Input_SetKeyCode");
+    g_pfnGetKeyPressed       = (PFN_GetKeyPressed)dlsym(handle, "OH_Input_GetKeyPressed");
+    g_pfnGetKeyState         = (PFN_GetKeyState)dlsym(handle, "OH_Input_GetKeyState");
+
+    if (g_pfnCreateKeyState && g_pfnDestroyKeyState && g_pfnSetKeyStateKeyCode &&
+        g_pfnGetKeyPressed && g_pfnGetKeyState) {
+        g_keyStateApiAvailable = true;
+        LOGI("Key state query API available");
+    } else {
+        LOGW("Key state query API not available on this device");
+        g_pfnCreateKeyState = nullptr;
+        g_pfnDestroyKeyState = nullptr;
+        g_pfnSetKeyStateKeyCode = nullptr;
+        g_pfnGetKeyPressed = nullptr;
+        g_pfnGetKeyState = nullptr;
+    }
+
+    // 不 dlclose，保持库加载
+    return g_keyStateApiAvailable;
 }
 
 // ==================== 音量键回注 ====================
@@ -354,6 +414,81 @@ static napi_value IsInjectApiAvailable(napi_env env, napi_callback_info info)
     return ret;
 }
 
+/**
+ * queryKeyStates(keyCodes: number[]): number[] | null
+ *
+ * 查询一组 HarmonyOS KeyCode 的当前物理按下状态（焦点恢复对账用）。
+ * 返回与入参等长的数组：1=按下 0=松开 -1=该键查询失败；
+ * API 不可用（低版本设备）返回 null。
+ */
+static napi_value QueryKeyStates(napi_env env, napi_callback_info info)
+{
+    if (!CheckAndLoadKeyStateApi()) {
+        napi_value ret;
+        napi_get_null(env, &ret);
+        return ret;
+    }
+
+    size_t argc = 1;
+    napi_value argv[1];
+    napi_get_cb_info(env, info, &argc, argv, nullptr, nullptr);
+    if (argc < 1) {
+        napi_throw_type_error(env, nullptr, "queryKeyStates requires an array of key codes");
+        return nullptr;
+    }
+
+    bool isArray = false;
+    napi_is_array(env, argv[0], &isArray);
+    if (!isArray) {
+        napi_throw_type_error(env, nullptr, "queryKeyStates requires an array of key codes");
+        return nullptr;
+    }
+
+    uint32_t length = 0;
+    napi_get_array_length(env, argv[0], &length);
+
+    napi_value result;
+    napi_create_array_with_length(env, length, &result);
+
+    KeyStateHandle state = g_pfnCreateKeyState();
+    if (!state) {
+        for (uint32_t i = 0; i < length; i++) {
+            napi_value v;
+            napi_create_int32(env, -1, &v);
+            napi_set_element(env, result, i, v);
+        }
+        return result;
+    }
+
+    for (uint32_t i = 0; i < length; i++) {
+        napi_value elem;
+        napi_get_element(env, argv[0], i, &elem);
+
+        int32_t keyCode = 0;
+        napi_get_value_int32(env, elem, &keyCode);
+
+        // Input_KeyStateAction: KEY_PRESSED=0, KEY_RELEASED=1, KEY_DEFAULT=-1（未知）
+        // 对外统一为 1=按下 0=松开 -1=查询失败
+        int32_t pressed = -1;
+        g_pfnSetKeyStateKeyCode(state, keyCode);
+        if (g_pfnGetKeyState(state) == INPUT_SUCCESS) {
+            int32_t action = g_pfnGetKeyPressed(state);
+            if (action == 0) {
+                pressed = 1;
+            } else if (action == 1) {
+                pressed = 0;
+            }
+        }
+
+        napi_value v;
+        napi_create_int32(env, pressed, &v);
+        napi_set_element(env, result, i, v);
+    }
+
+    g_pfnDestroyKeyState(&state);
+    return result;
+}
+
 // ==================== 模块初始化 ====================
 
 napi_value InputInterceptor_Init(napi_env env, napi_value exports)
@@ -367,6 +502,7 @@ napi_value InputInterceptor_Init(napi_env env, napi_value exports)
         {"removeKeyInterceptor", nullptr, RemoveKeyInterceptor, nullptr, nullptr, nullptr, napi_default, nullptr},
         {"isKeyInterceptorActive", nullptr, IsKeyInterceptorActive, nullptr, nullptr, nullptr, napi_default, nullptr},
         {"isInjectApiAvailable", nullptr, IsInjectApiAvailable, nullptr, nullptr, nullptr, napi_default, nullptr},
+        {"queryKeyStates", nullptr, QueryKeyStates, nullptr, nullptr, nullptr, napi_default, nullptr},
     };
 
     napi_define_properties(env, interceptorObj, sizeof(methods) / sizeof(methods[0]), methods);


### PR DESCRIPTION
## 改了啥呀

- 窗口失焦或应用进入后台时，主动释放主机端仍处于按下状态的按键
- 除已追踪按键外，补发左右 Shift、Ctrl、Alt、Win 的 `KEY_UP`，并先去重避免重复事件
- 同步清空本地修饰键掩码，防止恢复串流后继续携带残留状态
- **焦点恢复时对账按键状态**：通过 `OH_Input_GetKeyState` 查询 8 个修饰键 + 失焦时被强制释放的普通键的真实物理状态，与本地追踪做差量同步——仍按着的补发 `KEY_DOWN`（典型：Alt+Tab 的 Alt 还被用户按着），已松开但本地认为按着的补发 `KEY_UP`。触发点：窗口焦点恢复、回前台、串流菜单关闭，幂等可重复

## 为啥要改

Alt+Tab、系统弹窗或切后台期间，HarmonyOS 可能不再把 `KEY_UP` 交给应用，Windows 端就会误以为 Alt/Ctrl 还按着，导致返回后无法正常打字或 Blender 鼠标操作异常。现在在失焦边界统一清理；恢复边界再按真实物理状态对账，避免"失焦时统一抬起"把用户仍按住的键也误伤掉。

按键状态查询沿用 inject API 的 dlsym 运行时检测模式（`libohinput.so`），低版本设备无此 API 时静默降级为单纯释放，不引入新权限。

Refs #102

本 PR 处理 #102 中失焦/切后台后的按键残留与输入恢复问题；HarmonyOS 对部分系统快捷键的拦截行为仍需真机单独确认，因此不自动关闭该 issue。

## 验证

- `npm run check`
- `hvigorw assembleHar`（nativelib 编译通过，`QueryKeyStates` 已进 .so）
- `hvigorw assembleHap` ArkTS 编译零错误（本机无签名配置，打包/签名需 CI 或 DevEco 环境完成）

## 已知边界

- 修饰键 LEFT/RIGHT 的键码映射：2045-2048（Alt/Shift L/R）、2072-2073（Ctrl L/R）、2076-2077（Meta L/R），与 `KeyboardTranslator` 现有翻译一致
- `OH_Input_GetKeyState` 的 `Input_KeyStateAction` 语义为 KEY_PRESSED=0 / KEY_RELEASED=1 / KEY_DEFAULT=-1，native 层已统一转换为 1=按下 / 0=松开 / -1=未知

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复窗口失去焦点或应用进入后台时按键状态未及时释放的问题。
  * 自动释放普通按键及 Windows 修饰键，避免远端出现按键持续按下或卡住。
  * 窗口恢复焦点或游戏菜单关闭后，自动核对物理按键状态并恢复仍处于按下状态的按键。
  * 即使未检测到普通按键，也会完整发送修饰键释放事件。
  * 鼠标输入暂停期间不会错误恢复鼠标拦截。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->