### PR TITLE
fix(hdr): use static display capability profile

### DIFF
--- a/entry/src/main/ets/service/streaming/NvHttp.ets
+++ b/entry/src/main/ets/service/streaming/NvHttp.ets
@@ -24,6 +24,8 @@ import { selectBestAddress, NvHttpHost } from '../../model/ComputerInfo';
 // HarmonyOS BrightnessInfo exposes peak/headroom but not the panel black level.
 // Match Sunshine's unknown-display fallback instead of inventing a raised black floor.
 export const DEFAULT_HDR_MIN_BRIGHTNESS_NITS: number = 0.001;
+export const DEFAULT_HDR_MAX_BRIGHTNESS_NITS: number = 1000;
+export const DEFAULT_HDR_MAX_FULL_FRAME_BRIGHTNESS_NITS: number = 1000;
 
 /**
  * NvHTTP - 与 NVIDIA GameStream / Sunshine 服务器通信
@@ -1218,8 +1220,8 @@ export class NvHttp {
 
     // 客户端屏幕亮度范围（用于服务端 HDR tone mapping）
     const minBrightness = config.minBrightness ?? DEFAULT_HDR_MIN_BRIGHTNESS_NITS;
-    const maxBrightness = config.maxBrightness ?? 500;
-    const maxAvgBrightness = config.maxAverageBrightness ?? 200;
+    const maxBrightness = config.maxBrightness ?? DEFAULT_HDR_MAX_BRIGHTNESS_NITS;
+    const maxAvgBrightness = config.maxAverageBrightness ?? DEFAULT_HDR_MAX_FULL_FRAME_BRIGHTNESS_NITS;
     params.push(`minBrightness=${minBrightness}`);
     params.push(`maxBrightness=${maxBrightness}`);
     params.push(`maxAverageBrightness=${maxAvgBrightness}`);

--- a/entry/src/main/ets/service/streaming/StreamingSession.ets
+++ b/entry/src/main/ets/service/streaming/StreamingSession.ets
@@ -12,7 +12,13 @@ import { StreamConfig, HdrMode, getSurroundAudioInfo } from '../../model/StreamC
 import { InputEvent, InputType, ControllerButtonEvent, ControllerAxisEvent, ControllerButton } from '../../model/InputEvent';
 import { ComputerManager } from '../ComputerManager';
 import { ComputerInfo, selectBestAddress } from '../../model/ComputerInfo';
-import { NvHttp, LaunchConfig, DEFAULT_HDR_MIN_BRIGHTNESS_NITS } from './NvHttp';
+import {
+  NvHttp,
+  LaunchConfig,
+  DEFAULT_HDR_MIN_BRIGHTNESS_NITS,
+  DEFAULT_HDR_MAX_BRIGHTNESS_NITS,
+  DEFAULT_HDR_MAX_FULL_FRAME_BRIGHTNESS_NITS
+} from './NvHttp';
 import { CryptoUtil } from '../../utils/CryptoUtil';
 import { parseAddressAndPort, parseRtspSessionHost } from '../../utils/NetHelper';
 import { common, abilityAccessCtrl, bundleManager, Permissions } from '@kit.AbilityKit';
@@ -351,44 +357,19 @@ export class StreamingSession {
    */
   private static getBrightnessRange(): number[] {
     const minBrightness = DEFAULT_HDR_MIN_BRIGHTNESS_NITS;
-    // Keep the invalid-report fallback aligned with Foundation Sunshine's
-    // client_display_capabilities_t safe defaults.
-    const fallbackMaxBrightness = 1000;
-    const fallbackMaxAverageBrightness = 1000;
-    const minimumReliableSdrNits = 50;
-    const minimumReliablePeakNits = 100;
-    let maxBrightness = fallbackMaxBrightness;
-    let maxAverageBrightness = fallbackMaxAverageBrightness;
+    const maxBrightness = DEFAULT_HDR_MAX_BRIGHTNESS_NITS;
+    const maxAverageBrightness = DEFAULT_HDR_MAX_FULL_FRAME_BRIGHTNESS_NITS;
 
     try {
       const brightnessInfo = display.getBrightnessInfo(0);
       console.info(`[Brightness] sdrNits=${brightnessInfo.sdrNits}, ` +
         `currentHeadroom=${brightnessInfo.currentHeadroom}, maxHeadroom=${brightnessInfo.maxHeadroom}`);
-
-      const sdrNits = brightnessInfo.sdrNits;
-      const maxHeadroom = brightnessInfo.maxHeadroom;
-      const measuredMaxBrightness = sdrNits * maxHeadroom;
-      const hasReliableMeasurement = Number.isFinite(sdrNits) &&
-        Number.isFinite(maxHeadroom) &&
-        Number.isFinite(measuredMaxBrightness) &&
-        sdrNits >= minimumReliableSdrNits &&
-        maxHeadroom > 0 &&
-        measuredMaxBrightness >= minimumReliablePeakNits &&
-        measuredMaxBrightness >= sdrNits;
-
-      if (hasReliableMeasurement) {
-        maxBrightness = measuredMaxBrightness;
-        maxAverageBrightness = sdrNits;
-      } else {
-        console.warn(`[Brightness] measurement is too low or inconsistent, ` +
-          `using defaults: sdrNits=${sdrNits}, maxHeadroom=${maxHeadroom}, ` +
-          `peak=${measuredMaxBrightness}`);
-      }
     } catch (err) {
       console.warn(`[Brightness] getBrightnessInfo 不可用，使用默认值: ${err}`);
     }
 
-    console.info(`[Brightness] min=${minBrightness}, max=${maxBrightness}, avg=${maxAverageBrightness} nits`);
+    console.info(`[Brightness] using static HDR capability profile: ` +
+      `min=${minBrightness}, max=${maxBrightness}, avg=${maxAverageBrightness} nits`);
     return [minBrightness, maxBrightness, maxAverageBrightness];
   }
 

