### PR TITLE
feat(input): add screen-mapped DualSense touchpad

### DIFF
--- a/entry/src/main/ets/components/StreamMenuManager.ets
+++ b/entry/src/main/ets/components/StreamMenuManager.ets
@@ -79,6 +79,8 @@ export class StreamMenuManager {
         return '直接触摸模式';
       case 'mouse':
         return '鼠标模式';
+      case 'ds5_touchpad':
+        return 'DS5 触控板模式';
       default:
         return this.viewModel.touchMode;
     }
@@ -230,6 +232,11 @@ export class StreamMenuManager {
         title: currentMode === 'mouse' ? '✓ 鼠标模式' : '  鼠标模式',
         subtitle: '相对移动 + 按住拖动',
         value: 'mouse'
+      },
+      {
+        title: currentMode === 'ds5_touchpad' ? '✓ DS5 触控板' : '  DS5 触控板',
+        subtitle: '屏幕映射 DualSense 触控板，支持双指',
+        value: 'ds5_touchpad'
       },
       {
         title: '🖱️ 切换远程鼠标指针',

--- a/entry/src/main/ets/components/dialogs/GameMenuDialog.ets
+++ b/entry/src/main/ets/components/dialogs/GameMenuDialog.ets
@@ -460,7 +460,8 @@ export struct GameMenuDialog {
     const modes: TouchModeOption[] = [
       { key: 'trackpad', text: '触控板', subtitle: '像笔记本触控板一样操作' },
       { key: 'direct', text: '多点触控', subtitle: '直接点击屏幕位置' },
-      { key: 'mouse', text: '鼠标模式', subtitle: '模拟鼠标移动和点击' }
+      { key: 'mouse', text: '鼠标模式', subtitle: '模拟鼠标移动和点击' },
+      { key: 'ds5_touchpad', text: 'DS5 触控板', subtitle: '屏幕映射 DualSense 触控板' }
     ];
 
     const actions: ActionItem[] = modes.map((mode: TouchModeOption): ActionItem => {

--- a/entry/src/main/ets/components/dialogs/GameMenuDialog.ets
+++ b/entry/src/main/ets/components/dialogs/GameMenuDialog.ets
@@ -461,7 +461,7 @@ export struct GameMenuDialog {
       { key: 'trackpad', text: '触控板', subtitle: '像笔记本触控板一样操作' },
       { key: 'direct', text: '多点触控', subtitle: '直接点击屏幕位置' },
       { key: 'mouse', text: '鼠标模式', subtitle: '模拟鼠标移动和点击' },
-      { key: 'ds5_touchpad', text: 'DS5 触控板', subtitle: '屏幕映射 DualSense 触控板' }
+      { key: 'ds5_touchpad', text: 'DS5 触控板', subtitle: '屏幕映射 DualSense 触控板，支持双指' }
     ];
 
     const actions: ActionItem[] = modes.map((mode: TouchModeOption): ActionItem => {

--- a/entry/src/main/ets/pages/StreamPage.ets
+++ b/entry/src/main/ets/pages/StreamPage.ets
@@ -25,6 +25,15 @@ import { GameMenuDialog, GameMenuCallbacks } from '../components/dialogs/GameMen
 import { StreamMenuManager } from '../components/StreamMenuManager';
 import { StreamViewModel, TouchMode } from '../viewmodel/StreamViewModel';
 import { TouchInputHandler, TouchInputMode } from '../service/input/TouchInputHandler';
+import {
+  DS5_TOUCH_FEEDBACK_CANCEL,
+  DS5_TOUCH_FEEDBACK_CLICK_DOWN,
+  DS5_TOUCH_FEEDBACK_CLICK_UP,
+  DS5_TOUCH_FEEDBACK_DOWN,
+  DS5_TOUCH_FEEDBACK_MOVE,
+  DS5_TOUCH_FEEDBACK_UP,
+  Ds5TouchpadFeedback
+} from '../service/input/Ds5TouchpadGestureHandler';
 import { StreamWindowManager, DisplaySize } from '../service/streaming/StreamWindowManager';
 import { ShortcutManager, Shortcut } from '../components/ShortcutManager';
 import { pickRandomConnectingTip } from '../components/StreamConnectingTips';
@@ -91,6 +100,16 @@ interface StreamPageParams {
   displayGuid?: string;   // 指定的显示器 GUID
   useVdd?: boolean;       // 是否使用虚拟显示器
   posterPath?: string;    // 应用本地海报路径，连接中遮罩背景
+}
+
+interface Ds5TouchIndicator {
+  pointerId: number;
+  x: number;
+  y: number;
+  contactActive: boolean;
+  clickPressed: boolean;
+  opacity: number;
+  scale: number;
 }
 
 class BuiltStreamReport {
@@ -208,6 +227,8 @@ struct StreamPage {
   @State videoTranslateX: number = 0;
   /** 视频垂直平移 (vp) */
   @State videoTranslateY: number = 0;
+  /** DS5 触控板本地触点回显，短暂显示且不参与命中测试。 */
+  @State private ds5TouchIndicators: Ds5TouchIndicator[] = [];
 
   // 鼠标高帧率保持（C++ Monitor 不可用时的 fallback）
   // 使用 DisplaySync 直接向系统合成器请求高刷新率，
@@ -257,6 +278,7 @@ struct StreamPage {
   private streamReportAiRequestId: number = 0;
   // AI 可用性探测的延时定时器，aboutToDisappear 时需清理
   private aiProbeTimer: number | null = null;
+  private ds5TouchFadeTimers: Map<number, number> = new Map();
   
   // 页面参数
   private computerId: string = '';
@@ -790,7 +812,9 @@ struct StreamPage {
     
     // 清理 ViewModel
     this.touchInputHandler.cancelActiveInput();
+    this.clearDs5TouchIndicators();
     this.touchInputHandler.setDs5TouchpadSink(null);
+    this.touchInputHandler.setDs5TouchpadFeedbackCallback(null);
     this.viewModel.dispose();
     
     // 清理触摸处理器
@@ -1413,6 +1437,9 @@ struct StreamPage {
 
     // 将屏幕 DS5 触控板绑定到本次会话的 controller slot 0。
     this.touchInputHandler.setDs5TouchpadSink(this.viewModel.getSession());
+    this.touchInputHandler.setDs5TouchpadFeedbackCallback((feedback: Ds5TouchpadFeedback): void => {
+      this.handleDs5TouchpadFeedback(feedback);
+    });
     this.touchInputHandler.setDs5TouchpadUnsupportedCallback(() => {
       if (this.viewModel.touchMode !== TouchMode.DS5_TOUCHPAD) return;
       setTimeout(() => {
@@ -1837,6 +1864,7 @@ struct StreamPage {
 
     this.stopClipboardSync();
     this.touchInputHandler.cancelActiveInput();
+    this.clearDs5TouchIndicators();
 
     const report = this.buildCurrentStreamReport();
     await this.saveStreamDiagnostics(report.diagnosticsText);
@@ -1911,7 +1939,9 @@ struct StreamPage {
 
       // 先停止当前会话（静默，不导航不显示 toast）
       this.touchInputHandler.cancelActiveInput();
+      this.clearDs5TouchIndicators();
       this.touchInputHandler.setDs5TouchpadSink(null);
+      this.touchInputHandler.setDs5TouchpadFeedbackCallback(null);
       await this.viewModel.stopStreaming();
       console.info('[StreamPage] 旧会话已停止，开始重新连接...');
 
@@ -1990,6 +2020,103 @@ struct StreamPage {
     this.touchInputHandler.handleTouchEvent(event);
   }
 
+  private handleDs5TouchpadFeedback(feedback: Ds5TouchpadFeedback): void {
+    if (feedback.type === DS5_TOUCH_FEEDBACK_CANCEL) {
+      this.clearDs5TouchIndicators();
+      return;
+    }
+
+    if (feedback.pointerId < 0) return;
+    const current = this.ds5TouchIndicators;
+    let found = false;
+    const next: Ds5TouchIndicator[] = [];
+    for (let i = 0; i < current.length; i++) {
+      const indicator = current[i];
+      if (indicator.pointerId !== feedback.pointerId) {
+        next.push(indicator);
+        continue;
+      }
+
+      found = true;
+      const updated: Ds5TouchIndicator = {
+        pointerId: indicator.pointerId,
+        x: feedback.x,
+        y: feedback.y,
+        contactActive: indicator.contactActive,
+        clickPressed: indicator.clickPressed,
+        opacity: 1,
+        scale: 1
+      };
+      if (feedback.type === DS5_TOUCH_FEEDBACK_DOWN ||
+        feedback.type === DS5_TOUCH_FEEDBACK_MOVE) {
+        updated.contactActive = true;
+        updated.clickPressed = false;
+      } else if (feedback.type === DS5_TOUCH_FEEDBACK_UP) {
+        updated.contactActive = false;
+        updated.scale = 0.82;
+        updated.opacity = 0.82;
+      } else if (feedback.type === DS5_TOUCH_FEEDBACK_CLICK_DOWN) {
+        updated.clickPressed = true;
+        updated.scale = 1.12;
+      } else if (feedback.type === DS5_TOUCH_FEEDBACK_CLICK_UP) {
+        updated.clickPressed = false;
+        updated.contactActive = false;
+        updated.scale = 0.78;
+        updated.opacity = 0.72;
+      }
+      next.push(updated);
+    }
+
+    if (!found && (feedback.type === DS5_TOUCH_FEEDBACK_DOWN ||
+      feedback.type === DS5_TOUCH_FEEDBACK_CLICK_DOWN)) {
+      const created: Ds5TouchIndicator = {
+        pointerId: feedback.pointerId,
+        x: feedback.x,
+        y: feedback.y,
+        contactActive: feedback.type === DS5_TOUCH_FEEDBACK_DOWN,
+        clickPressed: feedback.type === DS5_TOUCH_FEEDBACK_CLICK_DOWN,
+        opacity: 1,
+        scale: feedback.type === DS5_TOUCH_FEEDBACK_CLICK_DOWN ? 1.12 : 1
+      };
+      next.push(created);
+    }
+
+    this.ds5TouchIndicators = next;
+    let shouldScheduleRemoval = feedback.type === DS5_TOUCH_FEEDBACK_CLICK_UP;
+    if (feedback.type === DS5_TOUCH_FEEDBACK_UP) {
+      for (let i = 0; i < this.ds5TouchIndicators.length; i++) {
+        const indicator = this.ds5TouchIndicators[i];
+        if (indicator.pointerId === feedback.pointerId && !indicator.clickPressed) {
+          shouldScheduleRemoval = true;
+          break;
+        }
+      }
+    }
+    if (shouldScheduleRemoval) {
+      this.scheduleDs5TouchIndicatorRemoval(feedback.pointerId);
+    }
+  }
+
+  private scheduleDs5TouchIndicatorRemoval(pointerId: number): void {
+    const previous = this.ds5TouchFadeTimers.get(pointerId);
+    if (previous !== undefined) clearTimeout(previous);
+    const timer = setTimeout(() => {
+      this.ds5TouchIndicators = this.ds5TouchIndicators.filter(
+        (indicator: Ds5TouchIndicator): boolean => indicator.pointerId !== pointerId
+      );
+      this.ds5TouchFadeTimers.delete(pointerId);
+    }, 140);
+    this.ds5TouchFadeTimers.set(pointerId, timer);
+  }
+
+  private clearDs5TouchIndicators(): void {
+    this.ds5TouchFadeTimers.forEach((timer: number): void => {
+      clearTimeout(timer);
+    });
+    this.ds5TouchFadeTimers.clear();
+    this.ds5TouchIndicators = [];
+  }
+
   /**
    * 处理本地系统触摸手势。
    *
@@ -2022,6 +2149,7 @@ struct StreamPage {
     }
 
     this.touchInputHandler.cancelActiveInput();
+    this.clearDs5TouchIndicators();
     if (nextMode === TouchMode.DS5_TOUCHPAD && this.isTouchOverrideEnabled) {
       this.isTouchOverrideEnabled = false;
       this.panZoomHandler.cancelActiveGesture();
@@ -2209,6 +2337,12 @@ struct StreamPage {
         })
       }
 
+      // DS5 触控板本地回显层：只画触点，不拦截后续触摸。
+      if (this.viewModel.isConnected && this.viewModel.touchMode === TouchMode.DS5_TOUCHPAD &&
+        this.ds5TouchIndicators.length > 0) {
+        this.Ds5TouchpadFeedbackOverlay()
+      }
+
       // 自定义按键覆盖层
       if (this.showCustomKeys && this.viewModel.isConnected) {
         Column() {
@@ -2300,6 +2434,60 @@ struct StreamPage {
   }
 
   // ==================== UI Builders ====================
+
+  @Builder
+  Ds5TouchpadFeedbackOverlay() {
+    Stack() {
+      ForEach(this.ds5TouchIndicators, (indicator: Ds5TouchIndicator) => {
+        Stack() {
+          Circle()
+            .width(42)
+            .height(42)
+            .fill(indicator.clickPressed ? '#45FFD166' : '#24FFFFFF')
+            .border({
+              width: indicator.clickPressed ? 2.5 : 1.5,
+              color: indicator.clickPressed ? '#FFF4C15D' : '#CCFFFFFF'
+            })
+          Circle()
+            .width(indicator.clickPressed ? 8 : 5)
+            .height(indicator.clickPressed ? 8 : 5)
+            .fill(indicator.clickPressed ? '#FFFFD166' : '#E6FFFFFF')
+        }
+          .width(42)
+          .height(42)
+          .position({
+            x: (indicator.x * 100) + '%',
+            y: (indicator.y * 100) + '%'
+          })
+          .translate({
+            x: -21,
+            y: -21
+          })
+          .opacity(indicator.opacity)
+          .scale({
+            x: indicator.scale,
+            y: indicator.scale
+          })
+          .hitTestBehavior(HitTestMode.None)
+      }, (indicator: Ds5TouchIndicator): string => String(indicator.pointerId))
+    }
+      .width(this.xComponentWidth)
+      .height(this.xComponentHeight)
+      .alignContent(this.xComponentAlignment)
+      .offset({ x: this.xComponentOffsetX, y: this.xComponentOffsetY })
+      .scale({
+        x: this.videoScale,
+        y: this.videoScale,
+        centerX: 0,
+        centerY: 0
+      })
+      .translate({
+        x: this.videoTranslateX,
+        y: this.videoTranslateY
+      })
+      .clip(true)
+      .hitTestBehavior(HitTestMode.None)
+  }
 
   @Builder
   KeyboardInputPanel() {

--- a/entry/src/main/ets/pages/StreamPage.ets
+++ b/entry/src/main/ets/pages/StreamPage.ets
@@ -2027,6 +2027,17 @@ struct StreamPage {
     }
 
     if (feedback.pointerId < 0) return;
+    // pointerId 可能被复用：新触点激活时取消旧的淡出移除定时器，
+    // 否则 140ms 后活跃触点会被旧定时器误删。
+    if (feedback.type === DS5_TOUCH_FEEDBACK_DOWN ||
+      feedback.type === DS5_TOUCH_FEEDBACK_MOVE ||
+      feedback.type === DS5_TOUCH_FEEDBACK_CLICK_DOWN) {
+      const pending = this.ds5TouchFadeTimers.get(feedback.pointerId);
+      if (pending !== undefined) {
+        clearTimeout(pending);
+        this.ds5TouchFadeTimers.delete(feedback.pointerId);
+      }
+    }
     const current = this.ds5TouchIndicators;
     let found = false;
     const next: Ds5TouchIndicator[] = [];

--- a/entry/src/main/ets/pages/StreamPage.ets
+++ b/entry/src/main/ets/pages/StreamPage.ets
@@ -335,6 +335,7 @@ struct StreamPage {
         // 失焦（Alt+Tab 切走 / 弹系统对话框）：释放所有按键，
         // 防止 KEY_UP 丢失导致主机端修饰键/普通键卡住
         this.inputHandler.releaseAllKeys();
+        this.touchInputHandler.cancelActiveInput();
         this.inputHandler.stopMouseInterceptor();
         this.stopMouseKeepAlive();
       } else {
@@ -788,6 +789,8 @@ struct StreamPage {
     this.lifecycleManager.stopBackgroundTask();
     
     // 清理 ViewModel
+    this.touchInputHandler.cancelActiveInput();
+    this.touchInputHandler.setDs5TouchpadSink(null);
     this.viewModel.dispose();
     
     // 清理触摸处理器
@@ -1408,6 +1411,23 @@ struct StreamPage {
 
     await this.viewModel.startStreaming(this.computerId, this.appId, surfaceId, this.context, this.displayGuid, this.useVdd);
 
+    // 将屏幕 DS5 触控板绑定到本次会话的 controller slot 0。
+    this.touchInputHandler.setDs5TouchpadSink(this.viewModel.getSession());
+    this.touchInputHandler.setDs5TouchpadUnsupportedCallback(() => {
+      if (this.viewModel.touchMode !== TouchMode.DS5_TOUCHPAD) return;
+      setTimeout(() => {
+        if (this.viewModel.touchMode !== TouchMode.DS5_TOUCHPAD) return;
+        this.setTouchMode(TouchMode.TRACKPAD);
+        ToastQueue.show({ message: '主机未启用 DS5 触控板协议，已回退为普通触控板', duration: 2500 });
+      }, 0);
+    });
+
+    if (this.viewModel.touchMode === TouchMode.DS5_TOUCHPAD &&
+      !this.viewModel.isDs5TouchpadSupported()) {
+      this.setTouchMode(TouchMode.TRACKPAD);
+      ToastQueue.show({ message: '主机未启用 DS5 触控板协议，已回退为普通触控板', duration: 2500 });
+    }
+
     // 串流启动后调度未识别 USB 手柄检测（延迟内 GCK 完成扫描）
     this.scheduleUnhandledUsbDetection();
   }
@@ -1454,8 +1474,7 @@ struct StreamPage {
       }
       
       // 设置触摸输入模式
-      const touchModeStr = this.viewModel.touchMode as string;
-      this.touchInputHandler.setMode(touchModeStr as TouchInputMode);
+      this.touchInputHandler.setMode(this.toTouchInputMode(this.viewModel.touchMode));
       // 配置双击时间阈值和双击拖动
       if (streamConfig) {
         this.touchInputHandler.setDoubleTapTimeThreshold(streamConfig.doubleTapTimeThreshold);
@@ -1817,6 +1836,7 @@ struct StreamPage {
     }
 
     this.stopClipboardSync();
+    this.touchInputHandler.cancelActiveInput();
 
     const report = this.buildCurrentStreamReport();
     await this.saveStreamDiagnostics(report.diagnosticsText);
@@ -1851,6 +1871,7 @@ struct StreamPage {
     }
 
     this.stopClipboardSync();
+    this.touchInputHandler.cancelActiveInput();
 
     const report = this.buildCurrentStreamReport();
     await this.saveStreamDiagnostics(report.diagnosticsText);
@@ -1889,6 +1910,8 @@ struct StreamPage {
       this.stopClipboardSync();
 
       // 先停止当前会话（静默，不导航不显示 toast）
+      this.touchInputHandler.cancelActiveInput();
+      this.touchInputHandler.setDs5TouchpadSink(null);
       await this.viewModel.stopStreaming();
       console.info('[StreamPage] 旧会话已停止，开始重新连接...');
 
@@ -1944,6 +1967,8 @@ struct StreamPage {
         return '多点触控模式';
       case 'mouse':
         return '鼠标模式';
+      case 'ds5_touchpad':
+        return 'DS5 触控板模式';
       default:
         return this.viewModel.touchMode;
     }
@@ -1958,7 +1983,8 @@ struct StreamPage {
     }
     // 虚拟手柄显示时，默认不处理触摸输入（避免与虚拟按键手势竞争）
     // touchPassthrough 开启时允许共存
-    if (this.viewModel.showController && !this.touchPassthrough) {
+    if (this.viewModel.showController && !this.touchPassthrough &&
+      this.viewModel.touchMode !== TouchMode.DS5_TOUCHPAD) {
       return;
     }
     this.touchInputHandler.handleTouchEvent(event);
@@ -1988,9 +2014,35 @@ struct StreamPage {
    * 设置触摸模式
    */
   setTouchMode(mode: string): void {
-    this.viewModel.setTouchMode(mode as TouchMode);
-    this.touchInputHandler.setMode(mode as TouchInputMode);
+    const nextMode = mode as TouchMode;
+    if (nextMode === TouchMode.DS5_TOUCHPAD && this.viewModel.isConnected &&
+      !this.viewModel.isDs5TouchpadSupported()) {
+      ToastQueue.show({ message: '主机未启用 DS5 触控板协议', duration: 2200 });
+      return;
+    }
+
+    this.touchInputHandler.cancelActiveInput();
+    if (nextMode === TouchMode.DS5_TOUCHPAD && this.isTouchOverrideEnabled) {
+      this.isTouchOverrideEnabled = false;
+      this.panZoomHandler.cancelActiveGesture();
+    }
+    this.viewModel.setTouchMode(nextMode);
+    this.touchInputHandler.setMode(this.toTouchInputMode(nextMode));
     console.info(`StreamPage: 触摸模式切换为 ${mode}`);
+  }
+
+  private toTouchInputMode(mode: TouchMode): TouchInputMode {
+    switch (mode) {
+      case TouchMode.DIRECT:
+        return TouchInputMode.DIRECT;
+      case TouchMode.MOUSE:
+        return TouchInputMode.MOUSE;
+      case TouchMode.DS5_TOUCHPAD:
+        return TouchInputMode.DS5_TOUCHPAD;
+      case TouchMode.TRACKPAD:
+      default:
+        return TouchInputMode.TRACKPAD;
+    }
   }
   
   /**
@@ -2041,7 +2093,9 @@ struct StreamPage {
           .height(this.xComponentHeight)
           .offset({ x: this.xComponentOffsetX, y: this.xComponentOffsetY })
           .attributeModifier(this.aihdrModifier)
-          .hitTestBehavior((this.viewModel.showController && !this.touchPassthrough) ? HitTestMode.None : HitTestMode.Default)
+          .hitTestBehavior((this.viewModel.showController && !this.touchPassthrough &&
+            this.viewModel.touchMode !== TouchMode.DS5_TOUCHPAD)
+            ? HitTestMode.None : HitTestMode.Default)
           .onTouch((event: TouchEvent) => {
             // 过滤鼠标源触摸事件：物理鼠标点击会同时触发 .onMouse 和 .onTouch，
             // 鼠标事件已在 .onMouse 中处理，此处跳过避免重复发送为触摸

--- a/entry/src/main/ets/service/input/Ds5TouchpadGestureHandler.ets
+++ b/entry/src/main/ets/service/input/Ds5TouchpadGestureHandler.ets
@@ -23,6 +23,21 @@ export interface Ds5TouchpadInputSink {
   setDs5TouchpadButtonPressed(pressed: boolean): void;
 }
 
+export const DS5_TOUCH_FEEDBACK_DOWN = 1;
+export const DS5_TOUCH_FEEDBACK_MOVE = 2;
+export const DS5_TOUCH_FEEDBACK_UP = 3;
+export const DS5_TOUCH_FEEDBACK_CANCEL = 4;
+export const DS5_TOUCH_FEEDBACK_CLICK_DOWN = 5;
+export const DS5_TOUCH_FEEDBACK_CLICK_UP = 6;
+
+/** Local-only feedback for showing the touch contact without changing input. */
+export interface Ds5TouchpadFeedback {
+  type: number;
+  pointerId: number;
+  x: number;
+  y: number;
+}
+
 interface Ds5TouchState {
   startX: number;
   startY: number;
@@ -49,9 +64,13 @@ export class Ds5TouchpadGestureHandler {
   private touches: Map<number, Ds5TouchState> = new Map();
   private clickReleaseTimer: number = -1;
   private clickPressed: boolean = false;
+  private clickPointerId: number = -1;
+  private clickX: number = 0;
+  private clickY: number = 0;
   private tapToClickEnabled: boolean = true;
   private unsupportedReported: boolean = false;
   private onUnsupported: (() => void) | null = null;
+  private onFeedback: ((feedback: Ds5TouchpadFeedback) => void) | null = null;
 
   setSink(sink: Ds5TouchpadInputSink | null): void {
     if (this.sink === sink) return;
@@ -62,6 +81,10 @@ export class Ds5TouchpadGestureHandler {
 
   setUnsupportedCallback(callback: (() => void) | null): void {
     this.onUnsupported = callback;
+  }
+
+  setFeedbackCallback(callback: ((feedback: Ds5TouchpadFeedback) => void) | null): void {
+    this.onFeedback = callback;
   }
 
   /** 将单指短触映射为 DualSense 触控板机械按键。 */
@@ -102,6 +125,7 @@ export class Ds5TouchpadGestureHandler {
     this.cancelActiveInput();
     this.sink = null;
     this.onUnsupported = null;
+    this.onFeedback = null;
     this.unsupportedReported = false;
   }
 
@@ -184,12 +208,16 @@ export class Ds5TouchpadGestureHandler {
       const state = this.touches.get(touch.id);
       if (!state) continue;
 
-      if (this.tapToClickEnabled && this.isTap(touch, state, now)) this.pressClickButton();
+      const normalizedX = this.normalize(touch.x, areaWidth);
+      const normalizedY = this.normalize(touch.y, areaHeight);
+      if (this.tapToClickEnabled && this.isTap(touch, state, now)) {
+        this.pressClickButton(touch.id, normalizedX, normalizedY);
+      }
       this.sendTouch(
         TOUCH_EVENT_UP,
         touch.id,
-        this.normalize(touch.x, areaWidth),
-        this.normalize(touch.y, areaHeight),
+        normalizedX,
+        normalizedY,
         0,
       );
       this.touches.delete(touch.id);
@@ -202,6 +230,19 @@ export class Ds5TouchpadGestureHandler {
     if (!sink) return -2;
 
     const ret = sink.sendDs5TouchpadEvent(eventType, pointerId, x, y, pressure);
+    if (ret >= 0 && this.onFeedback) {
+      let feedbackType = eventType;
+      if (eventType === TOUCH_EVENT_CANCEL_ALL) {
+        feedbackType = DS5_TOUCH_FEEDBACK_CANCEL;
+      }
+      const feedback: Ds5TouchpadFeedback = {
+        type: feedbackType,
+        pointerId: pointerId,
+        x: x,
+        y: y
+      };
+      this.onFeedback(feedback);
+    }
     if (ret === LI_ERR_UNSUPPORTED && !this.unsupportedReported) {
       this.unsupportedReported = true;
       const callback = this.onUnsupported;
@@ -210,7 +251,7 @@ export class Ds5TouchpadGestureHandler {
     return ret;
   }
 
-  private pressClickButton(): void {
+  private pressClickButton(pointerId: number, x: number, y: number): void {
     const sink = this.sink;
     if (!sink) return;
 
@@ -222,6 +263,18 @@ export class Ds5TouchpadGestureHandler {
 
     sink.setDs5TouchpadButtonPressed(true);
     this.clickPressed = true;
+    this.clickPointerId = pointerId;
+    this.clickX = x;
+    this.clickY = y;
+    if (this.onFeedback) {
+      const feedback: Ds5TouchpadFeedback = {
+        type: DS5_TOUCH_FEEDBACK_CLICK_DOWN,
+        pointerId: pointerId,
+        x: x,
+        y: y
+      };
+      this.onFeedback(feedback);
+    }
     this.clickReleaseTimer = setTimeout(() => {
       this.clickReleaseTimer = -1;
       this.releaseClickButton();
@@ -237,7 +290,17 @@ export class Ds5TouchpadGestureHandler {
 
     const sink = this.sink;
     if (sink) sink.setDs5TouchpadButtonPressed(false);
+    if (this.onFeedback) {
+      const feedback: Ds5TouchpadFeedback = {
+        type: DS5_TOUCH_FEEDBACK_CLICK_UP,
+        pointerId: this.clickPointerId,
+        x: this.clickX,
+        y: this.clickY
+      };
+      this.onFeedback(feedback);
+    }
     this.clickPressed = false;
+    this.clickPointerId = -1;
   }
 
   private markMultiTouchGesture(): void {

--- a/entry/src/main/ets/service/input/Ds5TouchpadGestureHandler.ets
+++ b/entry/src/main/ets/service/input/Ds5TouchpadGestureHandler.ets
@@ -1,0 +1,269 @@
+/*
+ * Moonlight for HarmonyOS
+ * Copyright (C) 2024-2025 Moonlight/AlkaidLab
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import {
+  TOUCH_EVENT_CANCEL_ALL,
+  TOUCH_EVENT_DOWN,
+  TOUCH_EVENT_MOVE,
+  TOUCH_EVENT_UP,
+  LI_ERR_UNSUPPORTED,
+} from '../streaming/MoonBridge';
+
+/** DS5 touchpad output owned by the active streaming session. */
+export interface Ds5TouchpadInputSink {
+  sendDs5TouchpadEvent(eventType: number, pointerId: number,
+    x: number, y: number, pressure: number): number;
+  setDs5TouchpadButtonPressed(pressed: boolean): void;
+}
+
+interface Ds5TouchState {
+  startX: number;
+  startY: number;
+  lastX: number;
+  lastY: number;
+  startTime: number;
+  tapEligible: boolean;
+}
+
+const MAX_TOUCHES = 2;
+const TAP_TIME_THRESHOLD_MS = 250;
+const TAP_MOVEMENT_THRESHOLD = 24;
+const CLICK_RELEASE_DELAY_MS = 50;
+
+/**
+ * Maps the screen surface to a DualSense touchpad.
+ *
+ * Touch contacts and the clickpad button are separate protocol states. A
+ * short single-finger tap presses the clickpad while the contact is still
+ * active, then releases both states in order.
+ */
+export class Ds5TouchpadGestureHandler {
+  private sink: Ds5TouchpadInputSink | null = null;
+  private touches: Map<number, Ds5TouchState> = new Map();
+  private clickReleaseTimer: number = -1;
+  private clickPressed: boolean = false;
+  private tapToClickEnabled: boolean = true;
+  private unsupportedReported: boolean = false;
+  private onUnsupported: (() => void) | null = null;
+
+  setSink(sink: Ds5TouchpadInputSink | null): void {
+    if (this.sink === sink) return;
+    this.cancelActiveInput();
+    this.sink = sink;
+    this.unsupportedReported = false;
+  }
+
+  setUnsupportedCallback(callback: (() => void) | null): void {
+    this.onUnsupported = callback;
+  }
+
+  /** 将单指短触映射为 DualSense 触控板机械按键。 */
+  setTapToClickEnabled(enabled: boolean): void {
+    this.tapToClickEnabled = enabled;
+    if (!enabled) this.releaseClickButton();
+  }
+
+  handleEvent(event: TouchEvent): void {
+    if (!this.sink) return;
+
+    switch (event.type) {
+      case TouchType.Down:
+        this.handleDown(event);
+        break;
+      case TouchType.Move:
+        this.handleMove(event);
+        break;
+      case TouchType.Up:
+        this.handleUp(event);
+        break;
+      case TouchType.Cancel:
+        this.cancelActiveInput();
+        break;
+    }
+  }
+
+  cancelActiveInput(): void {
+    const sink = this.sink;
+    if (sink && this.touches.size > 0) {
+      this.sendTouch(TOUCH_EVENT_CANCEL_ALL, 0, 0, 0, 0);
+    }
+    this.touches.clear();
+    this.releaseClickButton();
+  }
+
+  dispose(): void {
+    this.cancelActiveInput();
+    this.sink = null;
+    this.onUnsupported = null;
+    this.unsupportedReported = false;
+  }
+
+  private handleDown(event: TouchEvent): void {
+    const areaWidth = Number(event.target.area.width);
+    const areaHeight = Number(event.target.area.height);
+    if (areaWidth <= 0 || areaHeight <= 0) return;
+
+    const changedTouches = event.changedTouches;
+    for (let i = 0; i < changedTouches.length; i++) {
+      const touch = changedTouches[i];
+      if (this.touches.has(touch.id) || this.touches.size >= MAX_TOUCHES) {
+        this.markMultiTouchGesture();
+        continue;
+      }
+
+      const isOnlyTouch = this.touches.size === 0 && event.touches.length <= 1;
+      if (!isOnlyTouch) this.markMultiTouchGesture();
+
+      const x = this.normalize(touch.x, areaWidth);
+      const y = this.normalize(touch.y, areaHeight);
+      const pressure = this.getPressure(touch, true);
+      const ret = this.sendTouch(TOUCH_EVENT_DOWN, touch.id, x, y, pressure);
+      if (ret < 0) continue;
+
+      const state: Ds5TouchState = {
+        startX: touch.x,
+        startY: touch.y,
+        lastX: touch.x,
+        lastY: touch.y,
+        startTime: Date.now(),
+        tapEligible: isOnlyTouch,
+      };
+      this.touches.set(touch.id, state);
+    }
+
+    if (this.touches.size > 1) this.markMultiTouchGesture();
+  }
+
+  private handleMove(event: TouchEvent): void {
+    const areaWidth = Number(event.target.area.width);
+    const areaHeight = Number(event.target.area.height);
+    if (areaWidth <= 0 || areaHeight <= 0) return;
+
+    const activeTouches = event.touches;
+    for (let i = 0; i < activeTouches.length; i++) {
+      const touch = activeTouches[i];
+      const state = this.touches.get(touch.id);
+      if (!state) continue;
+
+      if (this.exceedsTapMovement(touch, state)) state.tapEligible = false;
+      state.lastX = touch.x;
+      state.lastY = touch.y;
+      this.sendTouch(
+        TOUCH_EVENT_MOVE,
+        touch.id,
+        this.normalize(touch.x, areaWidth),
+        this.normalize(touch.y, areaHeight),
+        this.getPressure(touch, true),
+      );
+    }
+  }
+
+  private handleUp(event: TouchEvent): void {
+    const areaWidth = Number(event.target.area.width);
+    const areaHeight = Number(event.target.area.height);
+    if (areaWidth <= 0 || areaHeight <= 0) {
+      this.cancelActiveInput();
+      return;
+    }
+
+    const now = Date.now();
+    const changedTouches = event.changedTouches;
+    if (changedTouches.length === 0 && event.touches.length === 0 && this.touches.size > 0) {
+      this.cancelActiveInput();
+      return;
+    }
+    for (let i = 0; i < changedTouches.length; i++) {
+      const touch = changedTouches[i];
+      const state = this.touches.get(touch.id);
+      if (!state) continue;
+
+      if (this.tapToClickEnabled && this.isTap(touch, state, now)) this.pressClickButton();
+      this.sendTouch(
+        TOUCH_EVENT_UP,
+        touch.id,
+        this.normalize(touch.x, areaWidth),
+        this.normalize(touch.y, areaHeight),
+        0,
+      );
+      this.touches.delete(touch.id);
+    }
+  }
+
+  private sendTouch(eventType: number, pointerId: number,
+    x: number, y: number, pressure: number): number {
+    const sink = this.sink;
+    if (!sink) return -2;
+
+    const ret = sink.sendDs5TouchpadEvent(eventType, pointerId, x, y, pressure);
+    if (ret === LI_ERR_UNSUPPORTED && !this.unsupportedReported) {
+      this.unsupportedReported = true;
+      const callback = this.onUnsupported;
+      if (callback) callback();
+    }
+    return ret;
+  }
+
+  private pressClickButton(): void {
+    const sink = this.sink;
+    if (!sink) return;
+
+    if (this.clickReleaseTimer !== -1) {
+      clearTimeout(this.clickReleaseTimer);
+      this.clickReleaseTimer = -1;
+    }
+    if (this.clickPressed) sink.setDs5TouchpadButtonPressed(false);
+
+    sink.setDs5TouchpadButtonPressed(true);
+    this.clickPressed = true;
+    this.clickReleaseTimer = setTimeout(() => {
+      this.clickReleaseTimer = -1;
+      this.releaseClickButton();
+    }, CLICK_RELEASE_DELAY_MS);
+  }
+
+  private releaseClickButton(): void {
+    if (this.clickReleaseTimer !== -1) {
+      clearTimeout(this.clickReleaseTimer);
+      this.clickReleaseTimer = -1;
+    }
+    if (!this.clickPressed) return;
+
+    const sink = this.sink;
+    if (sink) sink.setDs5TouchpadButtonPressed(false);
+    this.clickPressed = false;
+  }
+
+  private markMultiTouchGesture(): void {
+    this.touches.forEach((state: Ds5TouchState): void => {
+      state.tapEligible = false;
+    });
+  }
+
+  private isTap(touch: TouchObject, state: Ds5TouchState, now: number): boolean {
+    return state.tapEligible &&
+      now - state.startTime <= TAP_TIME_THRESHOLD_MS &&
+      !this.exceedsTapMovement(touch, state);
+  }
+
+  private exceedsTapMovement(touch: TouchObject, state: Ds5TouchState): boolean {
+    return Math.abs(touch.x - state.startX) > TAP_MOVEMENT_THRESHOLD ||
+      Math.abs(touch.y - state.startY) > TAP_MOVEMENT_THRESHOLD;
+  }
+
+  private getPressure(touch: TouchObject, active: boolean): number {
+    if (!active) return 0;
+    const pressure = touch.pressure ?? 1.0;
+    return Math.max(0, Math.min(1, pressure));
+  }
+
+  private normalize(value: number, extent: number): number {
+    return Math.max(0, Math.min(1, value / extent));
+  }
+}

--- a/entry/src/main/ets/service/input/Ds5TouchpadGestureHandler.ets
+++ b/entry/src/main/ets/service/input/Ds5TouchpadGestureHandler.ets
@@ -231,17 +231,16 @@ export class Ds5TouchpadGestureHandler {
 
     const ret = sink.sendDs5TouchpadEvent(eventType, pointerId, x, y, pressure);
     if (ret >= 0 && this.onFeedback) {
-      let feedbackType = eventType;
-      if (eventType === TOUCH_EVENT_CANCEL_ALL) {
-        feedbackType = DS5_TOUCH_FEEDBACK_CANCEL;
+      const feedbackType = this.toFeedbackType(eventType);
+      if (feedbackType !== 0) {
+        const feedback: Ds5TouchpadFeedback = {
+          type: feedbackType,
+          pointerId: pointerId,
+          x: x,
+          y: y
+        };
+        this.onFeedback(feedback);
       }
-      const feedback: Ds5TouchpadFeedback = {
-        type: feedbackType,
-        pointerId: pointerId,
-        x: x,
-        y: y
-      };
-      this.onFeedback(feedback);
     }
     if (ret === LI_ERR_UNSUPPORTED && !this.unsupportedReported) {
       this.unsupportedReported = true;
@@ -251,15 +250,27 @@ export class Ds5TouchpadGestureHandler {
     return ret;
   }
 
+  /** 协议事件值与本地反馈类型不同序，必须显式映射。返回 0 表示无对应反馈。 */
+  private toFeedbackType(eventType: number): number {
+    switch (eventType) {
+      case TOUCH_EVENT_DOWN:
+        return DS5_TOUCH_FEEDBACK_DOWN;
+      case TOUCH_EVENT_MOVE:
+        return DS5_TOUCH_FEEDBACK_MOVE;
+      case TOUCH_EVENT_UP:
+        return DS5_TOUCH_FEEDBACK_UP;
+      case TOUCH_EVENT_CANCEL_ALL:
+        return DS5_TOUCH_FEEDBACK_CANCEL;
+      default:
+        return 0;
+    }
+  }
+
   private pressClickButton(pointerId: number, x: number, y: number): void {
     const sink = this.sink;
     if (!sink) return;
 
-    if (this.clickReleaseTimer !== -1) {
-      clearTimeout(this.clickReleaseTimer);
-      this.clickReleaseTimer = -1;
-    }
-    if (this.clickPressed) sink.setDs5TouchpadButtonPressed(false);
+    if (this.clickPressed) this.releaseClickButton();
 
     sink.setDs5TouchpadButtonPressed(true);
     this.clickPressed = true;

--- a/entry/src/main/ets/service/input/TouchInputHandler.ets
+++ b/entry/src/main/ets/service/input/TouchInputHandler.ets
@@ -16,7 +16,11 @@
 import nativeLib from 'libmoonlight_nativelib.so';
 import { PointXY } from './PanZoomHandler';
 import { TrackpadGestureHandler, TrackpadInputSink, TrackpadConfig } from './TrackpadGestureHandler';
-import { Ds5TouchpadGestureHandler, Ds5TouchpadInputSink } from './Ds5TouchpadGestureHandler';
+import {
+  Ds5TouchpadFeedback,
+  Ds5TouchpadGestureHandler,
+  Ds5TouchpadInputSink
+} from './Ds5TouchpadGestureHandler';
 import {
   BUTTON_ACTION_PRESS,
   BUTTON_ACTION_RELEASE,
@@ -341,6 +345,11 @@ export class TouchInputHandler {
   /** 设置 DS5 触控板不受支持时的回退通知。 */
   setDs5TouchpadUnsupportedCallback(callback: (() => void) | null): void {
     this.ds5Touchpad.setUnsupportedCallback(callback);
+  }
+
+  /** 绑定 DS5 触点的本地视觉反馈，不改变远端输入协议。 */
+  setDs5TouchpadFeedbackCallback(callback: ((feedback: Ds5TouchpadFeedback) => void) | null): void {
+    this.ds5Touchpad.setFeedbackCallback(callback);
   }
 
   /**

--- a/entry/src/main/ets/service/input/TouchInputHandler.ets
+++ b/entry/src/main/ets/service/input/TouchInputHandler.ets
@@ -16,6 +16,7 @@
 import nativeLib from 'libmoonlight_nativelib.so';
 import { PointXY } from './PanZoomHandler';
 import { TrackpadGestureHandler, TrackpadInputSink, TrackpadConfig } from './TrackpadGestureHandler';
+import { Ds5TouchpadGestureHandler, Ds5TouchpadInputSink } from './Ds5TouchpadGestureHandler';
 import {
   BUTTON_ACTION_PRESS,
   BUTTON_ACTION_RELEASE,
@@ -42,7 +43,8 @@ import {
 export enum TouchInputMode {
   TRACKPAD = 'trackpad',  // 触摸板模式：相对移动
   DIRECT = 'direct',      // 直接触摸模式：绝对坐标（多点触控协议）
-  MOUSE = 'mouse'         // 鼠标模式：绝对定位 + 死区 + 长按右键 + 双指滚轮
+  MOUSE = 'mouse',        // 鼠标模式：绝对定位 + 死区 + 长按右键 + 双指滚轮
+  DS5_TOUCHPAD = 'ds5_touchpad' // 屏幕映射 DualSense 触控板
 }
 
 /**
@@ -145,6 +147,8 @@ export class TouchInputHandler {
 
   /** 触控板手势处理器（对齐 Android RelativeTouchContext） */
   private trackpad: TrackpadGestureHandler;
+  /** 屏幕映射 DualSense 触控板（与普通鼠标触控板完全独立） */
+  private ds5Touchpad: Ds5TouchpadGestureHandler = new Ds5TouchpadGestureHandler();
 
   // ====== 鼠标模式状态（绝对定位 + 死区 + 长按右键，对齐 Android AbsoluteTouchContext） ======
   /** 主手指按下位置 */
@@ -322,8 +326,21 @@ export class TouchInputHandler {
     if (this.mode === TouchInputMode.MOUSE && mode !== TouchInputMode.MOUSE) {
       this.resetMouseState(true);
     }
+    if (this.mode === TouchInputMode.DS5_TOUCHPAD && mode !== TouchInputMode.DS5_TOUCHPAD) {
+      this.ds5Touchpad.cancelActiveInput();
+    }
     this.mode = mode;
     console.info(`TouchInputHandler: 模式切换为 ${mode}`);
+  }
+
+  /** 绑定当前串流会话的 DS5 触控输出。 */
+  setDs5TouchpadSink(sink: Ds5TouchpadInputSink | null): void {
+    this.ds5Touchpad.setSink(sink);
+  }
+
+  /** 设置 DS5 触控板不受支持时的回退通知。 */
+  setDs5TouchpadUnsupportedCallback(callback: (() => void) | null): void {
+    this.ds5Touchpad.setUnsupportedCallback(callback);
   }
 
   /**
@@ -335,6 +352,7 @@ export class TouchInputHandler {
   cancelActiveInput(): void {
     this.trackpad.dispose();
     this.resetMouseState(true);
+    this.ds5Touchpad.cancelActiveInput();
     this.touchStates.clear();
     this.lastForce.clear();
     this.lastSize.clear();
@@ -399,9 +417,14 @@ export class TouchInputHandler {
    */
   handleTouchEvent(event: TouchEvent): void {
     const touches = event.touches;
-    if (touches.length === 0) {
+
+    // DS5 触控板的 Up/Cancel 可能只携带 changedTouches，不能在这里提前返回。
+    if (this.mode === TouchInputMode.DS5_TOUCHPAD) {
+      this.ds5Touchpad.handleEvent(event);
       return;
     }
+
+    if (touches.length === 0) return;
 
     // 检测手写笔输入：SourceTool.Pen = 2
     // 仅在 DIRECT 模式下发送 Pen 协议事件（带压感/倾斜），
@@ -1087,6 +1110,7 @@ export class TouchInputHandler {
    */
   dispose(): void {
     this.trackpad.dispose();
+    this.ds5Touchpad.dispose();
     this.resetMouseState(false);
     this.touchStates.clear();
     this.lastForce.clear();

--- a/entry/src/main/ets/service/input/TouchInputHandler.ets
+++ b/entry/src/main/ets/service/input/TouchInputHandler.ets
@@ -32,6 +32,7 @@ import {
   TOUCH_EVENT_CANCEL,
   TOUCH_EVENT_HOVER,
   TOUCH_EVENT_CANCEL_ALL,
+  LI_ERR_UNSUPPORTED,
   LI_TOOL_TYPE_UNKNOWN,
   LI_TOOL_TYPE_PEN,
   LI_TOOL_TYPE_ERASER,
@@ -1006,7 +1007,7 @@ export class TouchInputHandler {
             areaMajor, areaMinor, rotation, tilt
           );
           // 检测主机是否支持 Pen 事件
-          if (ret === -7) { // LI_ERR_UNSUPPORTED = -7
+          if (ret === LI_ERR_UNSUPPORTED) {
             console.warn('手写笔: 主机不支持 Pen 事件，回退到 Touch 事件');
             this.penUnsupported = true;
             // 回退：用 touch 事件重新发送

--- a/entry/src/main/ets/service/streaming/MoonBridge.ets
+++ b/entry/src/main/ets/service/streaming/MoonBridge.ets
@@ -74,6 +74,8 @@ export const LI_ROT_UNKNOWN = 0xFFFF;
 
 // 主机功能标志
 export const LI_FF_PEN_TOUCH_EVENTS = 0x01;
+export const LI_FF_CONTROLLER_TOUCH_EVENTS = 0x02;
+export const LI_ERR_UNSUPPORTED = -5501;
 
 // 手柄按钮（完整定义见 CustomKeyTypes.GamepadButton）
 export const A_FLAG = 0x1000;

--- a/entry/src/main/ets/service/streaming/StreamingSession.ets
+++ b/entry/src/main/ets/service/streaming/StreamingSession.ets
@@ -902,7 +902,9 @@ export class StreamingSession implements Ds5TouchpadInputSink {
       this.hostFeatureFlagsKnown = true;
     } catch (_) {
       this.hostFeatureFlags = 0;
-      this.hostFeatureFlagsKnown = false;
+      // Feature flags are fixed for the lifetime of the connection. Treat a
+      // failed read as unsupported and avoid retrying on every MOVE event.
+      this.hostFeatureFlagsKnown = true;
     }
     return this.hostFeatureFlags;
   }

--- a/entry/src/main/ets/service/streaming/StreamingSession.ets
+++ b/entry/src/main/ets/service/streaming/StreamingSession.ets
@@ -31,6 +31,7 @@ import { AudioVibrationService } from '../AudioVibrationService';
 import { AdaptiveBitrateService } from './AdaptiveBitrateService';
 import { NetworkBoostService } from '../network/NetworkBoostService';
 import { BandwidthProbeService } from '../network/BandwidthProbeService';
+import { Ds5TouchpadInputSink } from '../input/Ds5TouchpadGestureHandler';
 import { MoonBridge as ClipboardNativeBridge } from '../jni/ClipboardBridge';
 import {
   MoonBridge,
@@ -39,8 +40,12 @@ import {
   CONTROLLER_TYPE_PS,
   LI_CCAP_ANALOG_TRIGGERS,
   LI_CCAP_RUMBLE,
+  LI_CCAP_TOUCHPAD,
   LI_CCAP_ACCEL,
   LI_CCAP_GYRO,
+  LI_FF_CONTROLLER_TOUCH_EVENTS,
+  LI_ERR_UNSUPPORTED,
+  TOUCHPAD_FLAG,
   MODIFIER_SHIFT,
   MODIFIER_CTRL,
   MODIFIER_ALT,
@@ -198,6 +203,11 @@ interface NativeModule {
     controllerNumber: number, activeGamepadMask: number, type: number,
     supportedButtonFlags: number, capabilities: number
   ): number;
+  sendControllerTouchEvent(
+    controllerNumber: number, eventType: number, pointerId: number,
+    x: number, y: number, pressure: number
+  ): number;
+  getHostFeatureFlags(): number;
   sendControllerMotionEvent(
     controllerNumber: number, motionType: number, x: number, y: number, z: number
   ): number;
@@ -338,7 +348,7 @@ const STANDARD_BUTTON_FLAGS =
  * - 麦克风采集与传输
  * - 性能统计
  */
-export class StreamingSession {
+export class StreamingSession implements Ds5TouchpadInputSink {
 
   // ---------------------------------------------------------------------------
   // 静态方法
@@ -437,6 +447,11 @@ export class StreamingSession {
   private virtualControllerArrived: boolean = false;
   private physicalControllerArrived = new Set<number>();
   private activeGamepadMask: number = 0;
+  /** 在连接建立前锁定触控板能力，确保首次 arrival 就带正确元数据。 */
+  private ds5TouchpadEnabled: boolean = false;
+  /** 每个槽位最近一次完整状态，触控板点击必须在此状态上合并。 */
+  private controllerStates: Map<number, ControllerState> = new Map();
+  private physicalControllerTypes: Map<number, number> = new Map();
   private controllerState: ControllerState = {
     buttonFlags: 0,
     leftTrigger: 0,
@@ -854,6 +869,63 @@ export class StreamingSession {
   }
 
   /**
+   * 在下一次 controller arrival 上声明触控板能力。
+   * 该开关应在连接建立前设置；Sunshine 不会接受已分配槽位的重复 arrival。
+   */
+  setDs5TouchpadEnabled(enabled: boolean): void {
+    const changed = this.ds5TouchpadEnabled !== enabled;
+    this.ds5TouchpadEnabled = enabled;
+    if (changed && this.isRunning) {
+      this.reannouncePrimaryController();
+    }
+  }
+
+  isDs5TouchpadEnabled(): boolean {
+    return this.ds5TouchpadEnabled;
+  }
+
+  /** 主机是否宣告 controller-touch 扩展。 */
+  isControllerTouchpadSupported(): boolean {
+    if (!this.isRunning) return false;
+    try {
+      return (this.nativeModule.getHostFeatureFlags() & LI_FF_CONTROLLER_TOUCH_EVENTS) !== 0;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  /** Ds5TouchpadInputSink: 发送屏幕触控板触点。 */
+  sendDs5TouchpadEvent(eventType: number, pointerId: number,
+    x: number, y: number, pressure: number): number {
+    if (!this.isRunning || !this.ds5TouchpadEnabled) return LI_ERR_UNSUPPORTED;
+    if (!this.isControllerTouchpadSupported()) return LI_ERR_UNSUPPORTED;
+
+    this.ensureVirtualControllerArrival(0);
+    return this.nativeModule.sendControllerTouchEvent(
+      0, eventType, pointerId, x, y, pressure
+    );
+  }
+
+  /** Ds5TouchpadInputSink: 在最近一次完整手柄状态上合并 clickpad。 */
+  setDs5TouchpadButtonPressed(pressed: boolean): void {
+    if (!this.isRunning || (!this.ds5TouchpadEnabled && pressed)) return;
+
+    if (this.ds5TouchpadEnabled) {
+      this.ensureVirtualControllerArrival(0);
+    } else if (!this.virtualControllerArrived && !this.physicalControllerArrived.has(0)) {
+      return;
+    }
+    const state = this.getControllerState(0);
+    if (pressed) {
+      state.buttonFlags |= TOUCHPAD_FLAG;
+    } else {
+      state.buttonFlags &= ~TOUCHPAD_FLAG;
+    }
+    this.controllerStates.set(0, state);
+    this.sendControllerStateSnapshot(0, state);
+  }
+
+  /**
    * 发送虚拟手柄输入（供 CustomKeyManager 使用）
    *
    * 与直接调用 MoonBridge 不同，此方法会先确保 controllerArrival 已发送，
@@ -867,6 +939,14 @@ export class StreamingSession {
     if (!this.isRunning) return;
     const controllerIndex = 0;
     this.ensureVirtualControllerArrival(controllerIndex);
+    this.controllerState.buttonFlags = buttonFlags;
+    this.controllerState.leftTrigger = leftTrigger;
+    this.controllerState.rightTrigger = rightTrigger;
+    this.controllerState.leftStickX = leftStickX;
+    this.controllerState.leftStickY = leftStickY;
+    this.controllerState.rightStickX = rightStickX;
+    this.controllerState.rightStickY = rightStickY;
+    this.controllerStates.set(controllerIndex, this.cloneControllerState(this.controllerState));
     this.nativeModule.sendMultiControllerInput(
       controllerIndex, this.activeGamepadMask,
       buttonFlags, leftTrigger, rightTrigger,
@@ -910,11 +990,17 @@ export class StreamingSession {
     }
 
     this.ensurePhysicalControllerArrival(controllerIndex, controllerType);
-    this.nativeModule.sendMultiControllerInput(
-      controllerIndex, this.activeGamepadMask,
-      buttons, leftTrigger, rightTrigger,
-      leftStickX, leftStickY, rightStickX, rightStickY
-    );
+    const state: ControllerState = {
+      buttonFlags: buttons,
+      leftTrigger: leftTrigger,
+      rightTrigger: rightTrigger,
+      leftStickX: leftStickX,
+      leftStickY: leftStickY,
+      rightStickX: rightStickX,
+      rightStickY: rightStickY
+    };
+    this.controllerStates.set(controllerIndex, state);
+    this.sendControllerStateSnapshot(controllerIndex, state);
   }
 
   /**
@@ -1265,6 +1351,10 @@ export class StreamingSession {
       connectionStarted: (): void => {
         console.info('连接已建立');
         this.isRunning = true;
+        if (this.ds5TouchpadEnabled) {
+          const supported = this.isControllerTouchpadSupported();
+          console.info(`DS5 屏幕触控板: 主机 controller-touch=${supported}`);
+        }
         this.startMicrophoneIfNeeded();
       },
       connectionTerminated: (errorCode: number): void => {
@@ -1633,21 +1723,26 @@ export class StreamingSession {
   private sendControllerState(controllerIndex: number): void {
     this.ensureVirtualControllerArrival(controllerIndex);
     const s = this.controllerState;
-    this.nativeModule.sendMultiControllerInput(
-      controllerIndex, this.activeGamepadMask,
-      s.buttonFlags, s.leftTrigger, s.rightTrigger,
-      s.leftStickX, s.leftStickY, s.rightStickX, s.rightStickY
-    );
+    this.controllerStates.set(controllerIndex, this.cloneControllerState(s));
+    this.sendControllerStateSnapshot(controllerIndex, s);
   }
 
   private ensureVirtualControllerArrival(controllerIndex: number): void {
-    if (this.virtualControllerArrived) return;
+    // A screen touchpad augments the primary physical controller. Reuse its
+    // slot instead of sending a duplicate arrival packet for controller 0.
+    if (this.virtualControllerArrived || this.physicalControllerArrived.has(controllerIndex)) return;
 
     this.activeGamepadMask |= (1 << controllerIndex);
+    const touchpadEnabled = this.ds5TouchpadEnabled;
+    const supportedButtons = touchpadEnabled
+      ? STANDARD_BUTTON_FLAGS | TOUCHPAD_FLAG
+      : STANDARD_BUTTON_FLAGS;
+    const controllerType = touchpadEnabled ? CONTROLLER_TYPE_PS : CONTROLLER_TYPE_XBOX;
+    const capabilities = LI_CCAP_ANALOG_TRIGGERS | LI_CCAP_RUMBLE |
+      (touchpadEnabled ? LI_CCAP_TOUCHPAD : 0);
     const ret = this.nativeModule.sendControllerArrivalEvent(
       controllerIndex, this.activeGamepadMask,
-      CONTROLLER_TYPE_XBOX, STANDARD_BUTTON_FLAGS,
-      LI_CCAP_ANALOG_TRIGGERS | LI_CCAP_RUMBLE
+      controllerType, supportedButtons, capabilities
     );
 
     if (ret >= 0) {
@@ -1661,22 +1756,45 @@ export class StreamingSession {
   private ensurePhysicalControllerArrival(controllerIndex: number, controllerType: number = CONTROLLER_TYPE_XBOX): void {
     if (this.physicalControllerArrived.has(controllerIndex)) return;
 
+    // A virtual controller may have claimed slot 0 before the physical device
+    // produced its first input. Treat the first physical state as the same
+    // logical controller and keep the already-advertised capability profile.
+    if (this.virtualControllerArrived && controllerIndex === 0) {
+      this.physicalControllerArrived.add(controllerIndex);
+      this.physicalControllerTypes.set(controllerIndex, controllerType);
+      console.info(`[Gamepad] reusing virtual arrival for physical slot ${controllerIndex}`);
+      return;
+    }
+
     let capabilities = LI_CCAP_ANALOG_TRIGGERS | LI_CCAP_RUMBLE;
     capabilities |= GamepadManager.getInstance().getSensorCapabilities(controllerIndex);
+    if (this.ds5TouchpadEnabled && controllerIndex === 0) {
+      capabilities |= LI_CCAP_TOUCHPAD;
+    }
 
     let reportedType = controllerType;
-    if ((capabilities & (LI_CCAP_ACCEL | LI_CCAP_GYRO)) && controllerType !== CONTROLLER_TYPE_PS) {
+    if (this.ds5TouchpadEnabled && controllerIndex === 0) {
+      // A screen-provided touchpad is a PS-family capability. The host's
+      // explicit DS5 mode still decides whether the slot is backed by DS5.
+      reportedType = CONTROLLER_TYPE_PS;
+    }
+    if ((capabilities & (LI_CCAP_ACCEL | LI_CCAP_GYRO)) && reportedType !== CONTROLLER_TYPE_PS) {
       reportedType = CONTROLLER_TYPE_UNKNOWN;
     }
 
     this.activeGamepadMask |= (1 << controllerIndex);
     const ret = this.nativeModule.sendControllerArrivalEvent(
       controllerIndex, this.activeGamepadMask,
-      reportedType, STANDARD_BUTTON_FLAGS, capabilities
+      reportedType,
+      this.ds5TouchpadEnabled && controllerIndex === 0
+        ? STANDARD_BUTTON_FLAGS | TOUCHPAD_FLAG
+        : STANDARD_BUTTON_FLAGS,
+      capabilities
     );
 
     if (ret >= 0) {
       this.physicalControllerArrived.add(controllerIndex);
+      this.physicalControllerTypes.set(controllerIndex, controllerType);
       console.info(`[Gamepad] arrival: index=${controllerIndex}, type=${reportedType}(orig=${controllerType}), ` +
         `caps=0x${capabilities.toString(16)}, mask=0x${this.activeGamepadMask.toString(16)}`);
     }
@@ -1685,7 +1803,70 @@ export class StreamingSession {
   private resetControllerState(): void {
     this.virtualControllerArrived = false;
     this.physicalControllerArrived.clear();
+    this.physicalControllerTypes.clear();
     this.activeGamepadMask = 0;
+    this.controllerStates.clear();
+    this.controllerState.buttonFlags = 0;
+    this.controllerState.leftTrigger = 0;
+    this.controllerState.rightTrigger = 0;
+    this.controllerState.leftStickX = 0;
+    this.controllerState.leftStickY = 0;
+    this.controllerState.rightStickX = 0;
+    this.controllerState.rightStickY = 0;
+  }
+
+  private getControllerState(controllerIndex: number): ControllerState {
+    const existing = this.controllerStates.get(controllerIndex);
+    if (existing) return existing;
+    const initial = this.cloneControllerState(this.controllerState);
+    this.controllerStates.set(controllerIndex, initial);
+    return initial;
+  }
+
+  private cloneControllerState(state: ControllerState): ControllerState {
+    return {
+      buttonFlags: state.buttonFlags,
+      leftTrigger: state.leftTrigger,
+      rightTrigger: state.rightTrigger,
+      leftStickX: state.leftStickX,
+      leftStickY: state.leftStickY,
+      rightStickX: state.rightStickX,
+      rightStickY: state.rightStickY
+    };
+  }
+
+  private sendControllerStateSnapshot(controllerIndex: number, state: ControllerState): void {
+    this.nativeModule.sendMultiControllerInput(
+      controllerIndex, this.activeGamepadMask,
+      state.buttonFlags, state.leftTrigger, state.rightTrigger,
+      state.leftStickX, state.leftStickY, state.rightStickX, state.rightStickY
+    );
+  }
+
+  /**
+   * Rebuild slot 0 when the user changes the touchpad mode during a session.
+   * Sunshine ignores duplicate arrival packets, so a real removal packet is
+   * required before advertising the new capability profile.
+   */
+  private reannouncePrimaryController(): void {
+    if (!this.isRunning) return;
+
+    const hadPhysical = this.physicalControllerArrived.has(0);
+    const hadSlot = hadPhysical || this.virtualControllerArrived || (this.activeGamepadMask & 1) !== 0;
+    if (!hadSlot) return;
+
+    const remainingMask = this.activeGamepadMask & ~1;
+    this.nativeModule.sendMultiControllerInput(0, remainingMask, 0, 0, 0, 0, 0, 0, 0);
+    this.activeGamepadMask = remainingMask;
+    this.virtualControllerArrived = false;
+    this.physicalControllerArrived.delete(0);
+
+    if (hadPhysical) {
+      const originalType = this.physicalControllerTypes.get(0) ?? CONTROLLER_TYPE_XBOX;
+      this.ensurePhysicalControllerArrival(0, originalType);
+    } else {
+      this.ensureVirtualControllerArrival(0);
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/entry/src/main/ets/service/streaming/StreamingSession.ets
+++ b/entry/src/main/ets/service/streaming/StreamingSession.ets
@@ -449,6 +449,11 @@ export class StreamingSession implements Ds5TouchpadInputSink {
   private activeGamepadMask: number = 0;
   /** 在连接建立前锁定触控板能力，确保首次 arrival 就带正确元数据。 */
   private ds5TouchpadEnabled: boolean = false;
+  /** 连接期间稳定不变的主机能力，避免触摸 MOVE 热路径跨 NAPI 查询。 */
+  private hostFeatureFlags: number = 0;
+  private hostFeatureFlagsKnown: boolean = false;
+  /** 屏幕触控板 clickpad 的粘滞状态，独立于各来源的完整手柄快照。 */
+  private ds5TouchpadButtonPressed: boolean = false;
   /** 每个槽位最近一次完整状态，触控板点击必须在此状态上合并。 */
   private controllerStates: Map<number, ControllerState> = new Map();
   private physicalControllerTypes: Map<number, number> = new Map();
@@ -887,17 +892,27 @@ export class StreamingSession implements Ds5TouchpadInputSink {
   /** 主机是否宣告 controller-touch 扩展。 */
   isControllerTouchpadSupported(): boolean {
     if (!this.isRunning) return false;
+    if (!this.hostFeatureFlagsKnown) this.readHostFeatureFlags();
+    return (this.hostFeatureFlags & LI_FF_CONTROLLER_TOUCH_EVENTS) !== 0;
+  }
+
+  private readHostFeatureFlags(): number {
     try {
-      return (this.nativeModule.getHostFeatureFlags() & LI_FF_CONTROLLER_TOUCH_EVENTS) !== 0;
+      this.hostFeatureFlags = this.nativeModule.getHostFeatureFlags();
+      this.hostFeatureFlagsKnown = true;
     } catch (_) {
-      return false;
+      this.hostFeatureFlags = 0;
+      this.hostFeatureFlagsKnown = false;
     }
+    return this.hostFeatureFlags;
   }
 
   /** Ds5TouchpadInputSink: 发送屏幕触控板触点。 */
   sendDs5TouchpadEvent(eventType: number, pointerId: number,
     x: number, y: number, pressure: number): number {
-    if (!this.isRunning || !this.ds5TouchpadEnabled) return LI_ERR_UNSUPPORTED;
+    // -2 means the local session is unavailable; it must not trigger the
+    // user-facing "host unsupported" fallback in the gesture handler.
+    if (!this.isRunning || !this.ds5TouchpadEnabled) return -2;
     if (!this.isControllerTouchpadSupported()) return LI_ERR_UNSUPPORTED;
 
     this.ensureVirtualControllerArrival(0);
@@ -915,14 +930,8 @@ export class StreamingSession implements Ds5TouchpadInputSink {
     } else if (!this.virtualControllerArrived && !this.physicalControllerArrived.has(0)) {
       return;
     }
-    const state = this.getControllerState(0);
-    if (pressed) {
-      state.buttonFlags |= TOUCHPAD_FLAG;
-    } else {
-      state.buttonFlags &= ~TOUCHPAD_FLAG;
-    }
-    this.controllerStates.set(0, state);
-    this.sendControllerStateSnapshot(0, state);
+    this.ds5TouchpadButtonPressed = pressed;
+    this.sendControllerStateSnapshot(0, this.getControllerState(0));
   }
 
   /**
@@ -947,11 +956,7 @@ export class StreamingSession implements Ds5TouchpadInputSink {
     this.controllerState.rightStickX = rightStickX;
     this.controllerState.rightStickY = rightStickY;
     this.controllerStates.set(controllerIndex, this.cloneControllerState(this.controllerState));
-    this.nativeModule.sendMultiControllerInput(
-      controllerIndex, this.activeGamepadMask,
-      buttonFlags, leftTrigger, rightTrigger,
-      leftStickX, leftStickY, rightStickX, rightStickY
-    );
+    this.sendControllerStateSnapshot(controllerIndex, this.controllerState);
   }
 
   // ---------------------------------------------------------------------------
@@ -1012,6 +1017,10 @@ export class StreamingSession implements Ds5TouchpadInputSink {
     controllerType: number = CONTROLLER_TYPE_XBOX
   ): void {
     if (!this.isRunning || !this.physicalControllerArrived.has(controllerIndex)) return;
+    if (controllerIndex === 0 && this.virtualControllerArrived) {
+      this.reannouncePrimaryController(controllerType);
+      return;
+    }
     this.physicalControllerArrived.delete(controllerIndex);
     this.ensurePhysicalControllerArrival(controllerIndex, controllerType);
   }
@@ -1360,6 +1369,8 @@ export class StreamingSession implements Ds5TouchpadInputSink {
       connectionTerminated: (errorCode: number): void => {
         console.info(`连接已终止: ${errorCode}, userInitiated=${this.userInitiatedStop}`);
         this.isRunning = false;
+        this.hostFeatureFlags = 0;
+        this.hostFeatureFlagsKnown = false;
         NetworkBoostService.getInstance().stop();
         GamepadManager.getInstance().stopAllSensors();
         // 立即停止所有振动（设备马达 + USB 手柄马达 + 音频振动）
@@ -1805,6 +1816,9 @@ export class StreamingSession implements Ds5TouchpadInputSink {
     this.physicalControllerArrived.clear();
     this.physicalControllerTypes.clear();
     this.activeGamepadMask = 0;
+    this.hostFeatureFlags = 0;
+    this.hostFeatureFlagsKnown = false;
+    this.ds5TouchpadButtonPressed = false;
     this.controllerStates.clear();
     this.controllerState.buttonFlags = 0;
     this.controllerState.leftTrigger = 0;
@@ -1836,9 +1850,12 @@ export class StreamingSession implements Ds5TouchpadInputSink {
   }
 
   private sendControllerStateSnapshot(controllerIndex: number, state: ControllerState): void {
+    const buttonFlags = controllerIndex === 0 && this.ds5TouchpadEnabled && this.ds5TouchpadButtonPressed
+      ? state.buttonFlags | TOUCHPAD_FLAG
+      : state.buttonFlags;
     this.nativeModule.sendMultiControllerInput(
       controllerIndex, this.activeGamepadMask,
-      state.buttonFlags, state.leftTrigger, state.rightTrigger,
+      buttonFlags, state.leftTrigger, state.rightTrigger,
       state.leftStickX, state.leftStickY, state.rightStickX, state.rightStickY
     );
   }
@@ -1848,7 +1865,7 @@ export class StreamingSession implements Ds5TouchpadInputSink {
    * Sunshine ignores duplicate arrival packets, so a real removal packet is
    * required before advertising the new capability profile.
    */
-  private reannouncePrimaryController(): void {
+  private reannouncePrimaryController(physicalTypeOverride?: number): void {
     if (!this.isRunning) return;
 
     const hadPhysical = this.physicalControllerArrived.has(0);
@@ -1862,7 +1879,8 @@ export class StreamingSession implements Ds5TouchpadInputSink {
     this.physicalControllerArrived.delete(0);
 
     if (hadPhysical) {
-      const originalType = this.physicalControllerTypes.get(0) ?? CONTROLLER_TYPE_XBOX;
+      const originalType = physicalTypeOverride ??
+        this.physicalControllerTypes.get(0) ?? CONTROLLER_TYPE_XBOX;
       this.ensurePhysicalControllerArrival(0, originalType);
     } else {
       this.ensureVirtualControllerArrival(0);

--- a/entry/src/main/ets/viewmodel/StreamViewModel.ets
+++ b/entry/src/main/ets/viewmodel/StreamViewModel.ets
@@ -39,7 +39,8 @@ export enum StreamConnectionState {
 export enum TouchMode {
   TRACKPAD = 'trackpad',
   DIRECT = 'direct',
-  MOUSE = 'mouse'
+  MOUSE = 'mouse',
+  DS5_TOUCHPAD = 'ds5_touchpad'
 }
 
 /**
@@ -254,7 +255,8 @@ export class StreamViewModel {
     // 确定触摸模式
     // 优先使用用户在菜单中选择过的模式（持久化在 LAST_TOUCH_MODE）
     const lastTouchMode = await PreferencesUtil.get<string>(SettingsKeys.LAST_TOUCH_MODE, '');
-    if (lastTouchMode && (lastTouchMode === 'trackpad' || lastTouchMode === 'direct' || lastTouchMode === 'mouse')) {
+    if (lastTouchMode && (lastTouchMode === 'trackpad' || lastTouchMode === 'direct' ||
+      lastTouchMode === 'mouse' || lastTouchMode === 'ds5_touchpad')) {
       this.touchMode = lastTouchMode as TouchMode;
     } else if (this.inputSettings.touchscreenTrackpad) {
       // 用户在设置中强制启用了触控板模式
@@ -305,6 +307,7 @@ export class StreamViewModel {
       
       // 创建串流会话
       this.streamingSession = new StreamingSession();
+      this.streamingSession.setDs5TouchpadEnabled(this.touchMode === TouchMode.DS5_TOUCHPAD);
       
       // 设置 HDR 状态回调，当 drSetup 检测到实际 HDR 状态时更新 UI
       this.streamingSession.setHdrStateCallback((isHdr: boolean) => {
@@ -598,11 +601,16 @@ export class StreamViewModel {
    */
   setTouchMode(mode: TouchMode): void {
     this.touchMode = mode;
+    this.streamingSession?.setDs5TouchpadEnabled(mode === TouchMode.DS5_TOUCHPAD);
     // 持久化用户在菜单中选择的触摸模式，断开重连后恢复
     PreferencesUtil.put(SettingsKeys.LAST_TOUCH_MODE, mode as string).catch((err: Error) => {
       console.warn(`StreamViewModel: 保存触摸模式失败: ${err.message}`);
     });
     console.info(`StreamViewModel: 触摸模式切换为 ${mode}`);
+  }
+
+  isDs5TouchpadSupported(): boolean {
+    return this.streamingSession?.isControllerTouchpadSupported() ?? false;
   }
 
   /**


### PR DESCRIPTION
## 改了啥呀

- 新增独立的 `DS5_TOUCHPAD` 屏幕触控模式，支持最多双指 DOWN/MOVE/UP/CANCEL。
- 通过 common-c 的 `LiSendControllerTouchEvent()` 发送归一化触点，并将单指短触合并为 DualSense clickpad 按键。
- slot 0 复用实体手柄状态，clickpad 更新不会清掉普通按键、摇杆或扳机。
- 主机未宣告 `LI_FF_CONTROLLER_TOUCH_EVENTS` 时自动回退普通触控板；模式切换、失焦、断流和销毁都会清理触点。

## 为啥要改

鸿蒙之前只有普通触控板/鼠标路径，屏幕触摸无法进入 Sunshine 的 DS5 触控板协议。现在把 ArkUI 触摸、MoonBridge、StreamingSession 和菜单配置接起来；重复 arrival 这个坏状态也已处理，避免屏幕触控与实体 USB/GCK 手柄争抢同一个 slot。

## 验证

- `npm run check`
- `DEVECO_SDK_HOME=/Users/mac/ohos-sdk-cache/6.1-Release-mac/sdk-ci-shape JAVA_HOME=/Users/mac/ohos-sdk-cache/jdk17-temurin/Home node hvigorw.js assembleApp --mode project -p product=default -p buildMode=debug --no-daemon --stacktrace`
- Hvigor `BUILD SUCCESSFUL`；仅保留仓库已有 ArkTS/API 兼容性警告。

主机端需要启用 Sunshine 的 controller-touch 扩展；当前未宣称该能力的主机会保持普通触控板行为，杂鱼协议不会把触摸事件硬塞进去。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增“DualSense 触控板”触摸模式，支持双指操作、触控板点击及当前模式标记。
  * 支持在串流过程中切换和使用触控板输入，并提供触点移动、点击反馈及淡出效果。
  * 自动检测设备与主机的触控板支持情况；不支持时回退为普通触控板模式。
  * 切换至触控板模式时，画面缩放会自动关闭。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->