### PR TITLE
fix(haptics): route body and gamepad vibration complementarily

### DIFF
--- a/entry/src/main/ets/service/AudioVibrationService.ets
+++ b/entry/src/main/ets/service/AudioVibrationService.ets
@@ -238,7 +238,11 @@ export class AudioVibrationService {
       case '同时': return true;
       case '自动':
       default:
-        return !GamepadManager.getInstance().hasAnyGamepad();
+        // Automatic audio haptics may use the gamepad path only when this
+        // service can actually drive a USB rumble endpoint. Bluetooth/GCK
+        // input devices do not currently expose an audio haptics backend, so
+        // keep the body fallback enabled for those devices.
+        return !GamepadManager.getInstance().hasUsbControllers();
     }
   }
 
@@ -249,7 +253,7 @@ export class AudioVibrationService {
       case '仅设备': return false;
       case '自动':
       default:
-        return GamepadManager.getInstance().hasAnyGamepad();
+        return GamepadManager.getInstance().hasUsbControllers();
     }
   }
 

--- a/entry/src/main/ets/service/AudioVibrationService.ets
+++ b/entry/src/main/ets/service/AudioVibrationService.ets
@@ -238,7 +238,7 @@ export class AudioVibrationService {
       case '同时': return true;
       case '自动':
       default:
-        return !GamepadManager.getInstance().hasUsbControllers();
+        return !GamepadManager.getInstance().hasAnyGamepad();
     }
   }
 
@@ -249,7 +249,7 @@ export class AudioVibrationService {
       case '仅设备': return false;
       case '自动':
       default:
-        return GamepadManager.getInstance().hasUsbControllers();
+        return GamepadManager.getInstance().hasAnyGamepad();
     }
   }
 

--- a/entry/src/main/ets/service/input/GamepadManager.ets
+++ b/entry/src/main/ets/service/input/GamepadManager.ets
@@ -2653,15 +2653,6 @@ export class GamepadManager implements UsbDriverListener {
     return this.vibrationService.hasUsbControllers();
   }
 
-  /**
-   * Whether any controller input route is currently active. Audio haptics use
-   * this in automatic mode so Bluetooth/Game Controller Kit devices do not
-   * accidentally fall back to the body motor while a controller is present.
-   */
-  hasAnyGamepad(): boolean {
-    return this.hasUsbControllers() || this.hasConnectedGamepadOutsideUsbDriver();
-  }
-
   /** 立即停止所有振动（设备马达 + USB 控制器马达） */
   stopAllVibration(): void {
     this.vibrationService.stopAll();

--- a/entry/src/main/ets/service/input/GamepadManager.ets
+++ b/entry/src/main/ets/service/input/GamepadManager.ets
@@ -2653,6 +2653,15 @@ export class GamepadManager implements UsbDriverListener {
     return this.vibrationService.hasUsbControllers();
   }
 
+  /**
+   * Whether any controller input route is currently active. Audio haptics use
+   * this in automatic mode so Bluetooth/Game Controller Kit devices do not
+   * accidentally fall back to the body motor while a controller is present.
+   */
+  hasAnyGamepad(): boolean {
+    return this.hasUsbControllers() || this.hasConnectedGamepadOutsideUsbDriver();
+  }
+
   /** 立即停止所有振动（设备马达 + USB 控制器马达） */
   stopAllVibration(): void {
     this.vibrationService.stopAll();

--- a/entry/src/main/ets/service/input/GamepadVibrationService.ets
+++ b/entry/src/main/ets/service/input/GamepadVibrationService.ets
@@ -74,6 +74,13 @@ export class GamepadVibrationService {
   private static readonly IR_USB_RENDER_INTERVAL_MS = 10;
   /** Device vibrator APIs are relatively expensive; coalesce authored IR frames. */
   private static readonly DEVICE_RENDER_INTERVAL_MS = 40;
+  /**
+   * The body actuator is a single, broad-band motor. In simultaneous mode it
+   * should add weight rather than mirror the controller's high-frequency
+   * detail. Keep these gains separate from the controller output path.
+   */
+  private static readonly BODY_LOW_BAND_GAIN = 0.72;
+  private static readonly BODY_HIGH_BAND_GAIN = 0.28;
   private static readonly IR_FLAG_DISCONTINUITY = 0x01;
   private static readonly IR_FLAG_STREAM_END = 0x04;
   private static readonly IR_FLAG_SILENT = 0x08;
@@ -1025,7 +1032,11 @@ export class GamepadVibrationService {
     // the single scalar intensity accepted by the device vibrator.
     const lowIntensity = this.mixWithHeadroom(gameLowIntensity, irLowIntensity, 100);
     const highIntensity = this.mixWithHeadroom(gameHighIntensity, irHighIntensity, 100);
-    const gameIntensity = Math.max(lowIntensity, highIntensity);
+    // A controller can express two motor bands independently. The body motor
+    // cannot, so its continuous channel deliberately favors the low band and
+    // attenuates high-frequency detail. This makes "同时" complementary:
+    // the controller carries detail while the body adds physical weight.
+    const gameIntensity = this.getBodyContinuousIntensity(lowIntensity, highIntensity);
     const audioContinuous =
       !irActive && Date.now() <= this.audioDeviceContinuousUntilMs
         ? this.audioDeviceContinuous
@@ -1070,6 +1081,20 @@ export class GamepadVibrationService {
       this.triggerMixedTimeFallback(
         mixedContinuous, mixedTransient, effectiveAudioTransient, renderEpoch);
     }
+  }
+
+  private getBodyContinuousIntensity(lowIntensity: number,
+    highIntensity: number): number {
+    // With no controller destination, the body is the only actuator and must
+    // retain the full authored energy. Attenuation is reserved for simultaneous
+    // mode, where the controller carries the high-frequency detail.
+    if (this.vibrationMode !== '同时') {
+      return Math.max(lowIntensity, highIntensity);
+    }
+    return this.clampIntensity(
+      lowIntensity * GamepadVibrationService.BODY_LOW_BAND_GAIN +
+      highIntensity * GamepadVibrationService.BODY_HIGH_BAND_GAIN
+    );
   }
 
   /**


### PR DESCRIPTION
## 改了啥呀

- 让“同时”模式下机身和手柄互相补位：手柄保留 low/high 细节，机身偏重低频和整体重量感。
- 仅设备和自动无手柄模式保留完整能量，避免唯一执行器丢失高频反馈。
- 音频自动路由统一识别 USB、蓝牙和 Game Controller Kit 手柄。

## 为啥要改

机身通常是单个宽频马达，直接复制手柄双马达输出会放大噪声、丢失空间细节。之前的机身降维策略还会影响“仅设备”场景，弱高频事件可能低于机身触发阈值。现在只在“同时”模式做互补衰减，其他模式保持完整可感知能量，避免这个杂鱼路由状态偷偷吃掉反馈。

## 验证

- `git diff --check`
- 未运行 DevEco/Hvigor 编译：当前环境没有 `hvigor` 或 `deveco` 命令。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 优化自动振动模式：仅在检测到 USB 手柄时使用手柄振动路由，蓝牙及 GCK 手柄不再影响设备振动。

- **改进**
  - 优化“同时”振动模式下的设备马达强度计算，分别处理低频与高频振动，使整体反馈更加平衡。
  - 保留其他振动模式的强度表现，提升不同设备和模式下的振动一致性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->