### PR TITLE
feat(settings): deduplicate overlapping settings entries

### DIFF
--- a/entry/src/main/ets/components/StreamMenuManager.ets
+++ b/entry/src/main/ets/components/StreamMenuManager.ets
@@ -229,7 +229,7 @@ export class StreamMenuManager {
         value: 'direct'
       },
       {
-        title: currentMode === 'mouse' ? '✓ 鼠标模式' : '  鼠标模式',
+        title: currentMode === 'mouse' ? '✓ 触摸鼠标' : '  触摸鼠标',
         subtitle: '相对移动 + 按住拖动',
         value: 'mouse'
       },

--- a/entry/src/main/ets/components/StreamMenuManager.ets
+++ b/entry/src/main/ets/components/StreamMenuManager.ets
@@ -78,7 +78,7 @@ export class StreamMenuManager {
       case 'direct':
         return '直接触摸模式';
       case 'mouse':
-        return '鼠标模式';
+        return '触摸鼠标';
       case 'ds5_touchpad':
         return 'DS5 触控板模式';
       default:

--- a/entry/src/main/ets/components/dialogs/GameMenuDialog.ets
+++ b/entry/src/main/ets/components/dialogs/GameMenuDialog.ets
@@ -460,7 +460,7 @@ export struct GameMenuDialog {
     const modes: TouchModeOption[] = [
       { key: 'trackpad', text: '触控板', subtitle: '像笔记本触控板一样操作' },
       { key: 'direct', text: '多点触控', subtitle: '直接点击屏幕位置' },
-      { key: 'mouse', text: '鼠标模式', subtitle: '模拟鼠标移动和点击' },
+      { key: 'mouse', text: '触摸鼠标', subtitle: '模拟鼠标移动和点击' },
       { key: 'ds5_touchpad', text: 'DS5 触控板', subtitle: '屏幕映射 DualSense 触控板，支持双指' }
     ];
 

--- a/entry/src/main/ets/components/dialogs/GameMenuDialog.ets
+++ b/entry/src/main/ets/components/dialogs/GameMenuDialog.ets
@@ -20,7 +20,14 @@ import { CustomKeyStore } from '../../service/customkey/CustomKeyStore';
 import { ShortcutManager, Shortcut } from '../ShortcutManager';
 import { ActionDialog, ActionDialogConfig, ConfirmDialog, ConfirmDialogConfig } from './ConfirmDialog';
 import { SuperCmd } from '../../service/streaming/NvHttp';
-import { GyroAssistService, GYRO_ACTIVATION_ALWAYS, GYRO_ACTIVATION_LT, GYRO_ACTIVATION_RT } from '../../service/input/GyroAssistService';
+import {
+  GyroAssistService,
+  GYRO_ACTIVATION_ALWAYS,
+  GYRO_ACTIVATION_LT,
+  GYRO_ACTIVATION_RT,
+  GYRO_SENSITIVITY_MIN,
+  GYRO_SENSITIVITY_MAX
+} from '../../service/input/GyroAssistService';
 import { SettingsKeys } from '../../service/SettingsService';
 import { PreferencesUtil } from '../../utils/PreferencesUtil';
 import { DeviceSensorService } from '../../service/input/DeviceSensorService';
@@ -1546,8 +1553,8 @@ export struct GameMenuDialog {
 
           Slider({
             value: this.gyroSensitivity,
-            min: 0.5,
-            max: 10.0,
+            min: GYRO_SENSITIVITY_MIN,
+            max: GYRO_SENSITIVITY_MAX,
             step: 0.1,
             style: SliderStyle.OutSet
           })
@@ -1567,9 +1574,9 @@ export struct GameMenuDialog {
             })
 
           Row() {
-            Text('0.5x').fontSize(OV_FONT_XS).fontColor(StreamMenuColors.TextFaint)
+            Text(GYRO_SENSITIVITY_MIN.toFixed(1) + 'x').fontSize(OV_FONT_XS).fontColor(StreamMenuColors.TextFaint)
             Blank()
-            Text('3.0x').fontSize(OV_FONT_XS).fontColor(StreamMenuColors.TextFaint)
+            Text(GYRO_SENSITIVITY_MAX.toFixed(1) + 'x').fontSize(OV_FONT_XS).fontColor(StreamMenuColors.TextFaint)
           }
           .width('100%')
         }

--- a/entry/src/main/ets/pages/SettingsPageV2.ets
+++ b/entry/src/main/ets/pages/SettingsPageV2.ets
@@ -1061,7 +1061,7 @@ struct SettingsPageV2 {
                 title: '码率上限',
                 subtitle: this.bitrate === 0 
                   ? `自动 (推荐: ${this.getRecommendedBitrateForCurrentSettings()} Mbps)` 
-                  : this.bandwidthProbeEnabled ? '自动初始码率不会超过此值' : '视频传输比特率',
+                  : this.bandwidthProbeEnabled ? '自动选码率和动态调节的上限' : '视频传输比特率上限',
                 type: 'slider',
                 value: this.bitrate,
                 min: 1,  // 对数滑块最小值为1（0单独处理为"自动"）
@@ -1079,8 +1079,8 @@ struct SettingsPageV2 {
                 }
               },
               {
-                title: '自动初始码率',
-                subtitle: this.bandwidthProbeEnabled ? '开流前预估可用带宽' : '直接使用码率上限',
+                title: '开流前自动选码率',
+                subtitle: this.bandwidthProbeEnabled ? '连接前预估带宽，自动选择初始码率' : '关闭后直接使用码率上限',
                 type: 'toggle',
                 value: this.bandwidthProbeEnabled,
                 action: () => {
@@ -1102,8 +1102,8 @@ struct SettingsPageV2 {
                 }
               },
               {
-                title: '串流中动态调节',
-                subtitle: this.adaptiveBitrate ? '根据网络状况自动调节码率' : '手动码率模式',
+                title: '串流中自动调节码率',
+                subtitle: this.adaptiveBitrate ? '根据网络状况自动调节码率，不超过码率上限' : '关闭后使用固定码率',
                 tooltip: '实时上报丢包率、延迟、帧率等网络指标，由本地 PID 控制器自动调节码率；连接基地阳光的米塔智能体时，服务端 LLM 可综合游戏类型和画面复杂度给出更精准的码率推荐',
                 type: 'toggle',
                 value: this.adaptiveBitrate,
@@ -1113,8 +1113,8 @@ struct SettingsPageV2 {
                 }
               },
               {
-                title: '分辨率缩放',
-                subtitle: '主机渲染分辨率比例',
+                title: '主机分辨率缩放',
+                subtitle: '按所选串流分辨率调整主机渲染分辨率',
                 type: 'slider',
                 value: this.hostScale,
                 min: 50,   // Android: 50-400%, step 10
@@ -1153,7 +1153,7 @@ struct SettingsPageV2 {
                 }
               },
               {
-                title: 'HDR',
+                title: '串流 HDR',
                 subtitle: this.videoFormat === 'H.264' 
                   ? 'H.264 不支持 HDR' 
                   : '需要支持 HDR 的显示器',
@@ -1190,10 +1190,10 @@ struct SettingsPageV2 {
                 }
               },
               {
-                title: 'HDR 高亮度',
-                subtitle: this.videoFormat === 'H.264' 
-                  ? '需要 HEVC/AV1' 
-                  : '使用高亮度 HDR 模式',
+                title: '本机 HDR 屏幕增亮',
+                subtitle: this.videoFormat === 'H.264'
+                  ? '需要 HEVC/AV1'
+                  : '提高本机屏幕亮度，与上报给主机的峰值亮度无关',
                 type: 'toggle',
                 visible: this.enableHdr,
                 value: this.enableHdrHighBrightness,
@@ -1208,10 +1208,10 @@ struct SettingsPageV2 {
                 }
               },
               {
-                title: '手动 HDR 亮度校准',
+                title: 'HDR 峰值亮度校准',
                 subtitle: this.hdrBrightnessOverride
-                  ? '上报峰值 ' + this.hdrPeakBrightnessNits.toString() + ' nits，重新连接后生效'
-                  : '默认优先按屏幕实测亮度上报；测量不可靠时回退默认值，过曝/偏暗时可手动覆盖',
+                  ? '向主机上报 ' + this.hdrPeakBrightnessNits.toString() + ' nits，重新连接后生效'
+                  : '自动测量本机亮度；过曝或偏暗时可手动指定上报值',
                 type: 'toggle',
                 visible: this.enableHdr,
                 value: this.hdrBrightnessOverride,
@@ -1226,8 +1226,8 @@ struct SettingsPageV2 {
                 }
               },
               {
-                title: 'HDR 峰值亮度',
-                subtitle: '数值越高，Sunshine 会按更亮的 HDR 屏幕处理',
+                title: 'HDR 峰值亮度（上报主机）',
+                subtitle: '告知主机本机屏幕的最高亮度，不改变屏幕实际亮度',
                 type: 'slider',
                 visible: this.enableHdr && this.hdrBrightnessOverride,
                 value: this.hdrPeakBrightnessNits,
@@ -1305,10 +1305,10 @@ struct SettingsPageV2 {
                 }
               },
               {
-                title: '全范围颜色',
+                title: '全范围色彩',
                 subtitle: this.enableHdr
                   ? 'HDR 模式下需与服务端编码范围一致'
-                  : '使用完整颜色范围 (0-255)',
+                  : '使用完整色彩范围（0–255）',
                 tooltip: '仅在服务端与解码器均使用全范围时开启；范围不一致会导致黑位或高光异常',
                 type: 'toggle',
                 value: this.fullRange,
@@ -1359,7 +1359,7 @@ struct SettingsPageV2 {
                 }
               },
               {
-                title: '本地音频',
+                title: '主机同时播放音频',
                 subtitle: '同时在主机上播放音频',
                 type: 'toggle',
                 value: this.enableLocalAudio,
@@ -1424,7 +1424,7 @@ struct SettingsPageV2 {
             ]
           })
 
-          // 振动设置：游戏震动与音频触感汇入同一组执行器，集中配置
+          // 振动设置：游戏振动与音频触感汇入同一组执行器，集中配置
           this.SettingsGroup({
             id: 'vibration',
             icon: $r('sys.symbol.waveform'),
@@ -1432,7 +1432,7 @@ struct SettingsPageV2 {
             items: [
               {
                 title: '振动反馈',
-                subtitle: '串流游戏震动反馈',
+                subtitle: '串流游戏振动反馈',
                 type: 'toggle',
                 value: this.enableVibration,
                 action: () => {
@@ -1441,10 +1441,10 @@ struct SettingsPageV2 {
                 }
               },
               {
-                title: '震动强度',
+                title: '振动强度',
                 subtitle: this.gameVibrationStrength > GAME_VIBRATION_STRENGTH_ORIGINAL ?
                   '超过 100% 为 app 侧放大，不突破系统/硬件上限' :
-                  '串流游戏震动强度，100% 为原始强度',
+                  '串流游戏振动强度，100% 为原始强度',
                 type: 'slider',
                 visible: this.enableVibration,
                 value: this.gameVibrationStrength,
@@ -1494,7 +1494,7 @@ struct SettingsPageV2 {
                 }
               },
               {
-                title: '震动模式',
+                title: '振动模式',
                 subtitle: this.getVibrationModeSubtitle(),
                 type: 'segment',
                 value: this.vibrationMode,
@@ -1515,8 +1515,8 @@ struct SettingsPageV2 {
             title: '手柄',
             items: [
               {
-                title: '多手柄支持',
-                subtitle: '支持多个游戏手柄',
+                title: '多手柄输入',
+                subtitle: '允许多个手柄同时输入',
                 type: 'toggle',
                 value: this.multiController,
                 action: () => {
@@ -1550,7 +1550,7 @@ struct SettingsPageV2 {
               },
               {
                 title: '手柄运动传感器',
-                subtitle: '启用陀螺仪和加速度计',
+                subtitle: '把手柄的陀螺仪数据转发给主机（游戏需支持体感）',
                 type: 'toggle',
                 value: this.gamepadMotionSensors,
                 action: () => {
@@ -1560,7 +1560,7 @@ struct SettingsPageV2 {
               },
               {
                 title: '体感助手',
-                subtitle: '设备陀螺仪映射为右摇杆（串流菜单可临时调整）',
+                subtitle: '本机陀螺仪直接操控右摇杆，无需游戏支持体感',
                 type: 'toggle',
                 value: this.gyroAssistEnabled,
                 action: () => {
@@ -1618,7 +1618,7 @@ struct SettingsPageV2 {
               },
               {
                 title: '设备运动传感器回退',
-                subtitle: '使用设备传感器替代手柄',
+                subtitle: '手柄没有体感时，用本机传感器数据顶替转发',
                 type: 'toggle',
                 visible: this.gamepadMotionSensors,
                 value: this.gamepadMotionFallback,
@@ -1628,7 +1628,7 @@ struct SettingsPageV2 {
                 }
               },
               {
-                title: '触摸板作为鼠标',
+                title: '手柄触摸板作鼠标',
                 subtitle: 'DualSense/DS4 触摸板模拟鼠标（需 USB 驱动）',
                 type: 'toggle',
                 value: this.gamepadTouchpadMouse,
@@ -1677,8 +1677,8 @@ struct SettingsPageV2 {
             title: 'USB 驱动',
             items: [
               {
-                title: 'USB 手柄驱动',
-                subtitle: '启用 USB 手柄的震动和 LED 等高级功能。手柄输入仍由系统统一处理',
+                title: 'USB 手柄振动与 LED',
+                subtitle: '启用 USB 手柄的振动和 LED 等高级功能。手柄输入仍由系统统一处理',
                 type: 'toggle',
                 value: this.usbDriverEnabled,
                 action: () => {
@@ -1927,8 +1927,8 @@ struct SettingsPageV2 {
             title: '主机',
             items: [
               {
-                title: '服务器端优化',
-                subtitle: '让服务器优化游戏设置',
+                title: 'NVIDIA 游戏优化',
+                subtitle: '让兼容的 NVIDIA 服务端自动优化游戏设置',
                 type: 'toggle',
                 value: this.enableSops,
                 action: () => {
@@ -1989,8 +1989,8 @@ struct SettingsPageV2 {
                 }
               },
               {
-                title: '获取公网 IP',
-                subtitle: '使用 STUN 获取被控端公网地址',
+                title: 'STUN 公网地址探测',
+                subtitle: '通过 STUN 探测主机公网地址，用于网络诊断',
                 type: 'toggle',
                 value: this.enableStun,
                 action: () => {
@@ -2105,7 +2105,7 @@ struct SettingsPageV2 {
             items: [
               {
                 title: '解码队列深度',
-                subtitle: '0=自动(2)，同步模式也限制软件队列',
+                subtitle: '0=自动（2）；数值越大越平滑，延迟也可能增加',
                 type: 'slider',
                 value: this.decoderBufferCount,
                 min: 0,
@@ -2170,7 +2170,7 @@ struct SettingsPageV2 {
               },
               {
                 title: '性能模式',
-                subtitle: '优化线程优先级和系统资源调度',
+                subtitle: '提高线程优先级，降低调度延迟，但会增加功耗和发热',
                 type: 'toggle',
                 value: this.performanceMode,
                 action: () => {
@@ -3668,14 +3668,14 @@ struct SettingsPageV2 {
   private showEnhancedTouchZoneDividerPicker(): void { }
   private showPointerVelocityFactorPicker(): void { }
   
-  /** 震动模式分段项下方的说明文字，随所选模式变化。 */
+  /** 振动模式分段项下方的说明文字，随所选模式变化。 */
   private getVibrationModeSubtitle(): string {
     switch (this.vibrationMode) {
-      case '仅手柄': return '只使用手柄震动';
-      case '仅设备': return '只使用设备震动';
+      case '仅手柄': return '只使用手柄振动';
+      case '仅设备': return '只使用设备振动';
       case '协同': return '手柄承载高频细节，机身补充低频量感';
       case '自动':
-      default: return '有手柄用手柄震动，无手柄用设备震动';
+      default: return '有手柄用手柄振动，无手柄用设备振动';
     }
   }
   private showAudioVibrationSceneModePicker(): void {
@@ -4320,7 +4320,7 @@ struct PrivacyPolicyDialog {
     } as PrivacySection,
     { 
       title: '权限使用', 
-      content: '• 网络权限：建立与电脑的连接\n• 麦克风：语音聊天功能（可选）\n• 振动：手柄震动反馈\n• 传感器：体感控制功能（可选）'
+      content: '• 网络权限：建立与电脑的连接\n• 麦克风：语音聊天功能（可选）\n• 振动：手柄振动反馈\n• 传感器：体感控制功能（可选）'
     } as PrivacySection,
     { 
       title: '第三方服务', 

--- a/entry/src/main/ets/pages/SettingsPageV2.ets
+++ b/entry/src/main/ets/pages/SettingsPageV2.ets
@@ -33,7 +33,7 @@ import { MultiOptionPickerDialog, MultiOptionPickerDialogConfig, MultiOptionItem
 import { BackgroundImageUtil, BackgroundImageType } from '../utils/BackgroundImageUtil';
 import { InputInterceptorService } from '../service/input/InputInterceptorService';
 import { GamepadManager } from '../service/input/GamepadManager';
-import { SettingsKeys, UiSettings } from '../service/SettingsService';
+import { SettingsKeys, UiSettings, normalizeVibrationMode } from '../service/SettingsService';
 import { loadChangelog, ChangelogEntry, ChangeItem, getChangeTypeConfig } from '../common/Changelog';
 import { InlineSegmentPicker } from '../components/InlineSegmentPicker';
 import { isAihdrSupported } from '../components/AihdrModifier';
@@ -540,7 +540,11 @@ struct SettingsPageV2 {
       
       // 输入 - 手柄设置
       this.enableVibration = await this.loadBoolean(SettingsKeys.ENABLE_VIBRATION, true);
-      this.vibrationMode = await PreferencesUtil.get<string>(SettingsKeys.VIBRATION_MODE, '自动');
+      const storedVibrationMode = await PreferencesUtil.get<string>(SettingsKeys.VIBRATION_MODE, '自动');
+      this.vibrationMode = normalizeVibrationMode(storedVibrationMode);
+      if (this.vibrationMode !== storedVibrationMode) {
+        await PreferencesUtil.put(SettingsKeys.VIBRATION_MODE, this.vibrationMode);
+      }
       this.gameVibrationStrength = await this.loadGameVibrationStrength();
       this.enableAudioVibration = await this.loadBoolean(SettingsKeys.ENABLE_AUDIO_VIBRATION, false);
       this.audioVibrationStrength = await PreferencesUtil.get<number>(SettingsKeys.AUDIO_VIBRATION_STRENGTH, 60);
@@ -1062,7 +1066,8 @@ struct SettingsPageV2 {
                 title: '码率上限',
                 subtitle: this.bitrate === 0 
                   ? `自动 (推荐: ${this.getRecommendedBitrateForCurrentSettings()} Mbps)` 
-                  : this.bandwidthProbeEnabled ? '自动选码率和动态调节的上限' : '视频传输比特率上限',
+                  : (this.bandwidthProbeEnabled || this.adaptiveBitrate)
+                    ? '自动选码率和动态调节的上限' : '视频传输比特率上限',
                 type: 'slider',
                 value: this.bitrate,
                 min: 1,  // 对数滑块最小值为1（0单独处理为"自动"）

--- a/entry/src/main/ets/pages/SettingsPageV2.ets
+++ b/entry/src/main/ets/pages/SettingsPageV2.ets
@@ -42,6 +42,7 @@ import { DeveloperUnlockResult, DeveloperUnlockService, DeveloperUnlockStatus } 
 import { GitHubDeviceCode } from '../utils/GitHubStarVerifier';
 import { ToastQueue } from '../utils/ToastQueue';
 import { METERED_BANDWIDTH_PROBE_MAX_BYTES } from '../service/network/BandwidthProbeService';
+import { GYRO_SENSITIVITY_MIN, GYRO_SENSITIVITY_MAX } from '../service/input/GyroAssistService';
 
 /**
  * 选择器选项接口
@@ -1574,8 +1575,8 @@ struct SettingsPageV2 {
                 type: 'slider',
                 visible: this.gyroAssistEnabled,
                 value: this.gyroSensitivity,
-                min: 0.5,
-                max: 3,
+                min: GYRO_SENSITIVITY_MIN,
+                max: GYRO_SENSITIVITY_MAX,
                 step: 0.1,
                 formatValue: (v: number) => `${v.toFixed(1)}x`,
                 onSliderChange: (value: number) => {

--- a/entry/src/main/ets/pages/SettingsPageV2.ets
+++ b/entry/src/main/ets/pages/SettingsPageV2.ets
@@ -33,7 +33,7 @@ import { MultiOptionPickerDialog, MultiOptionPickerDialogConfig, MultiOptionItem
 import { BackgroundImageUtil, BackgroundImageType } from '../utils/BackgroundImageUtil';
 import { InputInterceptorService } from '../service/input/InputInterceptorService';
 import { GamepadManager } from '../service/input/GamepadManager';
-import { SettingsKeys, UiSettings, normalizeVibrationMode } from '../service/SettingsService';
+import { SettingsKeys, UiSettings } from '../service/SettingsService';
 import { loadChangelog, ChangelogEntry, ChangeItem, getChangeTypeConfig } from '../common/Changelog';
 import { InlineSegmentPicker } from '../components/InlineSegmentPicker';
 import { isAihdrSupported } from '../components/AihdrModifier';
@@ -189,7 +189,7 @@ struct SettingsPageV2 {
   
   // 输入 - 手柄设置
   @State enableVibration: boolean = true;
-  @State vibrationMode: string = '自动';  // 自动/仅手柄/仅设备/同时
+  @State vibrationMode: string = '自动';  // 自动/仅手柄/仅设备/协同
   @State gameVibrationStrength: number = GAME_VIBRATION_STRENGTH_DEFAULT;
   @State enableAudioVibration: boolean = false;
   @State audioVibrationStrength: number = 60;
@@ -540,11 +540,7 @@ struct SettingsPageV2 {
       
       // 输入 - 手柄设置
       this.enableVibration = await this.loadBoolean(SettingsKeys.ENABLE_VIBRATION, true);
-      const storedVibrationMode = await PreferencesUtil.get<string>(SettingsKeys.VIBRATION_MODE, '自动');
-      this.vibrationMode = normalizeVibrationMode(storedVibrationMode);
-      if (this.vibrationMode !== storedVibrationMode) {
-        await PreferencesUtil.put(SettingsKeys.VIBRATION_MODE, this.vibrationMode);
-      }
+      this.vibrationMode = await PreferencesUtil.get<string>(SettingsKeys.VIBRATION_MODE, '自动');
       this.gameVibrationStrength = await this.loadGameVibrationStrength();
       this.enableAudioVibration = await this.loadBoolean(SettingsKeys.ENABLE_AUDIO_VIBRATION, false);
       this.audioVibrationStrength = await PreferencesUtil.get<number>(SettingsKeys.AUDIO_VIBRATION_STRENGTH, 60);

--- a/entry/src/main/ets/pages/SettingsPageV2.ets
+++ b/entry/src/main/ets/pages/SettingsPageV2.ets
@@ -226,12 +226,12 @@ struct SettingsPageV2 {
   @State mouseNavButtons: boolean = false;
   @State gameMouseMode: boolean = false;   // 游戏鼠标模式（相对模式+光标回弹）
   
-  // 增强触控设置
-  @State enableEnhancedTouch: boolean = true;
-  @State enhancedTouchOnRight: boolean = false;
-  @State enhancedTouchZoneDivider: number = 50;
-  @State pointerVelocityFactor: number = 100;
-  @State longPressFlatRegion: number = 0;
+  // 体感助手设置
+  @State gyroAssistEnabled: boolean = false;
+  @State gyroSensitivity: number = 1.0;
+  @State gyroInvertX: boolean = false;
+  @State gyroInvertY: boolean = false;
+  @State gyroActivationKey: number = -1;
   
   // 主机设置
   @State enableSops: boolean = true;
@@ -297,11 +297,11 @@ struct SettingsPageV2 {
   private sidebarGroups: SidebarGroupMeta[] = [
     { id: 'video', icon: $r('sys.symbol.video_fill'), title: '视频' },
     { id: 'audio', icon: $r('sys.symbol.speaker_wave_2_fill'), title: '音频' },
+    { id: 'vibration', icon: $r('sys.symbol.waveform'), title: '振动' },
     { id: 'gamepad', icon: $r('sys.symbol.gamecontroller_fill'), title: '手柄' },
     { id: 'usb_driver', icon: $r('sys.symbol.charg_cable'), title: 'USB 驱动' },
     { id: 'osc', icon: $r('sys.symbol.gamecontroller'), title: '屏幕控制器' },
     { id: 'mouse', icon: $r('sys.symbol.mouse'), title: '鼠标触控' },
-    { id: 'enhanced_touch', icon: $r('sys.symbol.bolt_fill'), title: '增强触控' },
     { id: 'host', icon: $r('sys.symbol.computer_host_fill'), title: '主机' },
     { id: 'post_process', icon: $r('sys.symbol.wand_and_stars'), title: '后处理' },
     { id: 'performance', icon: $r('sys.symbol.slider_horizontal_2'), title: '性能与调试' },
@@ -582,12 +582,12 @@ struct SettingsPageV2 {
       this.mouseNavButtons = await this.loadBoolean(SettingsKeys.MOUSE_NAV_BUTTONS, false);
       this.gameMouseMode = await this.loadBoolean(SettingsKeys.GAME_MOUSE_MODE, false);
       
-      // 增强触控设置
-      this.enableEnhancedTouch = await this.loadBoolean(SettingsKeys.ENABLE_ENHANCED_TOUCH, true);
-      this.enhancedTouchOnRight = await this.loadBoolean(SettingsKeys.ENHANCED_TOUCH_ON_RIGHT, false);
-      this.enhancedTouchZoneDivider = await PreferencesUtil.get<number>(SettingsKeys.ENHANCED_TOUCH_ZONE_DIVIDER, 50);
-      this.pointerVelocityFactor = await PreferencesUtil.get<number>(SettingsKeys.POINTER_VELOCITY_FACTOR, 100);
-      this.longPressFlatRegion = await PreferencesUtil.get<number>(SettingsKeys.LONG_PRESS_FLAT_REGION, 0);
+      // 体感助手设置
+      this.gyroAssistEnabled = await this.loadBoolean(SettingsKeys.GYRO_ASSIST_ENABLED, false);
+      this.gyroSensitivity = await PreferencesUtil.get<number>(SettingsKeys.GYRO_SENSITIVITY, 1.0);
+      this.gyroInvertX = await this.loadBoolean(SettingsKeys.GYRO_INVERT_X, false);
+      this.gyroInvertY = await this.loadBoolean(SettingsKeys.GYRO_INVERT_Y, false);
+      this.gyroActivationKey = await PreferencesUtil.get<number>(SettingsKeys.GYRO_ACTIVATION_KEY, -1);
       
       // 主机设置
       this.enableSops = await this.loadBoolean(SettingsKeys.ENABLE_SOPS, true);
@@ -1420,6 +1420,42 @@ struct SettingsPageV2 {
                     this.saveSetting(SettingsKeys.MIC_BITRATE, value);
                   }
                 }
+              }
+            ]
+          })
+
+          // 振动设置：游戏震动与音频触感汇入同一组执行器，集中配置
+          this.SettingsGroup({
+            id: 'vibration',
+            icon: $r('sys.symbol.waveform'),
+            title: '振动',
+            items: [
+              {
+                title: '振动反馈',
+                subtitle: '串流游戏震动反馈',
+                type: 'toggle',
+                value: this.enableVibration,
+                action: () => {
+                  this.enableVibration = !this.enableVibration;
+                  this.saveSetting(SettingsKeys.ENABLE_VIBRATION, this.enableVibration);
+                }
+              },
+              {
+                title: '震动强度',
+                subtitle: this.gameVibrationStrength > GAME_VIBRATION_STRENGTH_ORIGINAL ?
+                  '超过 100% 为 app 侧放大，不突破系统/硬件上限' :
+                  '串流游戏震动强度，100% 为原始强度',
+                type: 'slider',
+                visible: this.enableVibration,
+                value: this.gameVibrationStrength,
+                min: GAME_VIBRATION_STRENGTH_MIN,
+                max: GAME_VIBRATION_STRENGTH_MAX,
+                step: GAME_VIBRATION_STRENGTH_STEP,
+                unit: '%',
+                onSliderChange: (value: number) => {
+                  this.gameVibrationStrength = normalizeGameVibrationStrength(value);
+                  this.saveSetting(SettingsKeys.VIBRATE_FALLBACK_STRENGTH, this.gameVibrationStrength);
+                }
               },
               {
                 title: '音频振动',
@@ -1456,55 +1492,28 @@ struct SettingsPageV2 {
                   this.audioVibrationSceneMode = value;
                   this.saveSetting(SettingsKeys.AUDIO_VIBRATION_SCENE_MODE, value);
                 }
+              },
+              {
+                title: '震动模式',
+                subtitle: this.getVibrationModeSubtitle(),
+                type: 'segment',
+                value: this.vibrationMode,
+                visible: this.enableVibration || this.enableAudioVibration,
+                segmentLabels: ['自动', '仅手柄', '仅设备', '协同'],
+                onSegmentChange: (value: string) => {
+                  this.vibrationMode = value;
+                  this.saveSetting(SettingsKeys.VIBRATION_MODE, value);
+                }
               }
             ]
           })
-          
+
           // 手柄设置
           this.SettingsGroup({
             id: 'gamepad',
             icon: $r('sys.symbol.gamecontroller_fill'),
             title: '手柄',
             items: [
-              {
-                title: '振动反馈',
-                subtitle: '串流游戏震动反馈',
-                type: 'toggle',
-                value: this.enableVibration,
-                action: () => {
-                  this.enableVibration = !this.enableVibration;
-                  this.saveSetting(SettingsKeys.ENABLE_VIBRATION, this.enableVibration);
-                }
-              },
-              {
-                title: '震动模式',
-                type: 'segment',
-                value: this.vibrationMode,
-                subtitle: this.getVibrationModeSubtitle(),
-                visible: this.enableVibration,
-                segmentLabels: ['自动', '仅手柄', '仅设备', '协同'],
-                onSegmentChange: (value: string) => {
-                  this.vibrationMode = value;
-                  this.saveSetting(SettingsKeys.VIBRATION_MODE, value);
-                }
-              },
-              {
-                title: '震动强度',
-                subtitle: this.gameVibrationStrength > GAME_VIBRATION_STRENGTH_ORIGINAL ?
-                  '超过 100% 为 app 侧放大，不突破系统/硬件上限' :
-                  '串流游戏震动强度，100% 为原始强度',
-                type: 'slider',
-                visible: this.enableVibration,
-                value: this.gameVibrationStrength,
-                min: GAME_VIBRATION_STRENGTH_MIN,
-                max: GAME_VIBRATION_STRENGTH_MAX,
-                step: GAME_VIBRATION_STRENGTH_STEP,
-                unit: '%',
-                onSliderChange: (value: number) => {
-                  this.gameVibrationStrength = normalizeGameVibrationStrength(value);
-                  this.saveSetting(SettingsKeys.VIBRATE_FALLBACK_STRENGTH, this.gameVibrationStrength);
-                }
-              },
               {
                 title: '多手柄支持',
                 subtitle: '支持多个游戏手柄',
@@ -1547,6 +1556,64 @@ struct SettingsPageV2 {
                 action: () => {
                   this.gamepadMotionSensors = !this.gamepadMotionSensors;
                   this.saveSetting(SettingsKeys.GAMEPAD_MOTION_SENSORS, this.gamepadMotionSensors);
+                }
+              },
+              {
+                title: '体感助手',
+                subtitle: '设备陀螺仪映射为右摇杆（串流菜单可临时调整）',
+                type: 'toggle',
+                value: this.gyroAssistEnabled,
+                action: () => {
+                  this.gyroAssistEnabled = !this.gyroAssistEnabled;
+                  this.saveSetting(SettingsKeys.GYRO_ASSIST_ENABLED, this.gyroAssistEnabled);
+                }
+              },
+              {
+                title: '体感灵敏度',
+                subtitle: '倍率越高，越小的旋转幅度即可满偏',
+                type: 'slider',
+                visible: this.gyroAssistEnabled,
+                value: this.gyroSensitivity,
+                min: 0.5,
+                max: 3,
+                step: 0.1,
+                formatValue: (v: number) => `${v.toFixed(1)}x`,
+                onSliderChange: (value: number) => {
+                  this.gyroSensitivity = Math.round(value * 10) / 10;
+                  this.saveSetting(SettingsKeys.GYRO_SENSITIVITY, this.gyroSensitivity);
+                }
+              },
+              {
+                title: '体感 X 轴反转',
+                type: 'toggle',
+                visible: this.gyroAssistEnabled,
+                value: this.gyroInvertX,
+                action: () => {
+                  this.gyroInvertX = !this.gyroInvertX;
+                  this.saveSetting(SettingsKeys.GYRO_INVERT_X, this.gyroInvertX);
+                }
+              },
+              {
+                title: '体感 Y 轴反转',
+                type: 'toggle',
+                visible: this.gyroAssistEnabled,
+                value: this.gyroInvertY,
+                action: () => {
+                  this.gyroInvertY = !this.gyroInvertY;
+                  this.saveSetting(SettingsKeys.GYRO_INVERT_Y, this.gyroInvertY);
+                }
+              },
+              {
+                title: '体感激活方式',
+                subtitle: '常开，或按住扳机时启用',
+                type: 'segment',
+                visible: this.gyroAssistEnabled,
+                value: String(this.gyroActivationKey),
+                segmentLabels: ['常开', 'LT', 'RT'],
+                segmentValues: ['-1', '0', '1'],
+                onSegmentChange: (value: string) => {
+                  this.gyroActivationKey = Math.round(Number(value));
+                  this.saveSetting(SettingsKeys.GYRO_ACTIVATION_KEY, this.gyroActivationKey);
                 }
               },
               {
@@ -1853,81 +1920,6 @@ struct SettingsPageV2 {
             ]
           })
           
-          // 增强触控设置 (实验性，设置值已保存但尚未接入 TouchInputHandler)
-          this.SettingsGroup({
-            id: 'enhanced_touch',
-            icon: $r('sys.symbol.bolt_fill'),
-            title: '增强触控 (实验性)',
-            items: [
-              {
-                title: '启用增强触控',
-                subtitle: '尚未实装，敬请期待',
-                type: 'toggle',
-                value: this.enableEnhancedTouch,
-                action: () => {
-                  this.enableEnhancedTouch = !this.enableEnhancedTouch;
-                  this.saveSetting(SettingsKeys.ENABLE_ENHANCED_TOUCH, this.enableEnhancedTouch);
-                }
-              },
-              {
-                title: '触控区域在右侧',
-                subtitle: '将增强触控区域放在右侧',
-                type: 'toggle',
-                visible: this.enableEnhancedTouch,
-                value: this.enhancedTouchOnRight,
-                action: () => {
-                  this.enhancedTouchOnRight = !this.enhancedTouchOnRight;
-                  this.saveSetting(SettingsKeys.ENHANCED_TOUCH_ON_RIGHT, this.enhancedTouchOnRight);
-                }
-              },
-              {
-                title: '触控区域分割',
-                subtitle: '触控区域占比',
-                type: 'slider',
-                visible: this.enableEnhancedTouch,
-                value: this.enhancedTouchZoneDivider,
-                min: 10,
-                max: 90,
-                step: 5,
-                unit: '%',
-                onSliderChange: (value: number) => {
-                  this.enhancedTouchZoneDivider = value;
-                  this.saveSetting(SettingsKeys.ENHANCED_TOUCH_ZONE_DIVIDER, value);
-                }
-              },
-              {
-                title: '指针速度因子',
-                subtitle: '指针移动速度倍数',
-                type: 'slider',
-                visible: this.enableEnhancedTouch,
-                value: this.pointerVelocityFactor,
-                min: 10,
-                max: 200,
-                step: 10,
-                unit: '%',
-                onSliderChange: (value: number) => {
-                  this.pointerVelocityFactor = value;
-                  this.saveSetting(SettingsKeys.POINTER_VELOCITY_FACTOR, value);
-                }
-              },
-              {
-                title: '长按平坦区域',
-                subtitle: '长按触发范围',
-                type: 'slider',
-                visible: this.enableEnhancedTouch,
-                value: this.longPressFlatRegion,
-                min: 0,
-                max: 50,
-                step: 5,
-                unit: ' px',
-                onSliderChange: (value: number) => {
-                  this.longPressFlatRegion = value;
-                  this.saveSetting(SettingsKeys.LONG_PRESS_FLAT_REGION, value);
-                }
-              }
-            ]
-          })
-          
           // 主机设置
           this.SettingsGroup({
             id: 'host',
@@ -2055,8 +2047,8 @@ struct SettingsPageV2 {
                 action: () => this.showSdrToHdrModePicker()
               },
               {
-                title: '显示峰值亮度',
-                subtitle: 'HDR 增强的目标峰值亮度上限',
+                title: 'SDR→HDR 亮度上限',
+                subtitle: '本机 SDR→HDR 映射的目标亮度，与报给主机的「HDR 峰值亮度」无关',
                 type: 'slider',
                 visible: this.sdrToHdrMode === 1,
                 value: this.sdrToHdrPeakNits,

--- a/entry/src/main/ets/pages/StreamPage.ets
+++ b/entry/src/main/ets/pages/StreamPage.ets
@@ -2009,24 +2009,6 @@ struct StreamPage {
   }
 
   /**
-   * 获取触摸模式的中文名称
-   */
-  getTouchModeName(): string {
-    switch (this.viewModel.touchMode) {
-      case 'trackpad':
-        return '触控板模式';
-      case 'direct':
-        return '多点触控模式';
-      case 'mouse':
-        return '鼠标模式';
-      case 'ds5_touchpad':
-        return 'DS5 触控板模式';
-      default:
-        return this.viewModel.touchMode;
-    }
-  }
-  
-  /**
    * 处理触摸事件
    */
   handleTouch(event: TouchEvent): void {

--- a/entry/src/main/ets/service/SettingsService.ets
+++ b/entry/src/main/ets/service/SettingsService.ets
@@ -187,6 +187,11 @@ export class SettingsKeys {
   static readonly PERFORMANCE_MODE: string = 'settings_performance_mode';
 }
 
+/** 将历史振动模式值归一化为当前显示和路由使用的值。 */
+export function normalizeVibrationMode(mode: string): string {
+  return mode === '同时' ? '协同' : mode;
+}
+
 /**
  * 输入设置
  */
@@ -622,7 +627,7 @@ export class SettingsService {
 
     // 获取输入设置
     const enableVibration = await this.getBoolean(SettingsKeys.ENABLE_VIBRATION, true);
-    const vibrationMode = await this.getString(SettingsKeys.VIBRATION_MODE, '自动');
+    const vibrationMode = await this.getNormalizedVibrationMode();
     const gameVibrationStrength = normalizeGameVibrationStrength(
       await this.getNumber(SettingsKeys.VIBRATE_FALLBACK_STRENGTH, GAME_VIBRATION_STRENGTH_DEFAULT)
     );
@@ -777,7 +782,7 @@ export class SettingsService {
     return {
       // 手柄
       enableVibration: await this.getBoolean(SettingsKeys.ENABLE_VIBRATION, true),
-      vibrationMode: await this.getString(SettingsKeys.VIBRATION_MODE, '自动'),
+      vibrationMode: await this.getNormalizedVibrationMode(),
       gameVibrationStrength: normalizeGameVibrationStrength(
         await this.getNumber(SettingsKeys.VIBRATE_FALLBACK_STRENGTH, GAME_VIBRATION_STRENGTH_DEFAULT)
       ),
@@ -830,6 +835,15 @@ export class SettingsService {
       pointerVelocityFactor: await this.getNumber(SettingsKeys.POINTER_VELOCITY_FACTOR, 100),
       longPressFlatRegion: await this.getNumber(SettingsKeys.LONG_PRESS_FLAT_REGION, 0)
     };
+  }
+
+  private async getNormalizedVibrationMode(): Promise<string> {
+    const storedMode = await this.getString(SettingsKeys.VIBRATION_MODE, '自动');
+    const normalizedMode = normalizeVibrationMode(storedMode);
+    if (normalizedMode !== storedMode) {
+      await PreferencesUtil.put(SettingsKeys.VIBRATION_MODE, normalizedMode);
+    }
+    return normalizedMode;
   }
 
   /**

--- a/entry/src/main/ets/service/SettingsService.ets
+++ b/entry/src/main/ets/service/SettingsService.ets
@@ -187,11 +187,6 @@ export class SettingsKeys {
   static readonly PERFORMANCE_MODE: string = 'settings_performance_mode';
 }
 
-/** 将历史振动模式值归一化为当前显示和路由使用的值。 */
-export function normalizeVibrationMode(mode: string): string {
-  return mode === '同时' ? '协同' : mode;
-}
-
 /**
  * 输入设置
  */
@@ -627,7 +622,7 @@ export class SettingsService {
 
     // 获取输入设置
     const enableVibration = await this.getBoolean(SettingsKeys.ENABLE_VIBRATION, true);
-    const vibrationMode = await this.getNormalizedVibrationMode();
+    const vibrationMode = await this.getString(SettingsKeys.VIBRATION_MODE, '自动');
     const gameVibrationStrength = normalizeGameVibrationStrength(
       await this.getNumber(SettingsKeys.VIBRATE_FALLBACK_STRENGTH, GAME_VIBRATION_STRENGTH_DEFAULT)
     );
@@ -782,7 +777,7 @@ export class SettingsService {
     return {
       // 手柄
       enableVibration: await this.getBoolean(SettingsKeys.ENABLE_VIBRATION, true),
-      vibrationMode: await this.getNormalizedVibrationMode(),
+      vibrationMode: await this.getString(SettingsKeys.VIBRATION_MODE, '自动'),
       gameVibrationStrength: normalizeGameVibrationStrength(
         await this.getNumber(SettingsKeys.VIBRATE_FALLBACK_STRENGTH, GAME_VIBRATION_STRENGTH_DEFAULT)
       ),
@@ -835,15 +830,6 @@ export class SettingsService {
       pointerVelocityFactor: await this.getNumber(SettingsKeys.POINTER_VELOCITY_FACTOR, 100),
       longPressFlatRegion: await this.getNumber(SettingsKeys.LONG_PRESS_FLAT_REGION, 0)
     };
-  }
-
-  private async getNormalizedVibrationMode(): Promise<string> {
-    const storedMode = await this.getString(SettingsKeys.VIBRATION_MODE, '自动');
-    const normalizedMode = normalizeVibrationMode(storedMode);
-    if (normalizedMode !== storedMode) {
-      await PreferencesUtil.put(SettingsKeys.VIBRATION_MODE, normalizedMode);
-    }
-    return normalizedMode;
   }
 
   /**

--- a/entry/src/main/ets/service/input/GyroAssistService.ets
+++ b/entry/src/main/ets/service/input/GyroAssistService.ets
@@ -25,7 +25,7 @@
  * 灵敏度模型:
  *   effectiveSensitivity = 180° / multiplier
  *   旋转速度达到 effectiveSensitivity deg/s 时摇杆满偏
- *   multiplier=1.0 → 180°/s 满偏; multiplier=3.0 → 60°/s 满偏
+ *   multiplier=1.0 → 180°/s 满偏; multiplier=10.0 → 18°/s 满偏
  */
 
 import { DeviceSensorService, LI_MOTION_TYPE_GYRO, SensorDataCallback } from './DeviceSensorService';
@@ -174,11 +174,12 @@ export class GyroAssistService {
   }
 
   /**
-   * 设置灵敏度倍率 (0.5 ~ 3.0)
+   * 设置灵敏度倍率 (0.5 ~ 10.0)
    * 倍率越高，越小的旋转幅度即可让摇杆满偏
    */
   setSensitivity(multiplier: number): void {
-    this._sensitivityMultiplier = Math.max(0.5, Math.min(10.0, multiplier));
+    this._sensitivityMultiplier = Math.max(GYRO_SENSITIVITY_MIN,
+      Math.min(GYRO_SENSITIVITY_MAX, multiplier));
   }
 
   /**
@@ -216,7 +217,8 @@ export class GyroAssistService {
    * 从设置加载配置
    */
   loadSettings(settings: GyroAssistSettings): void {
-    this._sensitivityMultiplier = settings.sensitivity;
+    this._sensitivityMultiplier = Math.max(GYRO_SENSITIVITY_MIN,
+      Math.min(GYRO_SENSITIVITY_MAX, settings.sensitivity));
     this._invertX = settings.invertX;
     this._invertY = settings.invertY;
     this._activationKey = settings.activationKey;

--- a/entry/src/main/ets/service/input/GyroAssistService.ets
+++ b/entry/src/main/ets/service/input/GyroAssistService.ets
@@ -46,6 +46,10 @@ const TRIGGER_ACTIVATE_THRESHOLD: number = 51; // 255 * 0.2
 /** 默认灵敏度倍率 */
 const DEFAULT_SENSITIVITY: number = 2.0;
 
+/** 体感灵敏度倍率范围 */
+export const GYRO_SENSITIVITY_MIN: number = 0.5;
+export const GYRO_SENSITIVITY_MAX: number = 10.0;
+
 /** 默认报告频率 */
 const GYRO_REPORT_RATE_HZ: number = 120;
 


### PR DESCRIPTION
## Summary

Follow-up to #119 (merged): this PR carries the settings-audit changes that did not reach `master` after the squash merge.

The settings page now removes overlapping entries and clarifies the remaining user-facing terminology:

1. Removed the unimplemented enhanced-touch group; preference keys remain backup-compatible.
2. Merged game rumble and audio haptics into one `振动` group with a shared mode router.
3. Clarified HDR responsibilities: stream HDR, local screen brightening, host-reported peak brightness, and local SDR→HDR enhancement now use distinct labels.
4. Clarified bitrate timing: pre-stream bandwidth probing, the bitrate ceiling, and in-stream adaptive bitrate are explicitly separated.
5. Clarified gyro sensor forwarding versus local gyro assist and device-sensor fallback.
6. Renamed touchpad, USB, host optimization, STUN, multi-controller, decoder queue, and performance labels to state their actual scope and tradeoffs.
7. Kept all preference keys, stored values, and backup semantics unchanged.

这些文案现在不会再让设置项互相撞名啦，杂鱼歧义退散。

## Validation

- [x] `git diff --check`
- [x] `npm run check`
- [x] Repository hygiene checks
- [x] Open-source license checks
- [x] Sunshine mock connection tests
- [ ] `assembleHap` locally: blocked by invalid `DEVECO_SDK_HOME` in the current environment

## Scope

Only `entry/src/main/ets/pages/SettingsPageV2.ets` was included in the follow-up commit. Other pre-existing local worktree changes were left untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增“体感助手”设置，可配置启用状态、灵敏度、轴反转及激活方式。
  * 新增独立“振动”设置分组，集中管理相关选项。
* **改进**
  * 优化设置项名称与侧边栏分类，移除“增强触控”选项。
  * 将触摸模式中的“鼠标模式”更名为“触摸鼠标”，功能保持不变。
  * 统一隐私政策中的振动权限相关文案。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->