### PR TITLE
refactor(network): centralize host connection policies

### DIFF
--- a/entry/src/main/ets/service/ComputerManager.ets
+++ b/entry/src/main/ets/service/ComputerManager.ets
@@ -17,6 +17,11 @@ import { PreferencesUtil } from '../utils/PreferencesUtil';
 import { CryptoUtil } from '../utils/CryptoUtil';
 import { WakeOnLan } from './network/WakeOnLan';
 import { isLanAddress, getBestIpv6Address, isIPv4Address, isIPv6Address, isLoopbackIPv4, parseAddressAndPort } from '../utils/NetHelper';
+import {
+  classifyServerIdentity,
+  collectKnownAddresses,
+  ServerIdentityDisposition
+} from './network/ComputerNetworkPolicy';
 import { connection } from '@kit.NetworkKit';
 import { common } from '@kit.AbilityKit';
 import { buffer } from '@kit.ArkTS';
@@ -252,18 +257,9 @@ export class ComputerManager {
       if (this.computers.get(computer.uuid) !== computer) {
         return;
       }
-      if (!serverInfo.uniqueId) {
-        throw new Error('mDNS 验证响应缺少主机 UUID');
-      }
-
-      // 处理 UUID 归一：discovered-* 临时条目获得真实 UUID
-      let target = computer;
-      if (computer.uuid !== serverInfo.uniqueId) {
-        if (computer.uuid.startsWith('discovered-')) {
-          target = this.reconcileUuid(computer, serverInfo.uniqueId);
-        } else {
-          throw new Error(`mDNS 验证返回了其他主机: expected=${computer.uuid}, actual=${serverInfo.uniqueId}`);
-        }
+      const target = this.resolveComputerIdentity(computer, serverInfo.uniqueId, 'mDNS 验证');
+      if (!target) {
+        throw new Error('mDNS 验证返回无效的主机身份');
       }
 
       // 走单一合并入口，保证与轮询/添加路径使用同一套守卫规则
@@ -317,6 +313,27 @@ export class ComputerManager {
       this.offlineCount.set(realUuid, carriedCount);
     }
     return computer;
+  }
+
+  /** 在进入合并路径前统一验证身份，并只为 discovered-* 条目执行 UUID 归一。 */
+  private resolveComputerIdentity(
+    computer: ComputerInfo,
+    serverUniqueId: string | undefined,
+    source: string
+  ): ComputerInfo | null {
+    const disposition = classifyServerIdentity(computer.uuid, serverUniqueId);
+    if (disposition === ServerIdentityDisposition.MATCH) {
+      return computer;
+    }
+    if (disposition === ServerIdentityDisposition.RECONCILE_DISCOVERED) {
+      return this.reconcileUuid(computer, serverUniqueId!);
+    }
+    if (disposition === ServerIdentityDisposition.MISSING) {
+      console.warn(`ComputerManager: ${source}响应缺少主机 UUID`);
+    } else {
+      console.warn(`ComputerManager: ${source}返回其他主机 expected=${computer.uuid}, actual=${serverUniqueId}`);
+    }
+    return null;
   }
 
   /**
@@ -920,7 +937,7 @@ export class ComputerManager {
    * 期间保留原状态，避免短暂网络抖动 / Sunshine 重启时的误报闪烁。
    */
   async pollComputer(computer: ComputerInfo): Promise<boolean> {
-    const addresses = this.collectAddresses(computer);
+    const addresses = collectKnownAddresses(computer);
     if (addresses.length === 0) {
       // 没有任何地址可试，直接认定离线；强制 OFFLINE 后计数不再被读取，清除即可
       computer.state = ComputerState.OFFLINE;
@@ -971,19 +988,6 @@ export class ComputerManager {
   }
 
   /**
-   * 收集电脑的所有可用地址（去重，按优先级排序）
-   */
-  private collectAddresses(computer: ComputerInfo): string[] {
-    const addressSet = new Set<string>();
-    if (computer.manualAddress) addressSet.add(computer.manualAddress);
-    if (computer.address) addressSet.add(computer.address);
-    if (computer.localAddress) addressSet.add(computer.localAddress);
-    if (computer.remoteAddress) addressSet.add(computer.remoteAddress);
-    if (computer.ipv6Address) addressSet.add(computer.ipv6Address);
-    return Array.from(addressSet);
-  }
-
-  /**
    * 尝试通过单个地址轮询
    */
   private async tryPollAddress(address: string, computer: ComputerInfo): Promise<PollResult> {
@@ -991,11 +995,12 @@ export class ComputerManager {
       const nvHttp = NvHttp.fromAddress(address, computer, this.context || undefined);
       const likelyOnline = computer.state === ComputerState.ONLINE && address === computer.address;
       const serverInfo = await nvHttp.getServerInfo(likelyOnline);
-      if (!serverInfo.uniqueId) {
+      const identity = classifyServerIdentity(computer.uuid, serverInfo.uniqueId);
+      if (identity === ServerIdentityDisposition.MISSING) {
         console.warn(`ComputerManager: 轮询 ${address} 的响应缺少主机 UUID`);
         return { address, serverInfo: null };
       }
-      if (computer.uuid !== serverInfo.uniqueId && !computer.uuid.startsWith('discovered-')) {
+      if (identity === ServerIdentityDisposition.MISMATCH) {
         console.warn(`ComputerManager: 轮询 ${address} 返回其他主机 expected=${computer.uuid}, actual=${serverInfo.uniqueId}`);
         return { address, serverInfo: null };
       }
@@ -1085,20 +1090,9 @@ export class ComputerManager {
     if (this.computers.get(computer.uuid) !== computer) {
       return;
     }
-    if (!info.uniqueId) {
-      console.warn(`ComputerManager: 忽略缺少主机 UUID 的轮询结果 (${result.address})`);
+    const target = this.resolveComputerIdentity(computer, info.uniqueId, `轮询 ${result.address}`);
+    if (!target) {
       return;
-    }
-
-    // 处理 UUID 归一：discovered-* 临时条目获得真实 UUID
-    let target = computer;
-    if (computer.uuid !== info.uniqueId) {
-      if (computer.uuid.startsWith('discovered-')) {
-        target = this.reconcileUuid(computer, info.uniqueId);
-      } else {
-        console.warn(`ComputerManager: 忽略其他主机的轮询结果 expected=${computer.uuid}, actual=${info.uniqueId}`);
-        return;
-      }
     }
 
     // 合并服务器信息（所有字段守卫规则集中在 mergeServerInfo）

--- a/entry/src/main/ets/service/ComputerManager.ets
+++ b/entry/src/main/ets/service/ComputerManager.ets
@@ -1324,7 +1324,7 @@ export class ComputerManager {
 
     await WakeOnLan.sendWolToAddresses(
       computer.macAddress,
-      this.collectAddresses(computer),
+      collectKnownAddresses(computer),
       computer.httpPort || NvHttp.DEFAULT_HTTP_PORT
     );
   }

--- a/entry/src/main/ets/service/network/ComputerNetworkPolicy.ets
+++ b/entry/src/main/ets/service/network/ComputerNetworkPolicy.ets
@@ -1,0 +1,67 @@
+/*
+ * Moonlight for HarmonyOS
+ * Copyright (C) 2024-2025 Moonlight/AlkaidLab
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import { AddressHolder } from '../../model/ComputerInfo';
+import { isLoopbackIPv4 } from '../../utils/NetHelper';
+
+export enum ServerIdentityDisposition {
+  MATCH = 0,
+  RECONCILE_DISCOVERED = 1,
+  MISSING = 2,
+  MISMATCH = 3
+}
+
+export interface AddressCollectionOptions {
+  includePreferred?: boolean;
+  excludeLoopbackIPv4?: boolean;
+}
+
+/** 对服务器返回的 UUID 做无副作用分类。 */
+export function classifyServerIdentity(
+  computerUuid: string,
+  serverUniqueId: string | undefined | null
+): ServerIdentityDisposition {
+  if (!serverUniqueId) {
+    return ServerIdentityDisposition.MISSING;
+  }
+  if (computerUuid === serverUniqueId) {
+    return ServerIdentityDisposition.MATCH;
+  }
+  if (computerUuid.startsWith('discovered-')) {
+    return ServerIdentityDisposition.RECONCILE_DISCOVERED;
+  }
+  return ServerIdentityDisposition.MISMATCH;
+}
+
+/**
+ * 收集电脑的已知地址并保持稳定顺序。
+ * 状态轮询使用默认选项；诊断可额外包含锁定地址并过滤回环 IPv4。
+ */
+export function collectKnownAddresses(
+  computer: AddressHolder,
+  options?: AddressCollectionOptions
+): string[] {
+  const addresses = new Set<string>();
+  const add = (address: string | undefined): void => {
+    if (!address) return;
+    if (options?.excludeLoopbackIPv4 && isLoopbackIPv4(address)) return;
+    addresses.add(address);
+  };
+
+  if (options?.includePreferred) {
+    add(computer.preferredAddress);
+  }
+  add(computer.manualAddress);
+  add(computer.address);
+  add(computer.localAddress);
+  add(computer.remoteAddress);
+  add(computer.ipv6Address);
+  return Array.from(addresses);
+}

--- a/entry/src/main/ets/viewmodel/PcListActions.ets
+++ b/entry/src/main/ets/viewmodel/PcListActions.ets
@@ -22,6 +22,11 @@ import { ComputerManager } from '../service/ComputerManager';
 import { PairingManager, PairState as PMPairState } from '../service/network/PairingManager';
 import { NvHttp, ServerInfo } from '../service/streaming/NvHttp';
 import { PairState, ComputerState, selectBestAddress, ComputerInfo } from '../model/ComputerInfo';
+import {
+  classifyServerIdentity,
+  collectKnownAddresses,
+  ServerIdentityDisposition
+} from '../service/network/ComputerNetworkPolicy';
 import { ConfirmDialogConfig, InfoDialogConfig } from '../components/dialogs/ConfirmDialog';
 import { AppColors } from '../common/Theme';
 import { isLoopbackIPv4 } from '../utils/NetHelper';
@@ -333,18 +338,12 @@ export class PcListActions {
     const computerInfo = computer.toComputerInfo();
     const context = getContext() as common.UIAbilityContext;
 
-    // 收集所有可用地址（过滤 127.x 回环地址）
-    const addressSet = new Set<string>();
-    const addIfValid = (addr: string | undefined) => {
-      if (addr && !isLoopbackIPv4(addr)) addressSet.add(addr);
-    };
-    addIfValid(computerInfo.preferredAddress);
-    addIfValid(computerInfo.manualAddress);
-    addIfValid(computerInfo.address);
-    addIfValid(computerInfo.localAddress);
-    addIfValid(computerInfo.remoteAddress);
-    addIfValid(computerInfo.ipv6Address);
-    const addresses = Array.from(addressSet);
+    // 诊断包含锁定地址，但过滤服务器自报的 127.x 回环地址。
+    const addresses = collectKnownAddresses(computerInfo, {
+      includePreferred: true,
+      excludeLoopbackIPv4: true
+    });
+    const addressSet = new Set<string>(addresses);
 
     if (addresses.length === 0) {
       this.ui.showInfoDialog({ title: '网络测试', content: '没有可用的连接地址' });
@@ -367,10 +366,11 @@ export class PcListActions {
           // 此处刻意不传 context：不配置客户端证书文件时 getServerInfo() 才走 HTTP。
           const nvHttp = NvHttp.fromAddress(addr, computerInfo);
           const info = await nvHttp.getServerInfo();
-          if (!info.uniqueId) {
+          const identity = classifyServerIdentity(computerInfo.uuid, info.uniqueId);
+          if (identity === ServerIdentityDisposition.MISSING) {
             throw new Error('服务器响应缺少主机 UUID');
           }
-          if (info.uniqueId !== computerInfo.uuid && !computerInfo.uuid.startsWith('discovered-')) {
+          if (identity === ServerIdentityDisposition.MISMATCH) {
             throw new Error(`主机身份不匹配 (${info.uniqueId})`);
           }
           const elapsed = Date.now() - startMs;

--- a/scripts/sunshine-mock-connection-test.js
+++ b/scripts/sunshine-mock-connection-test.js
@@ -162,6 +162,12 @@ function isLanAddress(address) {
     host.startsWith('fe80:') || host.startsWith('fc') || host.startsWith('fd') || host === '::1';
 }
 
+function isLanIPv4AddressModel(address) {
+  const host = String(address).replace(/:\d+$/, '');
+  return isIPv4Address(host) &&
+    (isPrivateIPv4(host) || isLoopbackIPv4(host) || host.startsWith('169.254.'));
+}
+
 function resolveHttpPort(address, fallback) {
   const match = String(address).match(/^[^:]+:(\d+)$/);
   if (!match) return fallback;
@@ -183,8 +189,12 @@ function nvHttpFromAddressModel(address, computer) {
 
 // Mirrors selectBestAddress().
 function selectBestAddressModel(computer) {
-  return computer.preferredAddress || computer.address || computer.manualAddress ||
-    computer.localAddress || computer.ipv6Address || computer.remoteAddress || '';
+  if (computer.preferredAddress) return computer.preferredAddress;
+  if (computer.address) return computer.address;
+  if (computer.manualAddress) return computer.manualAddress;
+  if (computer.localAddress && isLanIPv4AddressModel(computer.localAddress)) return computer.localAddress;
+  if (computer.ipv6Address && isLanAddress(computer.ipv6Address)) return computer.ipv6Address;
+  return computer.localAddress || computer.ipv6Address || computer.remoteAddress || '';
 }
 
 // Mirrors selectBestAddress() + NvHttp.fromComputer().
@@ -194,14 +204,13 @@ function nvHttpFromComputerModel(computer) {
 
 // Availability polling remains route-agnostic even when the user locks the
 // address used by authenticated AppList/streaming requests.
-function collectPollAddressesModel(computer) {
-  return Array.from(new Set([
-    computer.manualAddress,
-    computer.address,
-    computer.localAddress,
-    computer.remoteAddress,
-    computer.ipv6Address
-  ].filter(Boolean)));
+function collectKnownAddressesModel(computer, { includePreferred = false, excludeLoopbackIPv4 = false } = {}) {
+  const values = includePreferred ? [computer.preferredAddress] : [];
+  values.push(computer.manualAddress, computer.address, computer.localAddress,
+    computer.remoteAddress, computer.ipv6Address);
+  return Array.from(new Set(values.filter((address) => {
+    return address && (!excludeLoopbackIPv4 || !isLoopbackIPv4(address));
+  })));
 }
 
 // Mirrors the read-only, layered result produced by PcListActions.testNetwork().
@@ -228,10 +237,16 @@ function networkTestResultModel(computer, results) {
   };
 }
 
+function classifyServerIdentityModel(computerUuid, serverUniqueId) {
+  if (!serverUniqueId) return 'MISSING';
+  if (computerUuid === serverUniqueId) return 'MATCH';
+  return computerUuid.startsWith('discovered-') ? 'RECONCILE_DISCOVERED' : 'MISMATCH';
+}
+
 function acceptPollResultModel(computer, currentComputer, serverInfo) {
-  if (currentComputer !== computer || !serverInfo?.uniqueId) return false;
-  if (computer.uuid === serverInfo.uniqueId) return true;
-  return computer.uuid.startsWith('discovered-');
+  if (currentComputer !== computer) return false;
+  const identity = classifyServerIdentityModel(computer.uuid, serverInfo?.uniqueId);
+  return identity === 'MATCH' || identity === 'RECONCILE_DISCOVERED';
 }
 
 function parseAddressAndPortModel(address) {
@@ -1298,6 +1313,44 @@ async function testHttpsPortReuseModel() {
   assert.strictEqual(samePortDifferentHost.httpsPort, 47984);
 }
 
+async function testComputerNetworkPolicyModels() {
+  const lanIpv6Fallback = createComputer({
+    address: '',
+    localAddress: '203.0.113.20',
+    ipv6Address: 'fd00::20',
+    remoteAddress: '198.51.100.20'
+  });
+  assert.strictEqual(selectBestAddressModel(lanIpv6Fallback), 'fd00::20');
+
+  const globalIpv6Fallback = createComputer({
+    address: '',
+    localAddress: '203.0.113.20',
+    ipv6Address: '240e:1234::20',
+    remoteAddress: '198.51.100.20'
+  });
+  assert.strictEqual(selectBestAddressModel(globalIpv6Fallback), '203.0.113.20');
+
+  const addresses = collectKnownAddressesModel(createComputer({
+    preferredAddress: '100.97.89.33',
+    manualAddress: 'manual.example.com',
+    address: '127.0.0.1',
+    localAddress: '192.168.6.102',
+    remoteAddress: '100.97.89.33',
+    ipv6Address: 'fd00::20'
+  }), { includePreferred: true, excludeLoopbackIPv4: true });
+  assert.deepStrictEqual(addresses, [
+    '100.97.89.33',
+    'manual.example.com',
+    '192.168.6.102',
+    'fd00::20'
+  ]);
+
+  assert.strictEqual(classifyServerIdentityModel('host-a', ''), 'MISSING');
+  assert.strictEqual(classifyServerIdentityModel('host-a', 'host-a'), 'MATCH');
+  assert.strictEqual(classifyServerIdentityModel('discovered-Jue', 'host-a'), 'RECONCILE_DISCOVERED');
+  assert.strictEqual(classifyServerIdentityModel('host-a', 'host-b'), 'MISMATCH');
+}
+
 async function testServerInfoReachabilityDoesNotProveAppListScenario() {
   const { httpPort } = await findAdjacentPortPair();
   const mock = await new FoundationSunshineMock({
@@ -1362,7 +1415,7 @@ async function testPreferredAddressPollSplitScenario() {
   });
 
   const connection = nvHttpFromComputerModel(computer);
-  const pollCandidates = collectPollAddressesModel(computer);
+  const pollCandidates = collectKnownAddressesModel(computer);
   const pollResult = await raceForFirstSuccessModel(
     pollCandidates.map((address) => delay(5, { address, serverInfo: { hostname: 'Jue' } }))
   );
@@ -1762,6 +1815,7 @@ async function main() {
     ['ComputerManager merge model', testComputerManagerMergeModel],
     ['poll race prefers LAN', testPollRacePrefersLan],
     ['HTTPS port reuse model', testHttpsPortReuseModel],
+    ['computer network policy models', testComputerNetworkPolicyModels],
     ['scenario: serverinfo reachability does not prove applist', testServerInfoReachabilityDoesNotProveAppListScenario],
     ['scenario: network diagnostic remains read-only', testNetworkDiagnosticStateSplitScenario],
     ['scenario: preferred address does not constrain availability polling', testPreferredAddressPollSplitScenario],


### PR DESCRIPTION
## 改了啥呀
- 把地址候选收集和 Sunshine UUID 分类集中到 `ComputerNetworkPolicy`，杂鱼重复分支终于少一点啦
- `ComputerManager` 的 mDNS、轮询、Wake-on-LAN 与只读网络诊断复用同一套身份/地址规则
- 修正 Node 测试模型与生产地址优先级的漂移，补齐 LAN IPv4、LAN IPv6、去重/回环过滤和四类 UUID 场景

## 为啥要改
#116 已经把真实网络问题修好；这一单只收束修复后暴露的重复策略，避免轮询、唤醒与诊断以后各自悄悄长歪，笨蛋维护起来也不容易漏掉分支啦。

单地址响应在参与竞速前、竞速结果写入共享状态前仍各验证一次 UUID：前者防止错误主机抢先胜出，后者防止异步期间对象变旧，这是有意保留的两道边界。

## 验证
- `npm run check`：PASS（27 个 Sunshine mock/网络模型场景）
- `git diff --check`：PASS
- GitHub Actions `Build (debug)`：PASS（Native HAR + HAP/ArkTS）
- CodeRabbit：PASS（草稿 PR 跳过审查）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化网络地址收集，支持首选地址、地址去重及过滤 IPv4 环回地址。
  * 改进服务器身份校验与设备发现流程，支持身份匹配、缺失及不匹配状态的处理。
  * 优化网络测试和唤醒功能在多地址及 IPv6 场景下的连接稳定性。

* **测试**
  * 增加网络地址回退、地址去重、环回地址过滤及服务器身份校验覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->