### PR TITLE
feat(hdr): report measured brightness with SDR white anchoring

### DIFF
--- a/AppScope/app.json5
+++ b/AppScope/app.json5
@@ -2,8 +2,8 @@
   "app": {
     "bundleName": "com.alkaidlab.sdream",
     "vendor": "Moonlight",
-    "versionCode": 1000806,
-    "versionName": "1.0.0.806",
+    "versionCode": 1000808,
+    "versionName": "1.0.0.808",
     "icon": "$media:layered_icon",
     "label": "$string:app_name",
     "bundleType": "app",

--- a/ci/sdk-stubs/display-brightness-patch.d.ts
+++ b/ci/sdk-stubs/display-brightness-patch.d.ts
@@ -5,5 +5,8 @@ declare namespace display {
     currentHeadroom: number;
     maxHeadroom: number;
   }
+  type BrightnessCallback<T1, T2> = (data1: T1, data2: T2) => void;
   function getBrightnessInfo(displayId: number): BrightnessInfo;
+  function on(type: 'brightnessInfoChange', callback: BrightnessCallback<number, BrightnessInfo>): void;
+  function off(type: 'brightnessInfoChange', callback?: BrightnessCallback<number, BrightnessInfo>): void;
 }

--- a/docs/HDR_BRIGHTNESS_REPORTING.md
+++ b/docs/HDR_BRIGHTNESS_REPORTING.md
@@ -1,0 +1,35 @@
+# HDR 亮度上报契约(客户端 → Sunshine)
+
+客户端在 launch 请求(`POST /launch`)中上报显示亮度能力,宿主(foundation Sunshine)据此:
+
+1. 创建对应峰值亮度的虚拟 HDR 屏;
+2. 分析抓帧并生成 CUVA HDR Vivid 动态元数据的 tone-map 目标。
+
+## 参数
+
+| 参数 | 类型 | 语义 | 客户端行为 |
+|---|---|---|---|
+| `minBrightness` | float | 黑位(nits) | 固定 0.001(保留黑位精度,不取整) |
+| `maxBrightness` | int | 面板峰值亮度(nits),虚拟屏亮度依据 | 实测 `sdrNits × maxHeadroom` **吸附标准档 [400,600,800,1000,1200,1600,2000,2600,4000]**(±30% 内吸附,避免逐会话微变触发宿主重建 VDD);回退 1000;手动滑条覆盖时为用户值(300–4000) |
+| `maxAverageBrightness` | int | 满帧可持续亮度(nits),大面积亮场 tone-map 目标 | 实测 `sdrNits × p75(currentHeadroom)` 归整到 50 的倍数;回退/覆盖规则同上 |
+| `sdrBrightness` | int | **SDR 参考白 / paper white(nits)** | 实测有效即携带(手动滑条覆盖时同样携带);测量不可靠或非 HDR 会话时**省略该参数** |
+
+`sdrBrightness` 为本客户端扩展参数,旧宿主与 GFE 忽略未知 launch 参数,行为不变。
+
+## 宿主侧要求
+
+- **所有亮度参数都是 tone-map 目标,不是硬上限。**
+- 虚拟屏按 `maxBrightness` 建峰亮;`maxAverageBrightness` 用于压缩大面积亮场(面板 ABL/可持续约束)。
+- **`sdrBrightness` 的落地方式(foundation-sunshine 已实现)**:解析范围 [50,1000](越界忽略按未携带处理);在 scRGB→HLG 转换着色器中对 SDR 波段(≤ Windows 当前 SDR 白位,来自 VDD 光标共享内存的实时值)乘增益 `clamp(phoneSdr / windowsSdr, 0.5, 2.5)`,波段上沿 2 倍处平滑过渡回 1.0——HDR 高光保持绝对值,SDR 参考内容落到手机自己的 SDR 白位。未携带时增益恒 1,行为与旧宿主逐字节一致。日志关键字:`SDR band gain: phone=X, windows=Y, gain=Z`。
+- 宿主若不读 `sdrBrightness`,应假设 ~200 nits 参考白,绝不能把 `maxBrightness` 当 SDR 白位使用——那会让全画面中亮度内容整体过亮,是 HDR Vivid 过曝的直接来源。
+- VDD 能力比较带容差(每字段 ±max(25 nits, 5%)),配合客户端档位吸附,正常情况下同设备重复连接不触发 VDD 重建。
+
+## 客户端测量逻辑(参考)
+
+`entry/src/main/ets/service/streaming/BrightnessSampler.ets`:启动时对 `display.getBrightnessInfo()` 窗口采样(5 次 × 250ms),校验门:sdrNits ≥ 50、样本间波动比 ≤ 1.5、峰值 ≥ 100 且 ≥ sdrNits;`sdrNits` 取中位数,峰值取 `sdrNits × max(maxHeadroom)` 后吸附标准档,满帧取 `sdrNits × p75(currentHeadroom)` 后归整 50 倍数。
+
+sdrNits 并非恒定面板参数,是系统状态快照(亮度滑条/显示模式可能改变它);客户端同时注册 `brightnessInfoChange` 探针打日志(`[BrightnessProbe]`),用于评估其动态性。
+
+## 诊断
+
+串流性能浮层 DECODER 行显示 `屏<sdrr>/<peak>→<hostMaxLum>nit`:手机实测 SDR 白位/峰值 vs 宿主通过 SS_HDR_METADATA 回传的 `maxDisplayLuminance`。两者偏差大即 tone-map 目标与真实面板脱节,优先排查宿主是否吃到上述参数。

--- a/docs/HDR_BRIGHTNESS_REPORTING.md
+++ b/docs/HDR_BRIGHTNESS_REPORTING.md
@@ -30,6 +30,19 @@
 
 sdrNits 并非恒定面板参数,是系统状态快照(亮度滑条/显示模式可能改变它);客户端同时注册 `brightnessInfoChange` 探针打日志(`[BrightnessProbe]`),用于评估其动态性。
 
+## 运行时更新协议
+
+动态 SDR 白位更新仅用于 Sunshine 加密 HLG 会话。宿主通过 `LI_FF_DYNAMIC_SDR_WHITE` (`0x100`) 声明支持后,客户端才发送可靠控制包 `0x5506`;不支持时继续使用 launch 阶段的 `sdrBrightness` 快照,旧客户端和旧宿主行为不变。
+
+客户端对亮度变化做 500ms 防抖,并仅在变化达到 5% 或 10 nits 时发送。有效范围为 [50,1000] nits。控制包 payload 固定 8 字节:
+
+| 偏移 | 编码 | 语义 |
+|---|---|---|
+| 0–3 | little-endian int32 | 参数类型 `9` (`CLIENT_SDR_WHITE_NITS`) |
+| 4–7 | little-endian IEEE-754 float32 | 当前 SDR 参考白(nits) |
+
+该可靠通道没有应用层 ACK;发送成功只表示控制包已进入可靠发送队列,不表示宿主已经应用。宿主必须校验参数类型、payload 长度和数值范围,未知参数保持向前兼容地忽略。
+
 ## 诊断
 
 串流性能浮层 DECODER 行显示 `屏<sdrr>/<peak>→<hostMaxLum>nit`:手机实测 SDR 白位/峰值 vs 宿主通过 SS_HDR_METADATA 回传的 `maxDisplayLuminance`。两者偏差大即 tone-map 目标与真实面板脱节,优先排查宿主是否吃到上述参数。

--- a/entry/src/main/ets/components/PerformanceOverlay.ets
+++ b/entry/src/main/ets/components/PerformanceOverlay.ets
@@ -14,7 +14,7 @@
  * 从 StreamPage 抽离的独立组件，显示串流性能数据
  * 支持拖动、吸附、布局切换等功能
  */
-import { promptAction } from '@kit.ArkUI';
+import { promptAction, display } from '@kit.ArkUI';
 import { batteryInfo } from '@kit.BasicServicesKit';
 import { OptionPickerDialog, OptionPickerDialogConfig, OptionItem, SliderConfig } from './dialogs/OptionPickerDialog';
 import { ToastQueue } from '../utils/ToastQueue';