--- a/entry/src/main/ets/service/streaming/StreamingSession.ets
+++ b/entry/src/main/ets/service/streaming/StreamingSession.ets
@@ -352,10 +352,11 @@ export class StreamingSession {
   }
 
   /**
-   * 获取设备屏幕亮度范围（用于服务端 HDR tone mapping）
+   * 获取用于服务端 HDR tone mapping 的静态显示能力 profile。
+   * 当前屏幕亮度仅用于诊断，不参与 capability 上报。
    * @returns [minBrightness, maxBrightness, maxAverageBrightness] (nits)
    */
-  private static getBrightnessRange(): number[] {
+  private static getHdrCapabilityProfile(): number[] {
     const minBrightness = DEFAULT_HDR_MIN_BRIGHTNESS_NITS;
     const maxBrightness = DEFAULT_HDR_MAX_BRIGHTNESS_NITS;
     const maxAverageBrightness = DEFAULT_HDR_MAX_FULL_FRAME_BRIGHTNESS_NITS;
@@ -1392,7 +1393,7 @@ export class StreamingSession {
       this.config.hdr = effectiveHdr;
     }
 
-    let brightnessRange = StreamingSession.getBrightnessRange();
+    let brightnessRange = StreamingSession.getHdrCapabilityProfile();
     if (effectiveHdr && this.config.hdrBrightnessOverride) {
       brightnessRange = StreamingSession.applyBrightnessOverride(brightnessRange, this.config.hdrPeakBrightnessNits);
       console.info('[Brightness] HDR override: min=' + brightnessRange[0].toString() +

--- a/nativelib/src/main/cpp/video_decoder.cpp
+++ b/nativelib/src/main/cpp/video_decoder.cpp
@@ -819,14 +819,7 @@ int VideoDecoder::Init(const VideoDecoderConfig& config, OHNativeWindow* window)
                 OH_LOG_WARN(LOG_APP, "{Init} Failed to set colorspace: %{public}d", csRet);
             }
             
-            // 3. 设置 HDR 白点亮度
-            float hdrWhitePointBrightness = 1.0f;
-            int32_t hdrBrightRet = OH_NativeWindow_NativeWindowHandleOpt(window_, SET_HDR_WHITE_POINT_BRIGHTNESS, hdrWhitePointBrightness);
-            if (hdrBrightRet != 0) {
-                OH_LOG_WARN(LOG_APP, "{Init} Failed to set HDR white point: %{public}d", hdrBrightRet);
-            }
-            
-            // 4. 设置 HDR 静态元数据（SMPTE 2086 + CTA 861.3）
+            // 3. 设置 HDR 静态元数据（SMPTE 2086 + CTA 861.3）
             // Sunshine 会通过控制流传递主机显示器/内容元数据；缺失时才使用 BT.2020 默认值。
             OH_NativeBuffer_StaticMetadata staticMetadata;
             bool hasHostHdrStaticMetadata = false;


### PR DESCRIPTION
## 改了啥呀

- 将自动 HDR 亮度上报改为稳定的静态 capability profile：`1000/0.001/1000 nits`。
- 不再把 HarmonyOS 当前 `sdrNits` 填入 `maxBrightness` 或 `maxAverageBrightness`。
- 保留 `getBrightnessInfo()` 日志用于诊断；手动 HDR 亮度覆盖仍按用户配置生效。
- 集中复用客户端默认亮度常量，避免 HTTP fallback 与会话初始化使用不同值。
- 移除 NativeWindow 初始化时固定的 `SET_HDR_WHITE_POINT_BRIGHTNESS(..., 1.0f)`，交由系统默认白点策略处理。

## 为啥要改

HarmonyOS 的 `sdrNits` 是当前 SDR 白电平，会随屏幕亮度变化，不是静态 HDR 峰值，也不是 HDR `maxFullFrameNits`。此前正常会话可能上报 `max≈712`、`max-full-frame≈158`，把两个不同语义的值混在一起，导致 Sunshine/VDD 使用不稳定的 HDR 显示能力。

HarmonyOS 公开 API 没有提供面板静态 HDR nits/MaxFALL，Foundation Sunshine 已定义 `1000/0.001/1000` 为未知显示器的安全默认 profile。本 PR 使用该 profile，避免当前亮度滑块污染 HDR/Vivid 转换链路。低亮度异常防护已在 PR #108 中合并。

NativeWindow 的 HDR 白点参数只规定了 `0.0~1.0` 范围，没有公开从当前 nits 到归一化值的换算公式。固定写入 `1.0` 会强制最大白点并可能覆盖系统亮度策略，因此改为不主动覆盖。

## 验证

- `npm test`
- `npm run check:scripts`
- `git diff --check`

本机 Hvigor 构建仍受环境限制：`DEVECO_SDK_HOME` 配置无效。
