### PR TITLE
chore(release): update version to 1.0.0.806

### DIFF
--- a/AppScope/app.json5
+++ b/AppScope/app.json5
@@ -2,8 +2,8 @@
   "app": {
     "bundleName": "com.alkaidlab.sdream",
     "vendor": "Moonlight",
-    "versionCode": 1000797,
-    "versionName": "1.0.0.797",
+    "versionCode": 1000806,
+    "versionName": "1.0.0.806",
     "icon": "$media:layered_icon",
     "label": "$string:app_name",
     "bundleType": "app",

--- a/entry/src/main/resources/rawfile/CHANGELOG.md
+++ b/entry/src/main/resources/rawfile/CHANGELOG.md
@@ -25,6 +25,66 @@
   - 最新版本放在最前面
 -->
 
+<!-- releases 798-806 are not present in this checkout
+- 🐛 release stuck keys on focus loss (#109)
+- 🔧 stop forcing native window white point
+- 🩹 use static display capability profile
+- 🛡️ reject transient low brightness reports
+- 🔨 expose audio buffer latency
+- 🐛 bound simulated IR rumble output
+- 🔧 cache physical controller motion slots
+- 🩹 bound trigger callbacks and harden USB teardown
+- 🛡️ serialize driver lifecycle transitions
+- 🔨 refresh late controller capabilities
+- 🐛 route physical motion by device identity
+- 🔧 repair DualSense motion forwarding
+- 🩹 suppress low-level DualSense IR noise (#105)
+- 🛡️ 缓存重复的 AAAA 查询 (#101)
+- 🔨 按码流自动识别 HDR Vivid (#98)
+- 🐛 恢复按键触感并统一机身振动 (#96)
+- 🔧 保留客户端黑位精度 (#95)
+- 🩹 应用解码器颜色元数据 (#94)
+- 🛡️ recover RTSP host resolution (#93)
+- 🔨 打通 HEVC/AV1 CUVA HDR Vivid 链路 (#92)
+- 🐛 修复自动刷新导致应用列表跳动 (#90)
+- 🔧 clear stale targets on PTS reanchor
+-->
+
+## [1.0.0.806] - 2026-08-17
+
+### 新增
+- ✨ connect HarmonyOS DualSense adaptive triggers
+- 🎉 add DualSense IR v2 client pipeline (#104)
+- 🆕 add pre-stream bandwidth probing (#99)
+- ⚡ make three-finger IME gesture optional (#97)
+
+### 优化
+- 🎯 name static capability profile
+
+### 修复
+- 🐛 release stuck keys on focus loss (#109)
+- 🔧 stop forcing native window white point
+- 🩹 use static display capability profile
+- 🛡️ reject transient low brightness reports
+- 🔨 expose audio buffer latency
+- 🐛 bound simulated IR rumble output
+- 🔧 cache physical controller motion slots
+- 🩹 bound trigger callbacks and harden USB teardown
+- 🛡️ serialize driver lifecycle transitions
+- 🔨 refresh late controller capabilities
+- 🐛 route physical motion by device identity
+- 🔧 repair DualSense motion forwarding
+- 🩹 suppress low-level DualSense IR noise (#105)
+- 🛡️ 缓存重复的 AAAA 查询 (#101)
+- 🔨 按码流自动识别 HDR Vivid (#98)
+- 🐛 恢复按键触感并统一机身振动 (#96)
+- 🔧 保留客户端黑位精度 (#95)
+- 🩹 应用解码器颜色元数据 (#94)
+- 🛡️ recover RTSP host resolution (#93)
+- 🔨 打通 HEVC/AV1 CUVA HDR Vivid 链路 (#92)
+- 🐛 修复自动刷新导致应用列表跳动 (#90)
+- 🔧 clear stale targets on PTS reanchor
+
 ## [1.0.0.797] - 2026-07-27
 HDR Vivid 内容识别与全屏串流鼠标输入优化
 

--- a/scripts/gen-changelog.js
+++ b/scripts/gen-changelog.js
@@ -122,6 +122,14 @@ function insertIntoChangelog(entry) {
   }
 
   const content = fs.readFileSync(CHANGELOG_PATH, 'utf-8');
+  const versionMatch = entry.match(/^## \[([^\]]+)\]/m);
+  if (versionMatch) {
+    const versionHeading = `## [${versionMatch[1]}]`;
+    if (content.includes(versionHeading)) {
+      console.log(`CHANGELOG 已存在版本 ${versionMatch[1]}，跳过重复写入`);
+      return true;
+    }
+  }
   // 在第一个 ## 之前插入新条目
   const firstVersionIndex = content.indexOf('\n## [');
   if (firstVersionIndex === -1) {

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -63,20 +63,19 @@ function versionToCode(versionName) {
 // --- 查找上一版本的 commit ---
 function findPreviousVersionCommit() {
   try {
-    // 查找最近的 "chore: 版本升级" commit（跳过 HEAD，因为 HEAD 可能就是上一次版本升级）
-    const hashes = execSync(
-      'git log --oneline --grep="版本升级" --format="%H" -2',
+    // Locate the commit that added the current version heading. This works
+    // with all historical release commit formats and does not depend on the
+    // commit message wording.
+    const changelog = fs.readFileSync(
+      path.join(ROOT, 'entry/src/main/resources/rawfile/CHANGELOG.md'), 'utf-8');
+    const latestVersion = changelog.match(/^## \[([^\]]+)\]/m)?.[1];
+    if (!latestVersion) return null;
+
+    const heading = `## [${latestVersion}]`;
+    return execSync(
+      `git log --format=%H -S${JSON.stringify(heading)} -- entry/src/main/resources/rawfile/CHANGELOG.md -1`,
       { encoding: 'utf-8', cwd: ROOT }
-    ).trim().split('\n').filter(Boolean);
-
-    const headHash = execSync('git rev-parse HEAD', { encoding: 'utf-8', cwd: ROOT }).trim();
-
-    // 返回第一个不是 HEAD 的版本升级 commit
-    for (const h of hashes) {
-      if (h !== headHash) return h;
-    }
-    // 如果只有一个且就是 HEAD，返回它（说明 HEAD 后有未提交的变更）
-    return hashes[0] || null;
+    ).trim() || null;
   } catch {
     return null;
   }


### PR DESCRIPTION
## 改了啥呀\n\n- 将应用版本更新到 1.0.0.806。\n- 补齐 797 之后已存在于当前仓库历史中的变更到 CHANGELOG。\n- 修复发版脚本的版本起点识别，并阻止重复插入同一版本日志。\n\n## 为啥要改\n\n发版脚本只匹配旧的提交文案，导致 CHANGELOG 起始范围错误，部分变更被漏掉或可能重复收录。现在按 CHANGELOG 当前版本标题定位提交，坏掉的历史范围不会再继续捣乱。\n\n## 验证\n\n- git diff --check\n- npm run check:scripts\n