@@ -60,6 +60,10 @@ export struct PerformanceOverlay {
   @State perfHostLatency: number = 0;
   @State perfPacketLoss: number = 0;
   @State perfHdrVivid: boolean = false;
+  // HDR 亮度诊断:手机实测 SDR 白位/峰值 vs 宿主上报目标 (nits)
+  @State perfPhoneSdrNits: number = 0;
+  @State perfPhonePeakNits: number = 0;
+  @State perfHostMaxLuminance: number = 0;
   @State perfBatteryLevel: number = 100;
   @State perfIsCharging: boolean = false;
   @State perfUpscaleMode: number = 0;
@@ -224,6 +228,14 @@ export struct PerformanceOverlay {
       this.perfHostLatency = stats.hostLatency;
       this.perfPacketLoss = stats.packetLoss;
       this.perfHdrVivid = stats.hdrVivid;
+      this.perfHostMaxLuminance = stats.hostMaxLuminance || 0;
+      if (this.viewModel.actualHdr) {
+        try {
+          const brightnessInfo = display.getBrightnessInfo(0);
+          this.perfPhoneSdrNits = Math.round(brightnessInfo.sdrNits);
+          this.perfPhonePeakNits = Math.round(brightnessInfo.sdrNits * brightnessInfo.maxHeadroom);
+        } catch (_) { /* 低版本系统无此 API */ }
+      }
 
       // 🎃 愚人节彩蛋：负延迟串流™
       if (isAprilFools()) {
@@ -558,6 +570,12 @@ export struct PerformanceOverlay {
           .fontSize(12)
           .fontWeight(FontWeight.Bold)
           .fontColor('#FFFFFF')
+        if (this.viewModel.actualHdr && this.perfHostMaxLuminance > 0) {
+          Text(` 屏${this.perfPhoneSdrNits}/${this.perfPhonePeakNits}→${this.perfHostMaxLuminance}nit`)
+            .fontSize(11)
+            .fontWeight(FontWeight.Medium)
+            .fontColor('#CCFFFFFF')
+        }
       }
       .margin({ bottom: 4 })
     }
@@ -704,6 +722,11 @@ export struct PerformanceOverlay {
           .fontSize(11)
           .fontWeight(FontWeight.Bold)
           .fontColor('#FFFFFF')
+        if (this.viewModel.actualHdr && this.perfHostMaxLuminance > 0) {
+          Text(` 屏${this.perfPhoneSdrNits}/${this.perfPhonePeakNits}→${this.perfHostMaxLuminance}nit`)
+            .fontSize(10)
+            .fontColor('#CCFFFFFF')
+        }
         if (this.hasNextItem(PerformanceItem.DECODER)) this.Separator()
       }
       

--- a/entry/src/main/ets/pages/SettingsPageV2.ets
+++ b/entry/src/main/ets/pages/SettingsPageV2.ets
@@ -1211,7 +1211,7 @@ struct SettingsPageV2 {
                 title: '手动 HDR 亮度校准',
                 subtitle: this.hdrBrightnessOverride
                   ? '上报峰值 ' + this.hdrPeakBrightnessNits.toString() + ' nits，重新连接后生效'
-                  : '默认按屏幕实测亮度上报，过曝/偏暗时可手动覆盖',
+                  : '默认优先按屏幕实测亮度上报；测量不可靠时回退默认值，过曝/偏暗时可手动覆盖',
                 type: 'toggle',
                 visible: this.enableHdr,
                 value: this.hdrBrightnessOverride,

--- a/entry/src/main/ets/pages/SettingsPageV2.ets
+++ b/entry/src/main/ets/pages/SettingsPageV2.ets
@@ -1211,7 +1211,7 @@ struct SettingsPageV2 {
                 title: '手动 HDR 亮度校准',
                 subtitle: this.hdrBrightnessOverride
                   ? '上报峰值 ' + this.hdrPeakBrightnessNits.toString() + ' nits，重新连接后生效'
-                  : 'HDR 发灰或偏暗时覆盖上报给 Sunshine 的屏幕亮度',
+                  : '默认按屏幕实测亮度上报，过曝/偏暗时可手动覆盖',
                 type: 'toggle',
                 visible: this.enableHdr,
                 value: this.hdrBrightnessOverride,

--- a/entry/src/main/ets/service/streaming/BrightnessSampler.ets
+++ b/entry/src/main/ets/service/streaming/BrightnessSampler.ets
@@ -1,0 +1,124 @@
+import { display } from '@kit.ArkUI';
+
+/**
+ * HDR 亮度采样与聚合
+ *
+ * 通过 display.getBrightnessInfo 窗口采样估算真实显示能力:
+ * - sdrNits: SDR 参考白 (nits)
+ * - currentHeadroom / maxHeadroom: 相对 sdrNits 的倍率,峰值 = sdrNits × maxHeadroom
+ *
+ * 聚合逻辑为纯函数,不依赖 display,便于未来补单元测试。
+ */
+
+export interface BrightnessSample {
+  sdrNits: number;
+  currentHeadroom: number;
+  maxHeadroom: number;
+}
+
+export interface MeasuredBrightnessProfile {
+  sdrNits: number;
+  maxBrightness: number;
+  maxAverageBrightness: number;
+}
+
+/** a13fcce 校验阈值:低于此值视为系统未就绪/瞬态干扰 */
+const MIN_RELIABLE_SDR_NITS = 50;
+const MIN_RELIABLE_PEAK_NITS = 100;
+/** 样本间 sdrNits 最大波动比,超过视为瞬态(自动亮度正在调整) */
+const MAX_SDR_VARIANCE_RATIO = 1.5;
+const MIN_AGGREGATE_SAMPLES = 3;
+
+function median(values: number[]): number {
+  const sorted = values.slice().sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 1 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+function percentile75(values: number[]): number {
+  const sorted = values.slice().sort((a, b) => a - b);
+  const idx = Math.min(sorted.length - 1, Math.ceil(sorted.length * 0.75) - 1);
+  return sorted[idx];
+}
+
+function clampRound(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, Math.round(value)));
+}
+
+/** 峰值吸附标准档,避免逐会话微变触发宿主 VDD 重建 */
+const MAX_BRIGHTNESS_TIERS: number[] = [400, 600, 800, 1000, 1200, 1600, 2000, 2600, 4000];
+
+function snapToTier(value: number, tiers: number[]): number {
+  let best = tiers[0];
+  for (const tier of tiers) {
+    if (Math.abs(tier - value) < Math.abs(best - value)) {
+      best = tier;
+    }
+  }
+  return best;
+}
+
+/**
+ * 聚合采样并校验可靠性,不可靠返回 null(调用方回退静态 profile)。
+ */
+export function aggregateBrightnessSamples(samples: BrightnessSample[]): MeasuredBrightnessProfile | null {
+  const valid = samples.filter(s =>
+    Number.isFinite(s.sdrNits) && Number.isFinite(s.currentHeadroom) && Number.isFinite(s.maxHeadroom) &&
+    s.sdrNits >= MIN_RELIABLE_SDR_NITS && s.maxHeadroom > 0 && s.currentHeadroom > 0);
+  if (valid.length < MIN_AGGREGATE_SAMPLES) {
+    return null;
+  }
+
+  const sdrValues = valid.map(s => s.sdrNits);
+  const minSdr = Math.min(...sdrValues);
+  const maxSdr = Math.max(...sdrValues);
+  if (minSdr <= 0 || maxSdr / minSdr > MAX_SDR_VARIANCE_RATIO) {
+    return null;
+  }
+
+  const sdrNits = median(sdrValues);
+  const peak = sdrNits * Math.max(...valid.map(s => s.maxHeadroom));
+  if (!(peak >= MIN_RELIABLE_PEAK_NITS) || peak < sdrNits) {
+    return null;
+  }
+
+  // 峰值先取整钳位,再吸附标准档;吸附跳变超过 ±30% 时保留原值(避免低峰值被拉高太多)
+  const clampedPeak = clampRound(peak, MIN_RELIABLE_PEAK_NITS, 10000);
+  const snappedPeak = snapToTier(clampedPeak, MAX_BRIGHTNESS_TIERS);
+  const maxBrightness = Math.abs(snappedPeak - clampedPeak) <= clampedPeak * 0.3 ? snappedPeak : clampedPeak;
+  const maxAverageBrightness = Math.min(maxBrightness,
+    Math.round(clampRound(sdrNits * percentile75(valid.map(s => s.currentHeadroom)), 50, 10000) / 50) * 50);
+
+  return { sdrNits: Math.round(sdrNits), maxBrightness, maxAverageBrightness };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise<void>(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * 窗口采样:count 次读取、intervalMs 间隔(默认 5×250ms ≈ 1s)。
+ * 单次读取失败跳过,聚合结果不可靠时返回 null。
+ */
+export async function sampleDisplayBrightness(
+  displayId: number = 0,
+  count: number = 5,
+  intervalMs: number = 250
+): Promise<MeasuredBrightnessProfile | null> {
+  const samples: BrightnessSample[] = [];
+  for (let i = 0; i < count; i++) {
+    if (i > 0) {
+      await sleep(intervalMs);
+    }
+    try {
+      const info = display.getBrightnessInfo(displayId);
+      samples.push({ sdrNits: info.sdrNits, currentHeadroom: info.currentHeadroom, maxHeadroom: info.maxHeadroom });
+    } catch (err) {
+      console.warn(`[Brightness] getBrightnessInfo 不可用: ${err}`);
+    }
+  }
+  if (samples.length === 0) {
+    return null;
+  }
+  return aggregateBrightnessSamples(samples);
+}

--- a/entry/src/main/ets/service/streaming/MoonBridge.ets
+++ b/entry/src/main/ets/service/streaming/MoonBridge.ets
@@ -75,6 +75,7 @@ export const LI_ROT_UNKNOWN = 0xFFFF;
 // 主机功能标志
 export const LI_FF_PEN_TOUCH_EVENTS = 0x01;
 export const LI_FF_CONTROLLER_TOUCH_EVENTS = 0x02;
+export const LI_FF_DYNAMIC_SDR_WHITE = 0x100;
 export const LI_ERR_UNSUPPORTED = -5501;
 
 // 手柄按钮（完整定义见 CustomKeyTypes.GamepadButton）
@@ -715,6 +716,10 @@ class MoonBridgeClass {
 
   getHostFeatureFlags(): number {
     return nativeLib.getHostFeatureFlags();
+  }
+
+  sendClientSdrWhiteNits(nits: number): number {
+    return nativeLib.sendClientSdrWhiteNits(nits);
   }
 
   // ==========================================================================

--- a/entry/src/main/ets/service/streaming/NvHttp.ets
+++ b/entry/src/main/ets/service/streaming/NvHttp.ets
@@ -1225,6 +1225,11 @@ export class NvHttp {
     params.push(`minBrightness=${minBrightness}`);
     params.push(`maxBrightness=${maxBrightness}`);
     params.push(`maxAverageBrightness=${maxAvgBrightness}`);
+    // SDR 参考白(宿主用于虚拟屏 SDR 白位与 CUVA 动态元数据 paper white 锚点);
+    // 仅实测有效时携带,旧宿主忽略未知参数
+    if (config.sdrBrightness !== undefined && Number.isFinite(config.sdrBrightness) && config.sdrBrightness > 0) {
+      params.push(`sdrBrightness=${Math.round(config.sdrBrightness)}`);
+    }
 
     // 屏幕组合模式（Sunshine 多显示器管理）
     if (config.screenCombinationMode !== undefined && config.screenCombinationMode !== -1) {
@@ -1533,6 +1538,7 @@ export interface LaunchConfig {
   minBrightness?: number;       // 客户端屏幕最小亮度 (nits)
   maxBrightness?: number;       // 客户端屏幕最大亮度 (nits)
   maxAverageBrightness?: number; // 客户端屏幕最大平均亮度 (nits)
+  sdrBrightness?: number;       // 客户端 SDR 参考白 (nits),仅实测有效时携带
   screenCombinationMode?: number; // 屏幕组合模式 (-1=主机默认, 0=不修改, 1=确保开启, 2=主屏, 3=仅此屏)
 }
 

--- a/entry/src/main/ets/service/streaming/StreamingSession.ets
+++ b/entry/src/main/ets/service/streaming/StreamingSession.ets
@@ -453,6 +453,9 @@ export class StreamingSession implements Ds5TouchpadInputSink {
   /** 用户主动发起的停止（菜单断开/退出游戏），抑制 connectionTerminated 回调弹窗 */
   private userInitiatedStop: boolean = false;
   private isStartingConnection: boolean = false;
+  /** 回调代次:native 各回调走独立 TSFN,无跨队列顺序;init() 重注册时递增,用于丢弃旧代次迟到回调 */
+  private static callbackGeneration: number = 0;
+  private registeredGeneration: number = 0;
   private connectionStartPromise: Promise<number> | null = null;
   private lastFailedStage: number = 0;
   private computer: ComputerInfo | null = null;
@@ -1371,6 +1374,7 @@ export class StreamingSession implements Ds5TouchpadInputSink {
 
   private async initializeNative(): Promise<void> {
     console.info('初始化 Native 模块');
+    this.registeredGeneration = ++StreamingSession.callbackGeneration;
 
     const callbacks: StreamCallbacks = {
       drSetup: (videoFormat: number, width: number, height: number, redrawRate: number): void => {
@@ -1462,6 +1466,10 @@ export class StreamingSession implements Ds5TouchpadInputSink {
       setHdrMode: (enabled: boolean, hasMetadata: boolean, maxDisplayLuminance: number,
         minDisplayLuminance: number, maxContentLightLevel: number, maxFrameAverageLightLevel: number,
         maxFullFrameLuminance: number): void => {
+        // setHdrMode 与 connectionTerminated 分属不同 TSFN,无跨队列顺序保证:
+        // 丢弃旧代次注册或已终止会话的迟到回调(启动窗口靠 isStartingConnection 放行)
+        if (this.registeredGeneration !== StreamingSession.callbackGeneration) return;
+        if (!this.isRunning && !this.isStartingConnection) return;
         const metadata: HostHdrMetadata | null = hasMetadata ? {
           maxDisplayLuminance,
           minDisplayLuminance,

--- a/entry/src/main/ets/service/streaming/StreamingSession.ets
+++ b/entry/src/main/ets/service/streaming/StreamingSession.ets
@@ -45,6 +45,7 @@ import {
   LI_CCAP_ACCEL,
   LI_CCAP_GYRO,
   LI_FF_CONTROLLER_TOUCH_EVENTS,
+  LI_FF_DYNAMIC_SDR_WHITE,
   LI_ERR_UNSUPPORTED,
   TOUCHPAD_FLAG,
   MODIFIER_SHIFT,
@@ -220,6 +221,7 @@ interface NativeModule {
     x: number, y: number, pressure: number
   ): number;
   getHostFeatureFlags(): number;
+  sendClientSdrWhiteNits(nits: number): number;
   sendControllerMotionEvent(
     controllerNumber: number, motionType: number, x: number, y: number, z: number
   ): number;
@@ -349,6 +351,11 @@ const STANDARD_BUTTON_FLAGS =
   MoonlightButton.LS | MoonlightButton.RS |
   MoonlightButton.START | MoonlightButton.BACK | MoonlightButton.SPECIAL;
 
+/** 亮度事件防抖和 SDR white 发送迟滞，避免拖动亮度条时刷控制包。 */
+const SDR_WHITE_DEBOUNCE_MS = 500;
+const SDR_WHITE_MIN_DELTA_NITS = 10;
+const SDR_WHITE_MIN_DELTA_RATIO = 0.05;
+
 // =============================================================================
 // StreamingSession
 // =============================================================================
@@ -470,8 +477,13 @@ export class StreamingSession implements Ds5TouchpadInputSink {
   private brightnessSamplePromise: Promise<MeasuredBrightnessProfile | null> | null = null;
   /** 实测 SDR 参考白 (nits,0=未测量/不可靠),用于 sdrBrightness 上报 */
   private lastMeasuredSdrNits: number = 0;
-  /** sdrNits 动态性探针(brightnessInfoChange 日志),仅诊断不参与上报 */
+  /** brightnessInfoChange 监听器；事件只作失效信号，实际值由窗口重采样获得。 */
   private brightnessProbeHandler: ((displayId: number, info: display.BrightnessInfo) => void) | null = null;
+  private brightnessUpdateTimer: number = -1;
+  private brightnessSampleInFlight: boolean = false;
+  private brightnessSamplePending: boolean = false;
+  private brightnessUpdateGeneration: number = 0;
+  private lastSentSdrWhiteNits: number = 0;
 
   // 服务器信息
   private serverAppVersion: string = '';
@@ -643,6 +655,10 @@ export class StreamingSession implements Ds5TouchpadInputSink {
     this.abilityContext = context;
     this.userInitiatedStop = false;
     this.lastMeasuredSdrNits = 0;
+    this.lastSentSdrWhiteNits = 0;
+    this.brightnessSamplePending = false;
+    this.brightnessSampleInFlight = false;
+    this.brightnessUpdateGeneration++;
     this.lastHostHdrMetadata = null;
     // 亮度采样提前发起,与后续网络请求重叠执行,不增加启动延迟
     this.brightnessSamplePromise = sampleDisplayBrightness(0).catch(() => null);
@@ -1431,6 +1447,12 @@ export class StreamingSession implements Ds5TouchpadInputSink {
       connectionStarted: (): void => {
         console.info('连接已建立');
         this.isRunning = true;
+        this.readHostFeatureFlags();
+        if (this.lastMeasuredSdrNits > 0) {
+          this.sendDynamicSdrWhite(this.lastMeasuredSdrNits);
+        } else {
+          this.scheduleBrightnessResample(0);
+        }
         if (this.ds5TouchpadEnabled) {
           const supported = this.isControllerTouchpadSupported();
           console.info(`DS5 屏幕触控板: 主机 controller-touch=${supported}`);
@@ -1440,7 +1462,7 @@ export class StreamingSession implements Ds5TouchpadInputSink {
       connectionTerminated: (errorCode: number): void => {
         console.info(`连接已终止: ${errorCode}, userInitiated=${this.userInitiatedStop}`);
         this.isRunning = false;
-        this.unregisterBrightnessProbe();
+        this.stopBrightnessUpdates();
         this.hostFeatureFlags = 0;
         this.hostFeatureFlagsKnown = false;
         NetworkBoostService.getInstance().stop();
@@ -2054,21 +2076,91 @@ export class StreamingSession implements Ds5TouchpadInputSink {
   // 内部 — 清理
   // ---------------------------------------------------------------------------
 
-  /**
-   * sdrNits 动态性探针:记录 brightnessInfoChange 事件三元组,用于判定
-   * 亮度滑条调的是白位还是整体缩放(A/B/C 模型)。纯日志,不影响上报。
-   */
+  /** 注册亮度变化失效信号；不直接信任事件携带的瞬时值。 */
   private registerBrightnessProbe(): void {
     try {
       this.brightnessProbeHandler = (displayId: number, info: display.BrightnessInfo): void => {
         console.info(`[BrightnessProbe] display=${displayId}, sdrNits=${info.sdrNits}, ` +
           `currentHeadroom=${info.currentHeadroom}, maxHeadroom=${info.maxHeadroom}`);
+        if (displayId === 0) {
+          this.scheduleBrightnessResample(SDR_WHITE_DEBOUNCE_MS);
+        }
       };
       display.on('brightnessInfoChange', this.brightnessProbeHandler);
     } catch (err) {
       this.brightnessProbeHandler = null;
       console.warn(`[BrightnessProbe] brightnessInfoChange 不可用: ${err}`);
     }
+  }
+
+  private isDynamicSdrWhiteSupported(): boolean {
+    return this.isRunning && this.config?.hdr === true && this.config.hdrMode === HdrMode.HLG &&
+      (this.hostFeatureFlags & LI_FF_DYNAMIC_SDR_WHITE) !== 0;
+  }
+
+  private sendDynamicSdrWhite(nits: number): void {
+    if (!this.isDynamicSdrWhiteSupported() || !Number.isFinite(nits) || nits <= 0) return;
+    if (this.lastSentSdrWhiteNits > 0) {
+      const threshold = Math.max(SDR_WHITE_MIN_DELTA_NITS,
+        this.lastSentSdrWhiteNits * SDR_WHITE_MIN_DELTA_RATIO);
+      if (Math.abs(nits - this.lastSentSdrWhiteNits) < threshold) return;
+    }
+
+    const result = this.nativeModule.sendClientSdrWhiteNits(nits);
+    if (result === 0) {
+      this.lastSentSdrWhiteNits = nits;
+      this.lastMeasuredSdrNits = nits;
+      console.info(`[Brightness] 动态 SDR white 已更新: ${nits} nits`);
+    } else {
+      console.warn(`[Brightness] 动态 SDR white 发送失败: nits=${nits}, error=${result}`);
+    }
+  }
+
+  private scheduleBrightnessResample(delayMs: number): void {
+    if (!this.isDynamicSdrWhiteSupported()) return;
+    if (this.brightnessSampleInFlight) {
+      this.brightnessSamplePending = true;
+      return;
+    }
+    if (this.brightnessUpdateTimer >= 0) {
+      clearTimeout(this.brightnessUpdateTimer);
+    }
+    const generation = this.brightnessUpdateGeneration;
+    this.brightnessUpdateTimer = setTimeout(() => {
+      this.brightnessUpdateTimer = -1;
+      this.resampleAndSendSdrWhite(generation);
+    }, delayMs);
+  }
+
+  private async resampleAndSendSdrWhite(generation: number): Promise<void> {
+    if (generation !== this.brightnessUpdateGeneration || !this.isDynamicSdrWhiteSupported()) return;
+    this.brightnessSampleInFlight = true;
+    try {
+      const measured = await sampleDisplayBrightness(0);
+      if (generation === this.brightnessUpdateGeneration && measured && this.isDynamicSdrWhiteSupported()) {
+        this.sendDynamicSdrWhite(measured.sdrNits);
+      }
+    } catch (err) {
+      console.warn(`[Brightness] 动态重采样失败: ${err}`);
+    } finally {
+      if (generation !== this.brightnessUpdateGeneration) return;
+      this.brightnessSampleInFlight = false;
+      if (this.brightnessSamplePending) {
+        this.brightnessSamplePending = false;
+        this.scheduleBrightnessResample(SDR_WHITE_DEBOUNCE_MS);
+      }
+    }
+  }
+
+  private stopBrightnessUpdates(): void {
+    this.brightnessUpdateGeneration++;
+    if (this.brightnessUpdateTimer >= 0) {
+      clearTimeout(this.brightnessUpdateTimer);
+      this.brightnessUpdateTimer = -1;
+    }
+    this.brightnessSamplePending = false;
+    this.brightnessSampleInFlight = false;
+    this.unregisterBrightnessProbe();
   }
 
   private unregisterBrightnessProbe(): void {
@@ -2083,7 +2175,7 @@ export class StreamingSession implements Ds5TouchpadInputSink {
   private async cleanup(): Promise<void> {
     console.info('清理串流资源');
     this.isRunning = false;
-    this.unregisterBrightnessProbe();
+    this.stopBrightnessUpdates();
     // LiStopConnection() suppresses connectionTerminated for an explicit stop,
     // so clear controller output here as well as in the termination callback.
     GamepadManager.getInstance().stopAllVibration();

--- a/entry/src/main/ets/service/streaming/StreamingSession.ets
+++ b/entry/src/main/ets/service/streaming/StreamingSession.ets
@@ -33,6 +33,7 @@ import { NetworkBoostService } from '../network/NetworkBoostService';
 import { BandwidthProbeService } from '../network/BandwidthProbeService';
 import { Ds5TouchpadInputSink } from '../input/Ds5TouchpadGestureHandler';
 import { MoonBridge as ClipboardNativeBridge } from '../jni/ClipboardBridge';
+import { sampleDisplayBrightness, MeasuredBrightnessProfile } from './BrightnessSampler';
 import {
   MoonBridge,
   CONTROLLER_TYPE_UNKNOWN,
@@ -82,6 +83,8 @@ export interface StreamStats {
   codecOutputFrames: number;
   droppedFrames: number;
   hdrVivid: boolean;       // 码流中检测到 CUVA HDR Vivid 动态元数据
+  hostMaxLuminance: number;    // 宿主上报的虚拟屏峰值亮度 (nits, 0=未知)
+  hostMaxFullFrame: number;    // 宿主上报的满帧亮度 (nits, 0=未知)
   framesLost: number;
   totalFrames: number;
   globalAvgDecodeLatency: number;  // 全局平均解码延迟 ms
@@ -133,6 +136,15 @@ export interface DecoderCapabilities {
 
 /** HDR 状态变化回调 */
 export type HdrStateCallback = (isHdr: boolean) => void;
+
+/** 宿主通过 SS_HDR_METADATA 下发的 HDR 显示/内容元数据(单位 nits,minDisplayLuminance 为 1/10000 nit) */
+export interface HostHdrMetadata {
+  maxDisplayLuminance: number;
+  minDisplayLuminance: number;
+  maxContentLightLevel: number;
+  maxFrameAverageLightLevel: number;
+  maxFullFrameLuminance: number;
+}
 
 /** 编解码器状态变化回调 */
 export type CodecStateCallback = (codec: string) => void;
@@ -230,7 +242,7 @@ interface StreamCallbacks {
   connectionStarted?: () => void;
   connectionTerminated?: (errorCode: number) => void;
   connectionStatusUpdate?: (connectionStatus: number) => void;
-  setHdrMode?: (enabled: boolean) => void;
+  setHdrMode?: (enabled: boolean, metadata?: HostHdrMetadata) => void;
   rumble?: (controllerNumber: number, lowFreqMotor: number, highFreqMotor: number) => void;
   ds5HapticsIrV2?: (frame: Ds5HapticsIrV2Frame) => void;
   setAdaptiveTriggers?: (frame: AdaptiveTriggersFrame) => void;
@@ -362,26 +374,56 @@ export class StreamingSession implements Ds5TouchpadInputSink {
   }
 
   /**
-   * 获取用于服务端 HDR tone mapping 的静态显示能力 profile。
-   * 当前屏幕亮度仅用于诊断，不参与 capability 上报。
+   * 解析上报给 Sunshine 的 HDR 亮度范围。
+   * 优先级:手动滑条覆盖(仅峰值/满帧)> 窗口采样实测 > 静态 profile。
+   * sdrNits 与滑条正交:只要实测有效就上报。
    * @returns [minBrightness, maxBrightness, maxAverageBrightness] (nits)
    */
-  private static getHdrCapabilityProfile(): number[] {
-    const minBrightness = DEFAULT_HDR_MIN_BRIGHTNESS_NITS;
-    const maxBrightness = DEFAULT_HDR_MAX_BRIGHTNESS_NITS;
-    const maxAverageBrightness = DEFAULT_HDR_MAX_FULL_FRAME_BRIGHTNESS_NITS;
+  private async resolveBrightnessRange(effectiveHdr: boolean): Promise<number[]> {
+    const staticProfile = [
+      DEFAULT_HDR_MIN_BRIGHTNESS_NITS,
+      DEFAULT_HDR_MAX_BRIGHTNESS_NITS,
+      DEFAULT_HDR_MAX_FULL_FRAME_BRIGHTNESS_NITS
+    ];
 
-    try {
-      const brightnessInfo = display.getBrightnessInfo(0);
-      console.info(`[Brightness] sdrNits=${brightnessInfo.sdrNits}, ` +
-        `currentHeadroom=${brightnessInfo.currentHeadroom}, maxHeadroom=${brightnessInfo.maxHeadroom}`);
-    } catch (err) {
-      console.warn(`[Brightness] getBrightnessInfo 不可用，使用默认值: ${err}`);
+    if (!effectiveHdr) {
+      console.info('[Brightness] 非 HDR 会话,使用静态 profile: ' +
+        `min=${staticProfile[0]}, max=${staticProfile[1]}, avg=${staticProfile[2]} nits`);
+      return staticProfile;
     }
 
-    console.info(`[Brightness] using static HDR capability profile: ` +
-      `min=${minBrightness}, max=${maxBrightness}, avg=${maxAverageBrightness} nits`);
-    return [minBrightness, maxBrightness, maxAverageBrightness];
+    // HDR 会话统一等待采样(在 start() 已提前发起,与网络请求重叠;此处兜底 2s)
+    this.lastMeasuredSdrNits = 0;
+    let measured: MeasuredBrightnessProfile | null = null;
+    if (this.brightnessSamplePromise) {
+      measured = await Promise.race([
+        this.brightnessSamplePromise,
+        new Promise<MeasuredBrightnessProfile | null>(resolve => setTimeout(() => resolve(null), 2000))
+      ]);
+      if (measured) {
+        this.lastMeasuredSdrNits = measured.sdrNits;
+      }
+    } else {
+      console.warn('[Brightness] 无采样结果');
+    }
+
+    if (this.config?.hdrBrightnessOverride) {
+      const overridden = StreamingSession.applyBrightnessOverride(staticProfile, this.config.hdrPeakBrightnessNits);
+      console.info('[Brightness] HDR 手动覆盖: min=' + overridden[0].toString() +
+        ', max=' + overridden[1].toString() +
+        ', avg=' + overridden[2].toString() +
+        ', sdr=' + this.lastMeasuredSdrNits.toString() + ' nits');
+      return overridden;
+    }
+
+    if (measured) {
+      console.info('[Brightness] 实测 profile: sdr=' + measured.sdrNits.toString() +
+        ', max=' + measured.maxBrightness.toString() +
+        ', avg=' + measured.maxAverageBrightness.toString() + ' nits');
+      return [DEFAULT_HDR_MIN_BRIGHTNESS_NITS, measured.maxBrightness, measured.maxAverageBrightness];
+    }
+    console.warn('[Brightness] 采样超时或未通过校验,回退静态 profile');
+    return staticProfile;
   }
 
   private static applyBrightnessOverride(range: number[], peakBrightnessNits: number): number[] {
@@ -419,6 +461,12 @@ export class StreamingSession implements Ds5TouchpadInputSink {
   private riKeyId: number = 0;
   private displayGuid: string = '';
   private useVdd: boolean = false;
+  /** 启动时提前发起的亮度采样(与网络等待重叠),永不 reject */
+  private brightnessSamplePromise: Promise<MeasuredBrightnessProfile | null> | null = null;
+  /** 实测 SDR 参考白 (nits,0=未测量/不可靠),用于 sdrBrightness 上报 */
+  private lastMeasuredSdrNits: number = 0;
+  /** sdrNits 动态性探针(brightnessInfoChange 日志),仅诊断不参与上报 */
+  private brightnessProbeHandler: ((displayId: number, info: display.BrightnessInfo) => void) | null = null;
 
   // 服务器信息
   private serverAppVersion: string = '';
@@ -476,6 +524,7 @@ export class StreamingSession implements Ds5TouchpadInputSink {
     hostLatency: 0, networkLatency: 0, packetLoss: 0,
     decodedFrames: 0, codecOutputFrames: 0, droppedFrames: 0,
     hdrVivid: false,
+    hostMaxLuminance: 0, hostMaxFullFrame: 0,
     framesLost: 0, totalFrames: 0,
     globalAvgDecodeLatency: 0, globalAvgHostLatency: 0, globalAvgFps: 0,
     droppedByL1: 0, droppedByL2: 0, droppedByL3: 0, droppedByL4: 0, droppedByL5: 0,
@@ -490,6 +539,8 @@ export class StreamingSession implements Ds5TouchpadInputSink {
     presentationLeadAtLeast8Ms: 0, presentationPendingHighWater: 0
   };
   private lastValidStats: StreamStats | null = null;
+  /** 宿主最近一次通过 SS_HDR_METADATA 下发的元数据(null=未收到) */
+  private lastHostHdrMetadata: HostHdrMetadata | null = null;
 
   // 滑动窗口丢包率统计（对齐 Android: lastTwo = lastWindow + activeWindow）
   private prevSnapshotLost: number = 0;    // 上一窗口起始时的累计 framesLost
@@ -586,6 +637,11 @@ export class StreamingSession implements Ds5TouchpadInputSink {
     this.useVdd = useVdd || false;
     this.abilityContext = context;
     this.userInitiatedStop = false;
+    this.lastMeasuredSdrNits = 0;
+    this.lastHostHdrMetadata = null;
+    // 亮度采样提前发起,与后续网络请求重叠执行,不增加启动延迟
+    this.brightnessSamplePromise = sampleDisplayBrightness(0).catch(() => null);
+    this.registerBrightnessProbe();
 
     console.info(`开始串流: computer=${computerId}, app=${appId}`);
     console.info(`配置: ${config.width}x${config.height}@${config.fps}fps, ${config.bitrate}kbps, ${config.codec}`);
@@ -1041,6 +1097,8 @@ export class StreamingSession implements Ds5TouchpadInputSink {
       this.stats.codecOutputFrames = vs.codecOutputFrames || 0;
       this.stats.droppedFrames = vs.framesDropped;
       this.stats.hdrVivid = vs.hdrVivid || false;
+      this.stats.hostMaxLuminance = this.lastHostHdrMetadata ? this.lastHostHdrMetadata.maxDisplayLuminance : 0;
+      this.stats.hostMaxFullFrame = this.lastHostHdrMetadata ? this.lastHostHdrMetadata.maxFullFrameLuminance : 0;
       this.stats.fps = vs.fps || 0;
       this.stats.codecOutputFps = vs.codecOutputFps || 0;
       this.stats.renderedFps = vs.renderedFps || 0;
@@ -1129,6 +1187,8 @@ export class StreamingSession implements Ds5TouchpadInputSink {
       codecOutputFrames: this.stats.codecOutputFrames,
       droppedFrames: this.stats.droppedFrames,
       hdrVivid: this.stats.hdrVivid,
+      hostMaxLuminance: this.stats.hostMaxLuminance,
+      hostMaxFullFrame: this.stats.hostMaxFullFrame,
       framesLost: this.stats.framesLost,
       totalFrames: this.stats.totalFrames,
       globalAvgDecodeLatency: this.stats.globalAvgDecodeLatency,
@@ -1395,8 +1455,10 @@ export class StreamingSession implements Ds5TouchpadInputSink {
       clipboardData: (kind: number, token: number, payload: Uint8Array): void => {
         ClipboardNativeBridge.onClipboardDataReceived(kind, token, payload);
       },
-      setHdrMode: (enabled: boolean): void => {
-        console.info(`HDR 模式变化通知: ${enabled}`);
+      setHdrMode: (enabled: boolean, metadata?: HostHdrMetadata): void => {
+        console.info(`HDR 模式变化通知: ${enabled}` +
+          (metadata ? `, hostMaxLum=${metadata.maxDisplayLuminance}, hostFullFrame=${metadata.maxFullFrameLuminance}` : ''));
+        this.lastHostHdrMetadata = metadata ?? null;
         if (this.config && this.config.hdr !== enabled) {
           this.config.hdr = enabled;
         }
@@ -1496,13 +1558,7 @@ export class StreamingSession implements Ds5TouchpadInputSink {
       this.config.hdr = effectiveHdr;
     }
 
-    let brightnessRange = StreamingSession.getHdrCapabilityProfile();
-    if (effectiveHdr && this.config.hdrBrightnessOverride) {
-      brightnessRange = StreamingSession.applyBrightnessOverride(brightnessRange, this.config.hdrPeakBrightnessNits);
-      console.info('[Brightness] HDR override: min=' + brightnessRange[0].toString() +
-        ', max=' + brightnessRange[1].toString() +
-        ', avg=' + brightnessRange[2].toString() + ' nits');
-    }
+    const brightnessRange = await this.resolveBrightnessRange(effectiveHdr);
 
     const launchConfig: LaunchConfig = {
       appId: this.appId,
@@ -1521,6 +1577,7 @@ export class StreamingSession implements Ds5TouchpadInputSink {
       minBrightness: brightnessRange[0],
       maxBrightness: brightnessRange[1],
       maxAverageBrightness: brightnessRange[2],
+      sdrBrightness: this.lastMeasuredSdrNits > 0 ? this.lastMeasuredSdrNits : undefined,
       screenCombinationMode: this.config.screenCombinationMode,
     };
 
@@ -1974,9 +2031,36 @@ export class StreamingSession implements Ds5TouchpadInputSink {
   // 内部 — 清理
   // ---------------------------------------------------------------------------
 
+  /**
+   * sdrNits 动态性探针:记录 brightnessInfoChange 事件三元组,用于判定
+   * 亮度滑条调的是白位还是整体缩放(A/B/C 模型)。纯日志,不影响上报。
+   */
+  private registerBrightnessProbe(): void {
+    try {
+      this.brightnessProbeHandler = (displayId: number, info: display.BrightnessInfo): void => {
+        console.info(`[BrightnessProbe] display=${displayId}, sdrNits=${info.sdrNits}, ` +
+          `currentHeadroom=${info.currentHeadroom}, maxHeadroom=${info.maxHeadroom}`);
+      };
+      display.on('brightnessInfoChange', this.brightnessProbeHandler);
+    } catch (err) {
+      this.brightnessProbeHandler = null;
+      console.warn(`[BrightnessProbe] brightnessInfoChange 不可用: ${err}`);
+    }
+  }
+
+  private unregisterBrightnessProbe(): void {
+    if (this.brightnessProbeHandler) {
+      try {
+        display.off('brightnessInfoChange', this.brightnessProbeHandler);
+      } catch (_) { /* ignore */ }
+      this.brightnessProbeHandler = null;
+    }
+  }
+
   private async cleanup(): Promise<void> {
     console.info('清理串流资源');
     this.isRunning = false;
+    this.unregisterBrightnessProbe();
     // LiStopConnection() suppresses connectionTerminated for an explicit stop,
     // so clear controller output here as well as in the termination callback.
     GamepadManager.getInstance().stopAllVibration();

--- a/entry/src/main/ets/service/streaming/StreamingSession.ets
+++ b/entry/src/main/ets/service/streaming/StreamingSession.ets
@@ -353,6 +353,8 @@ const STANDARD_BUTTON_FLAGS =
 
 /** 亮度事件防抖和 SDR white 发送迟滞，避免拖动亮度条时刷控制包。 */
 const SDR_WHITE_DEBOUNCE_MS = 500;
+const SDR_WHITE_MIN_NITS = 50;
+const SDR_WHITE_MAX_NITS = 1000;
 const SDR_WHITE_MIN_DELTA_NITS = 10;
 const SDR_WHITE_MIN_DELTA_RATIO = 0.05;
 
@@ -2099,7 +2101,8 @@ export class StreamingSession implements Ds5TouchpadInputSink {
   }
 
   private sendDynamicSdrWhite(nits: number): void {
-    if (!this.isDynamicSdrWhiteSupported() || !Number.isFinite(nits) || nits <= 0) return;
+    if (!this.isDynamicSdrWhiteSupported() || !Number.isFinite(nits) ||
+      nits < SDR_WHITE_MIN_NITS || nits > SDR_WHITE_MAX_NITS) return;
     if (this.lastSentSdrWhiteNits > 0) {
       const threshold = Math.max(SDR_WHITE_MIN_DELTA_NITS,
         this.lastSentSdrWhiteNits * SDR_WHITE_MIN_DELTA_RATIO);

--- a/entry/src/main/ets/service/streaming/StreamingSession.ets
+++ b/entry/src/main/ets/service/streaming/StreamingSession.ets
@@ -455,7 +455,6 @@ export class StreamingSession implements Ds5TouchpadInputSink {
   private isStartingConnection: boolean = false;
   /** 回调代次:native 各回调走独立 TSFN,无跨队列顺序;init() 重注册时递增,用于丢弃旧代次迟到回调 */
   private static callbackGeneration: number = 0;
-  private registeredGeneration: number = 0;
   private connectionStartPromise: Promise<number> | null = null;
   private lastFailedStage: number = 0;
   private computer: ComputerInfo | null = null;
@@ -1374,7 +1373,10 @@ export class StreamingSession implements Ds5TouchpadInputSink {
 
   private async initializeNative(): Promise<void> {
     console.info('初始化 Native 模块');
-    this.registeredGeneration = ++StreamingSession.callbackGeneration;
+    // Capture the registration generation in each callback closure. Reading the
+    // mutable member here would let an old closure observe the next session's
+    // generation and accept a delayed HDR notification.
+    const generation = ++StreamingSession.callbackGeneration;
 
     const callbacks: StreamCallbacks = {
       drSetup: (videoFormat: number, width: number, height: number, redrawRate: number): void => {
@@ -1468,7 +1470,7 @@ export class StreamingSession implements Ds5TouchpadInputSink {
         maxFullFrameLuminance: number): void => {
         // setHdrMode 与 connectionTerminated 分属不同 TSFN,无跨队列顺序保证:
         // 丢弃旧代次注册或已终止会话的迟到回调(启动窗口靠 isStartingConnection 放行)
-        if (this.registeredGeneration !== StreamingSession.callbackGeneration) return;
+        if (generation !== StreamingSession.callbackGeneration) return;
         if (!this.isRunning && !this.isStartingConnection) return;
         const metadata: HostHdrMetadata | null = hasMetadata ? {
           maxDisplayLuminance,

--- a/entry/src/main/ets/service/streaming/StreamingSession.ets
+++ b/entry/src/main/ets/service/streaming/StreamingSession.ets
@@ -242,7 +242,10 @@ interface StreamCallbacks {
   connectionStarted?: () => void;
   connectionTerminated?: (errorCode: number) => void;
   connectionStatusUpdate?: (connectionStatus: number) => void;
-  setHdrMode?: (enabled: boolean, metadata?: HostHdrMetadata) => void;
+  /** native 侧按位置传 7 参:enabled + hasMetadata + 五个亮度值(见 callbacks.cpp CallJs_SetHdrMode) */
+  setHdrMode?: (enabled: boolean, hasMetadata: boolean, maxDisplayLuminance: number,
+    minDisplayLuminance: number, maxContentLightLevel: number, maxFrameAverageLightLevel: number,
+    maxFullFrameLuminance: number) => void;
   rumble?: (controllerNumber: number, lowFreqMotor: number, highFreqMotor: number) => void;
   ds5HapticsIrV2?: (frame: Ds5HapticsIrV2Frame) => void;
   setAdaptiveTriggers?: (frame: AdaptiveTriggersFrame) => void;
@@ -1431,6 +1434,7 @@ export class StreamingSession implements Ds5TouchpadInputSink {
       connectionTerminated: (errorCode: number): void => {
         console.info(`连接已终止: ${errorCode}, userInitiated=${this.userInitiatedStop}`);
         this.isRunning = false;
+        this.unregisterBrightnessProbe();
         this.hostFeatureFlags = 0;
         this.hostFeatureFlagsKnown = false;
         NetworkBoostService.getInstance().stop();
@@ -1455,10 +1459,19 @@ export class StreamingSession implements Ds5TouchpadInputSink {
       clipboardData: (kind: number, token: number, payload: Uint8Array): void => {
         ClipboardNativeBridge.onClipboardDataReceived(kind, token, payload);
       },
-      setHdrMode: (enabled: boolean, metadata?: HostHdrMetadata): void => {
+      setHdrMode: (enabled: boolean, hasMetadata: boolean, maxDisplayLuminance: number,
+        minDisplayLuminance: number, maxContentLightLevel: number, maxFrameAverageLightLevel: number,
+        maxFullFrameLuminance: number): void => {
+        const metadata: HostHdrMetadata | null = hasMetadata ? {
+          maxDisplayLuminance,
+          minDisplayLuminance,
+          maxContentLightLevel,
+          maxFrameAverageLightLevel,
+          maxFullFrameLuminance
+        } : null;
         console.info(`HDR 模式变化通知: ${enabled}` +
           (metadata ? `, hostMaxLum=${metadata.maxDisplayLuminance}, hostFullFrame=${metadata.maxFullFrameLuminance}` : ''));
-        this.lastHostHdrMetadata = metadata ?? null;
+        this.lastHostHdrMetadata = metadata;
         if (this.config && this.config.hdr !== enabled) {
           this.config.hdr = enabled;
         }

--- a/entry/src/main/resources/rawfile/CHANGELOG.md
+++ b/entry/src/main/resources/rawfile/CHANGELOG.md
@@ -50,6 +50,34 @@
 - 🔧 clear stale targets on PTS reanchor
 -->
 
+## [1.0.0.808] - 2026-08-18
+HDR 亮度上报稳定化与 SDR 白位闭环
+
+### 新增
+- **亮度探针**：串流期间监听 `brightnessInfoChange` 事件并打日志（`[BrightnessProbe]` 三元组），用于分析亮度滑条与 sdrNits/headroom 的联动关系，纯日志不影响上报
+
+### 优化
+- **上报值量化**：峰值亮度吸附标准档（400–4000 九档），满帧亮度归整 50 倍数，避免逐会话微变触发宿主 VDD 重建（配合宿主侧容差比较）
+- **手动滑条携带 sdrBrightness**：手动校准只覆盖峰值/满帧，实测 SDR 参考白照常上报
+
+### 修复
+- **SDR 白位脱钩**：宿主（foundation-sunshine）消费 `sdrBrightness`，在 HLG 转换中对 SDR 波段按 `phoneSdr/windowsSdr` 增益重锚，游戏 UI/中灰落到手机自己的 SDR 白位（HDR Vivid 过曝修复收尾）
+
+## [1.0.0.807] - 2026-08-17
+HDR 亮度真实上报,修复 HDR Vivid 过曝
+
+### 新增
+- **亮度实测上报**：串流启动时窗口采样 `getBrightnessInfo`（5 次 × 250ms，与网络请求重叠不增加延迟），按中位数/75 分位聚合真实 sdrNits、峰值与满帧亮度并上报，测量不可靠时回退静态 profile；手动滑条覆盖保留为最高优先级
+- **sdrBrightness 参数**：launch 请求新增 SDR 参考白上报（仅实测有效时携带），宿主契约见 docs/HDR_BRIGHTNESS_REPORTING.md
+- **浮层亮度诊断**：性能浮层 DECODER 行显示手机实测 SDR/峰值与宿主上报目标的对比（`屏sdr/peak→hostMaxLum nit`）
+
+### 优化
+- 复活亮度校验门（sdrNits ≥ 50、样本波动比 ≤ 1.5、峰值 ≥ 100 且 ≥ sdrNits），拒绝瞬态低报
+- SS_HDR_METADATA 宿主元数据透传至 ArkTS 层并计入 StreamStats（hostMaxLuminance/hostMaxFullFrame）
+
+### 修复
+- **HDR Vivid 过曝**：以实测亮度与真实 SDR 参考白替代静态虚构 1000/1000/1000，宿主虚拟屏与 CUVA 动态元数据不再建立在虚构面板上
+
 ## [1.0.0.806] - 2026-08-17
 
 ### 新增

--- a/nativelib/src/main/cpp/callbacks.cpp
+++ b/nativelib/src/main/cpp/callbacks.cpp
@@ -151,7 +151,7 @@ static bool ConvertSunshineHdrMetadata(const SS_HDR_METADATA* source, Smpte2086M
 // 通用参数传递结构
 typedef struct {
     int intParams[4];
-    double doubleParams[2];
+    double doubleParams[6];
     void* ptrParam;
     int ptrSize;
 } CallbackData;
@@ -290,12 +290,18 @@ static void CallJs_ConnectionStatusUpdate(napi_env env, napi_value js_callback, 
 static void CallJs_SetHdrMode(napi_env env, napi_value js_callback, void* context, void* data) {
     CallbackData* cbData = (CallbackData*)data;
     if (env != nullptr && js_callback != nullptr) {
-        napi_value argv[1];
+        // argv: [enabled, hasMetadata, maxDisplayLuminance, minDisplayLuminance,
+        //        maxContentLightLevel, maxFrameAverageLightLevel, maxFullFrameLuminance]
+        napi_value argv[7];
         napi_get_boolean(env, cbData->intParams[0] != 0, &argv[0]);
-        
+        napi_get_boolean(env, cbData->intParams[1] != 0, &argv[1]);
+        for (int i = 0; i < 5; i++) {
+            napi_create_double(env, cbData->doubleParams[i], &argv[2 + i]);
+        }
+
         napi_value undefined;
         napi_get_undefined(env, &undefined);
-        napi_call_function(env, undefined, js_callback, 1, argv, nullptr);
+        napi_call_function(env, undefined, js_callback, 7, argv, nullptr);
     }
     delete cbData;
 }
@@ -1596,10 +1602,20 @@ void BridgeClSetHdrMode(bool enabled, void* hdrMetadata) {
         VideoDecoderInstance::SetHdrStaticMetadata(nullptr);
     }
     
-    // 通知 ArkTS 层 HDR 状态变化
+    // 通知 ArkTS 层 HDR 状态变化;透传 SS_HDR_METADATA 原始亮度字段
+    // (不经 Smpte2086 转换,那会丢 minLuminance 缩放语义与 full-frame 字段)
     if (g_connCallbacks.tsfn_setHdrMode) {
         CallbackData* data = new CallbackData();
         data->intParams[0] = enabled;
+        if (enabled && hdrMetadata != nullptr) {
+            const SS_HDR_METADATA* meta = static_cast<const SS_HDR_METADATA*>(hdrMetadata);
+            data->intParams[1] = 1;
+            data->doubleParams[0] = static_cast<double>(meta->maxDisplayLuminance);
+            data->doubleParams[1] = static_cast<double>(meta->minDisplayLuminance);
+            data->doubleParams[2] = static_cast<double>(meta->maxContentLightLevel);
+            data->doubleParams[3] = static_cast<double>(meta->maxFrameAverageLightLevel);
+            data->doubleParams[4] = static_cast<double>(meta->maxFullFrameLuminance);
+        }
         napi_status st = napi_call_threadsafe_function(g_connCallbacks.tsfn_setHdrMode, data, napi_tsfn_nonblocking);
         if (st != napi_ok) delete data;
     }

--- a/nativelib/src/main/cpp/moonlight_bridge.cpp
+++ b/nativelib/src/main/cpp/moonlight_bridge.cpp
@@ -1493,6 +1493,22 @@ napi_value MoonBridge_GetHostFeatureFlags(napi_env env, napi_callback_info info)
     return result;
 }
 
+napi_value MoonBridge_SendClientSdrWhiteNits(napi_env env, napi_callback_info info) {
+    size_t argc = 1;
+    napi_value args[1];
+    napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
+
+    double nits = 0.0;
+    int ret = LI_DYNAMIC_SDR_WHITE_ERR_INVALID;
+    if (argc == 1 && napi_get_value_double(env, args[0], &nits) == napi_ok) {
+        ret = LiSendClientSdrWhiteNits(static_cast<float>(nits));
+    }
+
+    napi_value result;
+    napi_create_int32(env, ret, &result);
+    return result;
+}
+
 napi_value MoonBridge_GetLaunchUrlQueryParameters(napi_env env, napi_callback_info info) {
     const char* params = LiGetLaunchUrlQueryParameters();
     

--- a/nativelib/src/main/cpp/moonlight_bridge.cpp
+++ b/nativelib/src/main/cpp/moonlight_bridge.cpp
@@ -39,6 +39,7 @@ int LiSendClipboardData(const void* payload, int length);
 #include "mic_capturer.h"
 #include <hilog/log.h>
 #include <algorithm>
+#include <cmath>
 #include <cstring>
 #include <arpa/inet.h>
 #include <native_window/external_window.h>
@@ -1500,7 +1501,8 @@ napi_value MoonBridge_SendClientSdrWhiteNits(napi_env env, napi_callback_info in
 
     double nits = 0.0;
     int ret = LI_DYNAMIC_SDR_WHITE_ERR_INVALID;
-    if (argc == 1 && napi_get_value_double(env, args[0], &nits) == napi_ok) {
+    if (argc == 1 && napi_get_value_double(env, args[0], &nits) == napi_ok &&
+        std::isfinite(nits) && nits >= 50.0 && nits <= 1000.0) {
         ret = LiSendClientSdrWhiteNits(static_cast<float>(nits));
     }
 

--- a/nativelib/src/main/cpp/moonlight_bridge.h
+++ b/nativelib/src/main/cpp/moonlight_bridge.h
@@ -153,6 +153,7 @@ napi_value MoonBridge_GetPendingAudioDuration(napi_env env, napi_callback_info i
 napi_value MoonBridge_GetPendingVideoFrames(napi_env env, napi_callback_info info);
 napi_value MoonBridge_GetEstimatedRttInfo(napi_env env, napi_callback_info info);
 napi_value MoonBridge_GetHostFeatureFlags(napi_env env, napi_callback_info info);
+napi_value MoonBridge_SendClientSdrWhiteNits(napi_env env, napi_callback_info info);
 napi_value MoonBridge_GetLaunchUrlQueryParameters(napi_env env, napi_callback_info info);
 
 // =============================================================================

--- a/nativelib/src/main/cpp/napi_init.cpp
+++ b/nativelib/src/main/cpp/napi_init.cpp
@@ -108,6 +108,7 @@ static napi_value Init(napi_env env, napi_value exports) {
         { "getPendingVideoFrames", nullptr, MoonBridge_GetPendingVideoFrames, nullptr, nullptr, nullptr, napi_default, nullptr },
         { "getEstimatedRttInfo", nullptr, MoonBridge_GetEstimatedRttInfo, nullptr, nullptr, nullptr, napi_default, nullptr },
         { "getHostFeatureFlags", nullptr, MoonBridge_GetHostFeatureFlags, nullptr, nullptr, nullptr, napi_default, nullptr },
+        { "sendClientSdrWhiteNits", nullptr, MoonBridge_SendClientSdrWhiteNits, nullptr, nullptr, nullptr, napi_default, nullptr },
         { "getLaunchUrlQueryParameters", nullptr, MoonBridge_GetLaunchUrlQueryParameters, nullptr, nullptr, nullptr, napi_default, nullptr },
         
         // 工具函数


### PR DESCRIPTION
## Summary
- **实测亮度上报取代静态 profile**:`BrightnessSampler` 在启动窗口采样 `getBrightnessInfo`(5×250ms,与网络请求重叠零延迟),中位数 sdrNits + 分位数聚合,复活 a13fcce 校验门并加方差门(波动比 ≤1.5),测量不可靠回退静态 1000/1000/1000
- **新增 `sdrBrightness` launch 参数**:上报实测 SDR 参考白,宿主据此把 SDR 内容锚到手机自己的白位(HDR Vivid 过曝的主因修复);手动滑条只覆盖峰值/满帧,sdrNits 照常上报
- **上报值量化**:峰值吸附标准档(400–4000 九档)、满帧 50 倍数——配合宿主容差比较,避免逐会话微变触发 VDD 重建
- **诊断闭环**:SS_HDR_METADATA 亮度字段经 native 透传至 ArkTS(StreamStats.hostMaxLuminance/hostMaxFullFrame),性能浮层 DECODER 行显示 `屏sdr/peak→hostMaxLum`;新增 `brightnessInfoChange` 探针日志(`[BrightnessProbe]`)收集 sdrNits 动态性数据
- **宿主契约**:docs/HDR_BRIGHTNESS_REPORTING.md;配套宿主改动在 foundation-sunshine 仓库(另提 PR)

## Test plan
- [x] `hvigorw assembleHap` 构建通过(基于 origin/master 最新代码)
- [ ] HDR 串流两次:日志出现 `[Brightness] 实测 profile`,launch query 含 `sdrBrightness=<int>`,两次上报值落同档
- [ ] 手动滑条开启:launch query 仍含 `sdrBrightness`,峰值按滑条
- [ ] 非 HDR 会话:无 sdrBrightness,启动延迟无可感知变化
- [ ] 搭配宿主 PR:浮层 `屏sdr→host` 对齐,游戏 UI 白与手机状态栏白目视接近
- [ ] 旧版 Sunshine/GFE 宿主:串流正常(未知参数被忽略)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - HDR 会话支持自动采样并上报设备 SDR 白位、峰值亮度及满帧亮度。
  - 支持接收和显示 HDR 亮度元数据，提供更丰富的亮度诊断信息。
  - 支持亮度变化监测，采样异常时自动使用兼容的备用值。

- **改进**
  - 更新 HDR 手动校准说明，支持在过曝或偏暗时手动覆盖。
  - 改善 HDR 显示效果及 HLG 转换适配，减少过曝问题。

- **版本**
  - 应用更新至 1.0.0.808。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->