### PR TITLE
fix(haptics): gate complementary shaping on live USB output, unify auto fallback

### DIFF
--- a/entry/src/main/ets/model/StreamConfig.ets
+++ b/entry/src/main/ets/model/StreamConfig.ets
@@ -27,6 +27,11 @@ export function normalizeGameVibrationStrength(value: number): number {
   return Math.max(GAME_VIBRATION_STRENGTH_MIN, Math.min(GAME_VIBRATION_STRENGTH_MAX, roundedValue));
 }
 
+/** 兼容历史设置值：震动模式「同时」已更名为「协同」。 */
+export function normalizeVibrationMode(mode: string): string {
+  return mode === '同时' ? '协同' : mode;
+}
+
 export interface StreamConfig {
   // 视频设置
   width: number;
@@ -61,7 +66,7 @@ export interface StreamConfig {
   multiController: boolean;
   attachedGamepadMask: number;
   enableVibration: boolean;
-  vibrationMode: string;  // 震动模式：自动/仅手柄/仅设备/同时
+  vibrationMode: string;  // 震动模式：自动/仅手柄/仅设备/协同
   gameVibrationStrength: number;  // 串流游戏震动强度百分比（100=原始强度，100 以上为 app 侧放大）
   enableAudioVibration: boolean;  // 音频振动（低频驱动）
   audioVibrationStrength: number;  // 音频振动强度 (0-100)

--- a/entry/src/main/ets/model/StreamConfig.ets
+++ b/entry/src/main/ets/model/StreamConfig.ets
@@ -27,11 +27,6 @@ export function normalizeGameVibrationStrength(value: number): number {
   return Math.max(GAME_VIBRATION_STRENGTH_MIN, Math.min(GAME_VIBRATION_STRENGTH_MAX, roundedValue));
 }
 
-/** 兼容历史设置值：震动模式「同时」已更名为「协同」。 */
-export function normalizeVibrationMode(mode: string): string {
-  return mode === '同时' ? '协同' : mode;
-}
-
 export interface StreamConfig {
   // 视频设置
   width: number;

--- a/entry/src/main/ets/pages/SettingsPageV2.ets
+++ b/entry/src/main/ets/pages/SettingsPageV2.ets
@@ -1480,6 +1480,7 @@ struct SettingsPageV2 {
                 title: '震动模式',
                 type: 'segment',
                 value: this.vibrationMode,
+                subtitle: this.getVibrationModeSubtitle(),
                 visible: this.enableVibration,
                 segmentLabels: ['自动', '仅手柄', '仅设备', '协同'],
                 onSegmentChange: (value: string) => {
@@ -3675,27 +3676,15 @@ struct SettingsPageV2 {
   private showEnhancedTouchZoneDividerPicker(): void { }
   private showPointerVelocityFactorPicker(): void { }
   
-  /**
-   * 显示震动模式选择器
-   */
-  private showVibrationModePicker(): void {
-    const options: PickerOption[] = [
-      { title: '自动', subtitle: '有手柄用手柄震动，无手柄用设备震动', value: '自动' } as PickerOption,
-      { title: '仅手柄', subtitle: '只使用手柄震动', value: '仅手柄' } as PickerOption,
-      { title: '仅设备', subtitle: '只使用设备震动', value: '仅设备' } as PickerOption,
-      { title: '协同', subtitle: '手柄承载高频细节，机身补充低频量感', value: '协同' } as PickerOption
-    ];
-    const config: PickerConfig = {
-      title: '选择震动模式',
-      subtitle: '选择震动反馈的来源',
-      selectedValue: this.vibrationMode,
-      options: options,
-      onSelect: (option: PickerOption) => {
-        this.vibrationMode = option.value as string;
-        this.saveSetting(SettingsKeys.VIBRATION_MODE, option.value as string);
-      }
-    };
-    this.showPicker(config);
+  /** 震动模式分段项下方的说明文字，随所选模式变化。 */
+  private getVibrationModeSubtitle(): string {
+    switch (this.vibrationMode) {
+      case '仅手柄': return '只使用手柄震动';
+      case '仅设备': return '只使用设备震动';
+      case '协同': return '手柄承载高频细节，机身补充低频量感';
+      case '自动':
+      default: return '有手柄用手柄震动，无手柄用设备震动';
+    }
   }
   private showAudioVibrationSceneModePicker(): void {
     const options: PickerOption[] = [

--- a/entry/src/main/ets/pages/SettingsPageV2.ets
+++ b/entry/src/main/ets/pages/SettingsPageV2.ets
@@ -23,8 +23,7 @@ import {
   GAME_VIBRATION_STRENGTH_MIN,
   GAME_VIBRATION_STRENGTH_ORIGINAL,
   GAME_VIBRATION_STRENGTH_STEP,
-  normalizeGameVibrationStrength,
-  normalizeVibrationMode
+  normalizeGameVibrationStrength
 } from '../model/StreamConfig';
 import { PerfLabels } from '../components/PerformanceOverlayManager';
 import { SettingSlider, SettingSliderConfig, LogarithmicSlider } from '../components/SettingSlider';
@@ -540,8 +539,7 @@ struct SettingsPageV2 {
       
       // 输入 - 手柄设置
       this.enableVibration = await this.loadBoolean(SettingsKeys.ENABLE_VIBRATION, true);
-      this.vibrationMode = normalizeVibrationMode(
-        await PreferencesUtil.get<string>(SettingsKeys.VIBRATION_MODE, '自动'));
+      this.vibrationMode = await PreferencesUtil.get<string>(SettingsKeys.VIBRATION_MODE, '自动');
       this.gameVibrationStrength = await this.loadGameVibrationStrength();
       this.enableAudioVibration = await this.loadBoolean(SettingsKeys.ENABLE_AUDIO_VIBRATION, false);
       this.audioVibrationStrength = await PreferencesUtil.get<number>(SettingsKeys.AUDIO_VIBRATION_STRENGTH, 60);

--- a/entry/src/main/ets/pages/SettingsPageV2.ets
+++ b/entry/src/main/ets/pages/SettingsPageV2.ets
@@ -23,7 +23,8 @@ import {
   GAME_VIBRATION_STRENGTH_MIN,
   GAME_VIBRATION_STRENGTH_ORIGINAL,
   GAME_VIBRATION_STRENGTH_STEP,
-  normalizeGameVibrationStrength
+  normalizeGameVibrationStrength,
+  normalizeVibrationMode
 } from '../model/StreamConfig';
 import { PerfLabels } from '../components/PerformanceOverlayManager';
 import { SettingSlider, SettingSliderConfig, LogarithmicSlider } from '../components/SettingSlider';
@@ -539,7 +540,8 @@ struct SettingsPageV2 {
       
       // 输入 - 手柄设置
       this.enableVibration = await this.loadBoolean(SettingsKeys.ENABLE_VIBRATION, true);
-      this.vibrationMode = await PreferencesUtil.get<string>(SettingsKeys.VIBRATION_MODE, '自动');
+      this.vibrationMode = normalizeVibrationMode(
+        await PreferencesUtil.get<string>(SettingsKeys.VIBRATION_MODE, '自动'));
       this.gameVibrationStrength = await this.loadGameVibrationStrength();
       this.enableAudioVibration = await this.loadBoolean(SettingsKeys.ENABLE_AUDIO_VIBRATION, false);
       this.audioVibrationStrength = await PreferencesUtil.get<number>(SettingsKeys.AUDIO_VIBRATION_STRENGTH, 60);
@@ -1481,7 +1483,7 @@ struct SettingsPageV2 {
                 type: 'segment',
                 value: this.vibrationMode,
                 visible: this.enableVibration,
-                segmentLabels: ['自动', '仅手柄', '仅设备', '同时'],
+                segmentLabels: ['自动', '仅手柄', '仅设备', '协同'],
                 onSegmentChange: (value: string) => {
                   this.vibrationMode = value;
                   this.saveSetting(SettingsKeys.VIBRATION_MODE, value);
@@ -3683,7 +3685,7 @@ struct SettingsPageV2 {
       { title: '自动', subtitle: '有手柄用手柄震动，无手柄用设备震动', value: '自动' } as PickerOption,
       { title: '仅手柄', subtitle: '只使用手柄震动', value: '仅手柄' } as PickerOption,
       { title: '仅设备', subtitle: '只使用设备震动', value: '仅设备' } as PickerOption,
-      { title: '同时', subtitle: '手柄和设备同时震动', value: '同时' } as PickerOption
+      { title: '协同', subtitle: '手柄承载高频细节，机身补充低频量感', value: '协同' } as PickerOption
     ];
     const config: PickerConfig = {
       title: '选择震动模式',

--- a/entry/src/main/ets/service/AudioVibrationService.ets
+++ b/entry/src/main/ets/service/AudioVibrationService.ets
@@ -235,7 +235,7 @@ export class AudioVibrationService {
     switch (this.vibrationMode) {
       case '仅手柄': return false;
       case '仅设备':
-      case '同时': return true;
+      case '协同': return true;
       case '自动':
       default:
         // Automatic audio haptics may use the gamepad path only when this
@@ -249,7 +249,7 @@ export class AudioVibrationService {
   private shouldVibrateGamepad(): boolean {
     switch (this.vibrationMode) {
       case '仅手柄':
-      case '同时': return true;
+      case '协同': return true;
       case '仅设备': return false;
       case '自动':
       default:

--- a/entry/src/main/ets/service/SettingsService.ets
+++ b/entry/src/main/ets/service/SettingsService.ets
@@ -27,7 +27,8 @@ import {
   PerfOverlayPosition,
   getRecommendedBitrate,
   GAME_VIBRATION_STRENGTH_DEFAULT,
-  normalizeGameVibrationStrength
+  normalizeGameVibrationStrength,
+  normalizeVibrationMode
 } from '../model/StreamConfig';
 
 /**
@@ -72,7 +73,7 @@ export class SettingsKeys {
 
   // 输入 - 手柄设置
   static readonly ENABLE_VIBRATION: string = 'settings_enable_vibration';
-  static readonly VIBRATION_MODE: string = 'settings_vibration_mode';  // 震动模式：自动/仅手柄/仅设备/同时
+  static readonly VIBRATION_MODE: string = 'settings_vibration_mode';  // 震动模式：自动/仅手柄/仅设备/协同
   static readonly VIBRATE_FALLBACK_STRENGTH: string = 'settings_vibrate_fallback_strength';  // 历史存储键，现用于游戏震动强度
   static readonly ENABLE_AUDIO_VIBRATION: string = 'settings_enable_audio_vibration';  // 音频振动（低频驱动）
   static readonly AUDIO_VIBRATION_STRENGTH: string = 'settings_audio_vibration_strength';  // 音频振动强度 (0-100)
@@ -193,7 +194,7 @@ export class SettingsKeys {
 export interface InputSettings {
   // 手柄
   enableVibration: boolean;
-  vibrationMode: string;  // 自动/仅手柄/仅设备/同时
+  vibrationMode: string;  // 自动/仅手柄/仅设备/协同
   gameVibrationStrength: number;
   enableAudioVibration: boolean;  // 音频振动（低频驱动）
   audioVibrationStrength: number;  // 音频振动强度 (0-100)
@@ -622,7 +623,8 @@ export class SettingsService {
 
     // 获取输入设置
     const enableVibration = await this.getBoolean(SettingsKeys.ENABLE_VIBRATION, true);
-    const vibrationMode = await this.getString(SettingsKeys.VIBRATION_MODE, '自动');
+    const vibrationMode = normalizeVibrationMode(
+      await this.getString(SettingsKeys.VIBRATION_MODE, '自动'));
     const gameVibrationStrength = normalizeGameVibrationStrength(
       await this.getNumber(SettingsKeys.VIBRATE_FALLBACK_STRENGTH, GAME_VIBRATION_STRENGTH_DEFAULT)
     );
@@ -777,7 +779,8 @@ export class SettingsService {
     return {
       // 手柄
       enableVibration: await this.getBoolean(SettingsKeys.ENABLE_VIBRATION, true),
-      vibrationMode: await this.getString(SettingsKeys.VIBRATION_MODE, '自动'),
+      vibrationMode: normalizeVibrationMode(
+        await this.getString(SettingsKeys.VIBRATION_MODE, '自动')),
       gameVibrationStrength: normalizeGameVibrationStrength(
         await this.getNumber(SettingsKeys.VIBRATE_FALLBACK_STRENGTH, GAME_VIBRATION_STRENGTH_DEFAULT)
       ),

--- a/entry/src/main/ets/service/SettingsService.ets
+++ b/entry/src/main/ets/service/SettingsService.ets
@@ -27,8 +27,7 @@ import {
   PerfOverlayPosition,
   getRecommendedBitrate,
   GAME_VIBRATION_STRENGTH_DEFAULT,
-  normalizeGameVibrationStrength,
-  normalizeVibrationMode
+  normalizeGameVibrationStrength
 } from '../model/StreamConfig';
 
 /**
@@ -623,8 +622,7 @@ export class SettingsService {
 
     // 获取输入设置
     const enableVibration = await this.getBoolean(SettingsKeys.ENABLE_VIBRATION, true);
-    const vibrationMode = normalizeVibrationMode(
-      await this.getString(SettingsKeys.VIBRATION_MODE, '自动'));
+    const vibrationMode = await this.getString(SettingsKeys.VIBRATION_MODE, '自动');
     const gameVibrationStrength = normalizeGameVibrationStrength(
       await this.getNumber(SettingsKeys.VIBRATE_FALLBACK_STRENGTH, GAME_VIBRATION_STRENGTH_DEFAULT)
     );
@@ -779,8 +777,7 @@ export class SettingsService {
     return {
       // 手柄
       enableVibration: await this.getBoolean(SettingsKeys.ENABLE_VIBRATION, true),
-      vibrationMode: normalizeVibrationMode(
-        await this.getString(SettingsKeys.VIBRATION_MODE, '自动')),
+      vibrationMode: await this.getString(SettingsKeys.VIBRATION_MODE, '自动'),
       gameVibrationStrength: normalizeGameVibrationStrength(
         await this.getNumber(SettingsKeys.VIBRATE_FALLBACK_STRENGTH, GAME_VIBRATION_STRENGTH_DEFAULT)
       ),

--- a/entry/src/main/ets/service/input/GamepadManager.ets
+++ b/entry/src/main/ets/service/input/GamepadManager.ets
@@ -176,8 +176,7 @@ export class GamepadManager implements UsbDriverListener {
     this.mouseEmulationService = new MouseEmulationService();
     this.vibrationService = new GamepadVibrationService(
       this.usbDriverService,
-      this.deviceKeyToSlot,
-      (): boolean => this.hasConnectedGamepadOutsideUsbDriver()
+      this.deviceKeyToSlot
     );
     this.loadGCButtonMappingSettings();
     this.loadSensorSettings();
@@ -493,15 +492,6 @@ export class GamepadManager implements UsbDriverListener {
    */
   hasActiveGcGamepad(): boolean {
     return this.useGameControllerKit && this.gcDeviceIdToSlot.size > 0;
-  }
-
-  private hasConnectedGamepadOutsideUsbDriver(): boolean {
-    if (this.hasActiveGcGamepad()) return true;
-    let connected = false;
-    this.deviceInfoMap.forEach((info: GamepadInfo): void => {
-      if (!info.isUsb) connected = true;
-    });
-    return connected;
   }
 
   // ==================== 鼠标模拟（委托 MouseEmulationService） ====================

--- a/entry/src/main/ets/service/input/GamepadVibrationService.ets
+++ b/entry/src/main/ets/service/input/GamepadVibrationService.ets
@@ -75,9 +75,9 @@ export class GamepadVibrationService {
   /** Device vibrator APIs are relatively expensive; coalesce authored IR frames. */
   private static readonly DEVICE_RENDER_INTERVAL_MS = 40;
   /**
-   * The body actuator is a single, broad-band motor. In simultaneous mode it
-   * should add weight rather than mirror the controller's high-frequency
-   * detail. Keep these gains separate from the controller output path.
+   * The body actuator is a single, broad-band motor. In 协同 mode it should
+   * add weight rather than mirror the controller's high-frequency detail.
+   * Keep these gains separate from the controller output path.
    */
   private static readonly BODY_LOW_BAND_GAIN = 0.72;
   private static readonly BODY_HIGH_BAND_GAIN = 0.28;
@@ -88,7 +88,6 @@ export class GamepadVibrationService {
   private static readonly IR_PRIORITY_OVER_GAME = true;
   private usbDriverService: UsbDriverService;
   private deviceVibrationCoordinator: DeviceVibrationCoordinator;
-  private hasExternalGamepad: () => boolean;
   
   // 设置
   private vibrationFeedbackEnabled = true;
@@ -134,11 +133,9 @@ export class GamepadVibrationService {
   private pendingDeviceRenderTimer: number = -1;
   private pendingDeviceRenderTransient = false;
 
-  constructor(usbDriverService: UsbDriverService, deviceKeyToSlot: Map<string, number>,
-    hasExternalGamepad: () => boolean) {
+  constructor(usbDriverService: UsbDriverService, deviceKeyToSlot: Map<string, number>) {
     this.usbDriverService = usbDriverService;
     this.deviceKeyToSlotLookup = deviceKeyToSlot;
-    this.hasExternalGamepad = hasExternalGamepad;
     this.deviceVibrationCoordinator = DeviceVibrationCoordinator.getInstance();
     this.deviceVibrationCoordinator.setSourceResumeCallback((): void => {
       this.renderMixedDevice(false);
@@ -796,7 +793,7 @@ export class GamepadVibrationService {
       case '仅设备':
         return false;
       case '仅手柄':
-      case '同时':
+      case '协同':
         return true;
       case '自动':
       default:
@@ -809,12 +806,14 @@ export class GamepadVibrationService {
       case '仅手柄':
         return false;
       case '仅设备':
-      case '同时':
+      case '协同':
         return true;
       case '自动':
       default:
-        return this.usbDriverService.getControllers().length === 0 &&
-          !this.hasExternalGamepad();
+        // Bluetooth/GCK gamepads expose no rumble backend, so the body is the
+        // only usable actuator whenever no USB-driven controller exists —
+        // same policy as the audio haptics path.
+        return this.usbDriverService.getControllers().length === 0;
     }
   }
 
@@ -1034,18 +1033,21 @@ export class GamepadVibrationService {
     const highIntensity = this.mixWithHeadroom(gameHighIntensity, irHighIntensity, 100);
     // A controller can express two motor bands independently. The body motor
     // cannot, so its continuous channel deliberately favors the low band and
-    // attenuates high-frequency detail. This makes "同时" complementary:
+    // attenuates high-frequency detail. This makes "协同" complementary:
     // the controller carries detail while the body adds physical weight.
     const gameIntensity = this.getBodyContinuousIntensity(lowIntensity, highIntensity);
     const audioContinuous =
       !irActive && Date.now() <= this.audioDeviceContinuousUntilMs
         ? this.audioDeviceContinuous
         : 0;
+    // Audio haptics gets the same complementary treatment while a controller
+    // destination is live: the body adds weight instead of mirroring what the
+    // controller already plays.
     const mixedContinuous = this.mixWithHeadroom(
-      gameIntensity, audioContinuous, 100);
+      gameIntensity, this.shapeAudioForBody(audioContinuous), 100);
     const mixedTransient = effectiveAudioTransient
       ? this.mixWithHeadroom(
-        gameIntensity, this.audioDeviceTransient, 100)
+        gameIntensity, this.shapeAudioForBody(this.audioDeviceTransient), 100)
       : 0;
 
     if (this.deviceVibrationCoordinator.isTouchHapticActive()) return;
@@ -1085,16 +1087,38 @@ export class GamepadVibrationService {
 
   private getBodyContinuousIntensity(lowIntensity: number,
     highIntensity: number): number {
-    // With no controller destination, the body is the only actuator and must
-    // retain the full authored energy. Attenuation is reserved for simultaneous
-    // mode, where the controller carries the high-frequency detail.
-    if (this.vibrationMode !== '同时') {
+    // With no live controller destination, the body is the only actuator and
+    // must retain the full authored energy. Attenuation is reserved for 协同
+    // mode with a USB controller attached, where the controller carries the
+    // high-frequency detail.
+    if (!this.isComplementaryBodyShapingActive()) {
       return Math.max(lowIntensity, highIntensity);
     }
     return this.clampIntensity(
       lowIntensity * GamepadVibrationService.BODY_LOW_BAND_GAIN +
       highIntensity * GamepadVibrationService.BODY_HIGH_BAND_GAIN
     );
+  }
+
+  /** 互补衰减只在「协同」且确实有 USB 手柄承载细节时生效。 */
+  private isComplementaryBodyShapingActive(): boolean {
+    return this.vibrationMode === '协同' && this.hasUsbControllers();
+  }
+
+  /**
+   * 协同模式下的音频互塑：sharpness 反映音频频谱倾向，低频内容保留接近
+   * BODY_LOW_BAND_GAIN 的量感，尖锐内容衰减到 BODY_HIGH_BAND_GAIN，与游戏
+   * rumble 的双频段权重保持同一套互补语义。
+   */
+  private shapeAudioForBody(intensity: number): number {
+    if (intensity <= 0 || !this.isComplementaryBodyShapingActive()) {
+      return intensity;
+    }
+    const gain = GamepadVibrationService.BODY_HIGH_BAND_GAIN +
+      (1 - this.audioDeviceSharpness) *
+        (GamepadVibrationService.BODY_LOW_BAND_GAIN -
+          GamepadVibrationService.BODY_HIGH_BAND_GAIN);
+    return this.clampIntensity(intensity * gain);
   }
 
   /**


### PR DESCRIPTION
## Summary

Follow-up to #114 that makes the "complementary" body/gamepad routing actually conditional, extends it to audio haptics, and unifies the auto-mode fallback policy. Also renames the vibration mode 同时 → 协同 to match its actual semantics.

### 1. Body shaping now requires a live USB destination (#114 regression)

`getBodyContinuousIntensity` attenuated the body (0.72·low + 0.28·high) whenever the mode was 同时, regardless of whether any USB controller was rendering. With no USB-driven pad the body is the *only* actuator, yet pure-high-band rumble dropped from 100 to 28 (~−11 dB). Affected scenarios:

- 同时 + Bluetooth/GCK pad (no rumble backend exists for them)
- **mid-session USB detach** — `clearControllerSource` re-rendered with the attenuated value, so body output audibly/visibly dropped on unplug

The gate is now `mode === 协同 && hasUsbControllers()`.

### 2. Audio haptics gets the same complementary treatment

In 同时 mode audio haptics played at full amplitude on the body *and* near-full on the controller — the exact double-actuation #114 removed for game rumble. `shapeAudioForBody()` now applies a sharpness-interpolated gain (0.72 for bass-heavy content → 0.28 for sharp content) to both continuous and transient contributions, only while a controller destination is live.

### 3. Auto-mode fallback unified

The game path required `!hasUsbControllers() && !hasExternalGamepad()` while the audio path (since #114) only checked `!hasUsbControllers()`. No rumble backend exists for Bluetooth/GCK pads anywhere in the codebase, so with one attached the game rumble was silently dropped while audio still shook the body. Both paths now use the same rule: body vibrates unless a USB-driven controller can receive the rumble. The now-unused `hasExternalGamepad` plumbing was removed.

### 4. Rename 同时 → 协同

The mode never meant "both at full power" — it means complementary output (controller carries detail, body adds weight). UI subtitle updated accordingly. No legacy-value migration: the app has no external users yet, so a persisted 同时 simply falls back to the 自动 default.

## Reviewer notes

- Behavior table after this PR:

| Mode | Body | USB pad |
|---|---|---|
| 自动 | no USB-driven pad | any USB pad |
| 仅手柄 | off | on |
| 仅设备 | on (full energy) | off |
| 协同 | on, band-weighted **only while a USB pad is attached** | on |

- Staged separately from the in-progress `[GAMEPAD-IDLE]` probe work sitting in the same file; that stays uncommitted.

## Test plan

- [x] `assembleHap` builds in a clean worktree (submodule at master); only pre-existing warnings
- [ ] 协同 + USB DualSense: game rumble — body carries weighted low band, pad full detail
- [ ] 协同 + USB DualSense: unplug mid-rumble — body restores full energy immediately
- [ ] 自动 + Bluetooth pad: game rumble now reaches the body
- [ ] Legacy persisted 同时: falls back to 自动; UI segment reflects it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 震动模式名称由“同时”更新为“协同”，相关设置说明同步优化。
  * 协同模式下，手柄侧提供高频细节，设备侧补充低频量感，带来更协调的震动体验。
  * 未连接 USB 控制器时，设备可保留完整震动幅度。

* **改进**
  * 震动设置现在直接使用已保存的模式，避免历史名称转换造成显示不一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Settings page deduplication (follow-up commit)

Audit of all ~130 settings found overlaps; all five findings addressed:

1. **Removed the unimplemented enhanced-touch group** (5 items whose values were stored but never consumed). Keys stay in the preference store, so old backups still export/import without loss; the feature can return later.
2. **Merged vibration into one group.** Game rumble (振动反馈/震动强度) and audio haptics (音频振动/强度/场景) now live in a new 振动 group with the shared 震动模式 router, instead of being split across the gamepad and audio groups driving the same actuators. 震动模式 shows when either source is enabled.
3. **显示峰值亮度 → SDR→HDR 亮度上限** — the old name collided with the Sunshine-reported HDR 峰值亮度 in the video group; subtitle now states they are unrelated.
4. **Touch 'mouse' mode renamed to 触摸鼠标** — was colliding with 游戏鼠标模式 (relative host input). Applied in the stream menu picker and StreamMenuManager; deleted StreamPage's dead duplicate of `getTouchModeName` (also a literal duplicate).
5. **Gyro-assist tuning moved into the settings page** (gamepad group: enable/sensitivity/X-Y invert/activation), previously only reachable inside the stream menu. Reuses the existing `GYRO_*` keys — no persistence format change.

Backup/restore impact: `exportAll()` serializes the whole preference store, renames are display-only, no key changed semantics — old backups remain fully compatible.

## Test plan (settings restructure)

- [x] `assembleHap` builds in a clean worktree
- [ ] Narrow screen: 振动 group collapses/expands; wide screen: sidebar entry navigates correctly
- [ ] Gyro settings changed in the page apply on next stream start (StreamPage.initializeGyroAssist reads them via InputSettings)
- [ ] Importing a pre-change backup: enhanced-touch keys restore silently, all other values land
