### PR TITLE
feat(input): forward DualSense battery and native touchpad to host

### DIFF
--- a/entry/src/main/ets/components/test/UsbControllerTestView.ets
+++ b/entry/src/main/ets/components/test/UsbControllerTestView.ets
@@ -93,6 +93,14 @@ class TestViewDriverListener implements UsbDriverListener {
     x: number, y: number): void {
   }
 
+  reportTouchPoint(controllerId: number, pointIndex: number,
+    active: boolean, x: number, y: number): void {
+  }
+
+  reportControllerBattery(controllerId: number,
+    chargingStatus: number, batteryPercent: number): void {
+  }
+
   deviceAdded(controller: AbstractController): void {
     this.view.onDeviceAdded(controller);
   }

--- a/entry/src/main/ets/service/input/GamepadManager.ets
+++ b/entry/src/main/ets/service/input/GamepadManager.ets
@@ -24,7 +24,7 @@ import { DeviceSensorService, LI_MOTION_TYPE_ACCEL, LI_MOTION_TYPE_GYRO } from '
 import { MoonBridge, Ds5HapticsIrV2Frame, AdaptiveTriggersFrame,
   TOUCH_EVENT_DOWN, TOUCH_EVENT_MOVE, TOUCH_EVENT_UP, TOUCH_EVENT_CANCEL,
   LI_BATTERY_STATE_UNKNOWN, LI_BATTERY_STATE_DISCHARGING, LI_BATTERY_STATE_CHARGING,
-  LI_BATTERY_STATE_NOT_CHARGING, LI_BATTERY_STATE_FULL
+  LI_BATTERY_STATE_NOT_CHARGING, LI_BATTERY_STATE_FULL, LI_BATTERY_PERCENTAGE_UNKNOWN
 } from '../streaming/MoonBridge';
 import { MouseEmulationService, MouseEmulationCallback } from './MouseEmulationService';
 import { GamepadVibrationService } from './GamepadVibrationService';
@@ -2204,10 +2204,17 @@ export class GamepadManager implements UsbDriverListener {
    */
   setControllerTouchCallback(callback: ((controllerNumber: number, eventType: number,
     pointerId: number, x: number, y: number, pressure: number) => void) | null): void {
-    this.controllerTouchCallback = callback;
-    if (!callback) {
-      this.touchPointStates.clear();
+    // 会话停止/重启时注销回调：先经旧回调对活动触点发 CANCEL（回调闭包以
+    // isRunning 守卫，仅在会话仍存活时真正发出），再清空跨会话残留的触点缓存。
+    if (this.controllerTouchCallback && this.touchPointStates.size > 0) {
+      const slots: Set<number> = new Set<number>();
+      this.touchPointStates.forEach((_state, key) => slots.add(Math.floor(key / 2)));
+      for (const slot of slots) {
+        this.cancelActiveTouchPoints(slot);
+      }
     }
+    this.controllerTouchCallback = callback;
+    this.touchPointStates.clear();
   }
 
   /**
@@ -2319,7 +2326,11 @@ export class GamepadManager implements UsbDriverListener {
         batteryState = LI_BATTERY_STATE_UNKNOWN;
         break;
     }
-    this.controllerBatteryCallback(slot, batteryState, batteryPercent);
+    // 未知态（percent < 0）或异常值统一转为协议的 UNKNOWN 百分比标记
+    const reportedPercent = (batteryPercent >= 0 && batteryPercent <= 100)
+      ? batteryPercent
+      : LI_BATTERY_PERCENTAGE_UNKNOWN;
+    this.controllerBatteryCallback(slot, batteryState, reportedPercent);
   }
 
   /** 获取指定槽位 USB 驱动报告的触摸板/电池能力（用于 arrival 能力包）。 */
@@ -2588,6 +2599,8 @@ export class GamepadManager implements UsbDriverListener {
       this.deviceInfoMap.delete(controllerId);
       this.usbDeviceKeyToId.delete(deviceKey);
       this.controllerIdToDeviceKey.delete(controllerId);
+      // 槽位映射删除前先取消该槽位活动触点，避免主机侧触点悬死
+      this.cancelActiveTouchPoints(slot);
       this.usbControllerIdToSlot.delete(controllerId);
       this.releaseSlotForDevice(deviceKey);
       this.dpadAxisActive.delete(controllerId);

--- a/entry/src/main/ets/service/input/GamepadManager.ets
+++ b/entry/src/main/ets/service/input/GamepadManager.ets
@@ -21,7 +21,11 @@ import {
 import { SettingsService, SettingsKeys } from '../SettingsService';
 import { PreferencesUtil } from '../../utils/PreferencesUtil';
 import { DeviceSensorService, LI_MOTION_TYPE_ACCEL, LI_MOTION_TYPE_GYRO } from './DeviceSensorService';
-import { MoonBridge, Ds5HapticsIrV2Frame, AdaptiveTriggersFrame } from '../streaming/MoonBridge';
+import { MoonBridge, Ds5HapticsIrV2Frame, AdaptiveTriggersFrame,
+  TOUCH_EVENT_DOWN, TOUCH_EVENT_MOVE, TOUCH_EVENT_UP, TOUCH_EVENT_CANCEL,
+  LI_BATTERY_STATE_UNKNOWN, LI_BATTERY_STATE_DISCHARGING, LI_BATTERY_STATE_CHARGING,
+  LI_BATTERY_STATE_NOT_CHARGING, LI_BATTERY_STATE_FULL
+} from '../streaming/MoonBridge';
 import { MouseEmulationService, MouseEmulationCallback } from './MouseEmulationService';
 import { GamepadVibrationService } from './GamepadVibrationService';
 import { AudioHapticFrameFlag } from '../AudioHapticFrame';
@@ -96,6 +100,15 @@ export class GamepadManager implements UsbDriverListener {
   
   // 传感器数据发送回调（由 StreamingSession 设置）
   private sensorDataCallback: ((controllerNumber: number, motionType: number, x: number, y: number, z: number) => void) | null = null;
+
+  /** 控制器触摸板原生触点回调（由 StreamingSession 设置，发送 SS_CONTROLLER_TOUCH） */
+  private controllerTouchCallback: ((controllerNumber: number, eventType: number,
+    pointerId: number, x: number, y: number, pressure: number) => void) | null = null;
+  /** 控制器电池状态回调（由 StreamingSession 设置，发送 SS_CONTROLLER_BATTERY） */
+  private controllerBatteryCallback: ((controllerNumber: number,
+    batteryState: number, batteryPercentage: number) => void) | null = null;
+  /** 触点状态缓存：key = slot*2+pointIndex → [active, x, y]，用于计算 down/move/up 转换 */
+  private touchPointStates = new Map<number, [boolean, number, number]>();
   /** 主机当前请求的物理手柄传感器，key 为 "controllerNumber:motionType"。 */
   private requestedPhysicalMotion = new Set<string>();
 
@@ -2186,6 +2199,141 @@ export class GamepadManager implements UsbDriverListener {
   }
 
   /**
+   * 设置控制器触摸板原生触点回调
+   * 由 StreamingSession 调用；主机能力门控（LI_FF_CONTROLLER_TOUCH_EVENTS）由回调内部处理
+   */
+  setControllerTouchCallback(callback: ((controllerNumber: number, eventType: number,
+    pointerId: number, x: number, y: number, pressure: number) => void) | null): void {
+    this.controllerTouchCallback = callback;
+    if (!callback) {
+      this.touchPointStates.clear();
+    }
+  }
+
+  /**
+   * 设置控制器电池状态回调
+   */
+  setControllerBatteryCallback(callback: ((controllerNumber: number,
+    batteryState: number, batteryPercentage: number) => void) | null): void {
+    this.controllerBatteryCallback = callback;
+  }
+
+  /** DS5 触摸板原始分辨率，用于归一化到协议的 0.0-1.0 */
+  private static readonly DS5_TOUCHPAD_WIDTH = 1920;
+  private static readonly DS5_TOUCHPAD_HEIGHT = 1080;
+
+  /**
+   * USB 控制器多触点触摸板数据报告（DS5 双触点）
+   * 计算触点状态转换（down/move/up）并归一化坐标后转发到串流；
+   * 触摸板鼠标模拟开启时让位（鼠标模式独占触摸板）。
+   */
+  reportTouchPoint(
+    controllerId: number,
+    pointIndex: number,
+    active: boolean,
+    x: number,
+    y: number
+  ): void {
+    if (this.touchpadMouseEnabled || !this.controllerTouchCallback) {
+      return;
+    }
+    const slot = this.usbControllerIdToSlot.get(controllerId);
+    if (slot === undefined) return;
+
+    const key = slot * 2 + pointIndex;
+    const prev = this.touchPointStates.get(key);
+    const wasActive = prev !== undefined && prev[0];
+    if (!wasActive && !active) {
+      // 两帧都无手指：不产生事件，也不留缓存
+      if (prev !== undefined) this.touchPointStates.delete(key);
+      return;
+    }
+
+    let eventType: number;
+    let sendX = x;
+    let sendY = y;
+    if (!wasActive && active) {
+      eventType = TOUCH_EVENT_DOWN;
+      this.touchPointStates.set(key, [true, x, y]);
+    } else if (wasActive && !active) {
+      eventType = TOUCH_EVENT_UP;
+      this.touchPointStates.delete(key);
+      sendX = prev![1];
+      sendY = prev![2];
+    } else {
+      // wasActive && active
+      if (prev![1] === x && prev![2] === y) {
+        return; // 坐标未变，避免按输入报告频率刷 MOVE
+      }
+      eventType = TOUCH_EVENT_MOVE;
+      this.touchPointStates.set(key, [true, x, y]);
+    }
+
+    const nx = Math.max(0, Math.min(1, sendX / GamepadManager.DS5_TOUCHPAD_WIDTH));
+    const ny = Math.max(0, Math.min(1, sendY / GamepadManager.DS5_TOUCHPAD_HEIGHT));
+    this.controllerTouchCallback(slot, eventType, pointIndex, nx, ny, 1.0);
+  }
+
+  /** 取消某槽位所有活动触点（设备移除/会话结束时发送 CANCEL） */
+  private cancelActiveTouchPoints(slot: number): void {
+    if (!this.controllerTouchCallback) return;
+    const keysToCancel: number[] = [];
+    this.touchPointStates.forEach((_state, key) => {
+      if (Math.floor(key / 2) === slot) keysToCancel.push(key);
+    });
+    for (const key of keysToCancel) {
+      this.touchPointStates.delete(key);
+      this.controllerTouchCallback(slot, TOUCH_EVENT_CANCEL, key % 2, 0, 0, 0);
+    }
+  }
+
+  /**
+   * USB 控制器电池状态报告
+   * 将 DS5 原始充电状态映射为 moonlight 协议的 LI_BATTERY_STATE_* 后转发。
+   */
+  reportControllerBattery(
+    controllerId: number,
+    chargingStatus: number,
+    batteryPercent: number
+  ): void {
+    if (!this.controllerBatteryCallback) return;
+    const slot = this.usbControllerIdToSlot.get(controllerId);
+    if (slot === undefined) return;
+
+    let batteryState: number;
+    switch (chargingStatus) {
+      case 0x0:
+        batteryState = LI_BATTERY_STATE_DISCHARGING;
+        break;
+      case 0x1:
+        batteryState = LI_BATTERY_STATE_CHARGING;
+        break;
+      case 0x2:
+        batteryState = LI_BATTERY_STATE_FULL;
+        break;
+      case 0xa:
+      case 0xb:
+        batteryState = LI_BATTERY_STATE_NOT_CHARGING;
+        break;
+      default:
+        batteryState = LI_BATTERY_STATE_UNKNOWN;
+        break;
+    }
+    this.controllerBatteryCallback(slot, batteryState, batteryPercent);
+  }
+
+  /** 获取指定槽位 USB 驱动报告的触摸板/电池能力（用于 arrival 能力包）。 */
+  getPhysicalControllerCapabilities(controllerNumber: number): number {
+    let capabilities = 0;
+    for (const controller of this.usbDriverService.getControllers()) {
+      if (this.getUsbControllerSlot(controller) !== controllerNumber) continue;
+      capabilities |= controller.getCapabilities() &
+        (ControllerCapabilities.TOUCHPAD | ControllerCapabilities.BATTERY);
+    }
+    return capabilities;
+  }
+
+  /**
    * 加载触摸板鼠标设置
    */
   async loadTouchpadMouseSetting(): Promise<void> {
@@ -2414,6 +2562,7 @@ export class GamepadManager implements UsbDriverListener {
       this.usbControllerIdToSlot.delete(controllerId);
       if (slot !== undefined) {
         this.vibrationService.clearControllerSource(slot);
+        this.cancelActiveTouchPoints(slot);
       }
       console.info(`[GAMEPAD-USB] 混合模式: 清理震动路由记录`);
       return;

--- a/entry/src/main/ets/service/streaming/MoonBridge.ets
+++ b/entry/src/main/ets/service/streaming/MoonBridge.ets
@@ -117,6 +117,15 @@ export const LI_CCAP_GYRO = 0x20;
 export const LI_CCAP_BATTERY_STATE = 0x40;
 export const LI_CCAP_RGB_LED = 0x80;
 
+// 与 moonlight-common-c Limelight.h 的 LI_BATTERY_STATE_* 保持一致
+export const LI_BATTERY_STATE_UNKNOWN = 0x00;
+export const LI_BATTERY_STATE_NOT_PRESENT = 0x01;
+export const LI_BATTERY_STATE_DISCHARGING = 0x02;
+export const LI_BATTERY_STATE_CHARGING = 0x03;
+export const LI_BATTERY_STATE_NOT_CHARGING = 0x04;
+export const LI_BATTERY_STATE_FULL = 0x05;
+export const LI_BATTERY_PERCENTAGE_UNKNOWN = 0xFF;
+
 // DualSense adaptive trigger update flags and payload shape.
 export const DS_EFFECT_RIGHT_TRIGGER = 0x04;
 export const DS_EFFECT_LEFT_TRIGGER = 0x08;

--- a/entry/src/main/ets/service/streaming/StreamingSession.ets
+++ b/entry/src/main/ets/service/streaming/StreamingSession.ets
@@ -42,6 +42,7 @@ import {
   LI_CCAP_ANALOG_TRIGGERS,
   LI_CCAP_RUMBLE,
   LI_CCAP_TOUCHPAD,
+  LI_CCAP_BATTERY_STATE,
   LI_CCAP_ACCEL,
   LI_CCAP_GYRO,
   LI_FF_CONTROLLER_TOUCH_EVENTS,
@@ -233,6 +234,9 @@ interface NativeModule {
   sendClientSdrWhiteNits(nits: number): number;
   sendControllerMotionEvent(
     controllerNumber: number, motionType: number, x: number, y: number, z: number
+  ): number;
+  sendControllerBatteryEvent(
+    controllerNumber: number, batteryState: number, batteryPercentage: number
   ): number;
 }
 
@@ -1588,6 +1592,23 @@ export class StreamingSession implements Ds5TouchpadInputSink {
       }
     );
 
+    // USB DS5 物理触摸板原生触点转发（主机需宣告 controller-touch 扩展）
+    GamepadManager.getInstance().setControllerTouchCallback(
+      (cn: number, eventType: number, pointerId: number, x: number, y: number, pressure: number): void => {
+        if (!this.isRunning || !this.isControllerTouchpadSupported()) return;
+        this.nativeModule.sendControllerTouchEvent(cn, eventType, pointerId, x, y, pressure);
+      }
+    );
+
+    // USB DS5 电池状态转发
+    GamepadManager.getInstance().setControllerBatteryCallback(
+      (cn: number, batteryState: number, batteryPercentage: number): void => {
+        if (this.isRunning) {
+          this.nativeModule.sendControllerBatteryEvent(cn, batteryState, batteryPercentage);
+        }
+      }
+    );
+
     this.nativeModule.init(callbacks);
   }
 
@@ -1926,8 +1947,14 @@ export class StreamingSession implements Ds5TouchpadInputSink {
 
     let capabilities = LI_CCAP_ANALOG_TRIGGERS | LI_CCAP_RUMBLE;
     capabilities |= GamepadManager.getInstance().getSensorCapabilities(controllerIndex);
-    if (this.ds5TouchpadEnabled && controllerIndex === 0) {
+    // 物理触摸板/电池能力（USB DS5）；位值与 ControllerCapabilities 对齐
+    const physicalCaps = GamepadManager.getInstance().getPhysicalControllerCapabilities(controllerIndex);
+    const hasPhysicalTouchpad = (physicalCaps & LI_CCAP_TOUCHPAD) !== 0;
+    if (hasPhysicalTouchpad || (this.ds5TouchpadEnabled && controllerIndex === 0)) {
       capabilities |= LI_CCAP_TOUCHPAD;
+    }
+    if ((physicalCaps & LI_CCAP_BATTERY_STATE) !== 0) {
+      capabilities |= LI_CCAP_BATTERY_STATE;
     }
 
     let reportedType = controllerType;
@@ -1944,7 +1971,7 @@ export class StreamingSession implements Ds5TouchpadInputSink {
     const ret = this.nativeModule.sendControllerArrivalEvent(
       controllerIndex, this.activeGamepadMask,
       reportedType,
-      this.ds5TouchpadEnabled && controllerIndex === 0
+      (hasPhysicalTouchpad || (this.ds5TouchpadEnabled && controllerIndex === 0))
         ? STANDARD_BUTTON_FLAGS | TOUCHPAD_FLAG
         : STANDARD_BUTTON_FLAGS,
       capabilities

--- a/entry/src/main/ets/service/streaming/StreamingSession.ets
+++ b/entry/src/main/ets/service/streaming/StreamingSession.ets
@@ -742,6 +742,9 @@ export class StreamingSession implements Ds5TouchpadInputSink {
   async stop(): Promise<void> {
     console.info('停止串流');
     this.userInitiatedStop = true;
+    // 必须在 isRunning 翻转前注销：回调闭包以 isRunning 守卫，
+    // 翻转后 CANCEL 无法发出，主机侧活动触点将悬死到断连
+    GamepadManager.getInstance().setControllerTouchCallback(null);
     this.isRunning = false;
     this.resetControllerState();
     GamepadManager.getInstance().stopAllSensors();
@@ -767,6 +770,8 @@ export class StreamingSession implements Ds5TouchpadInputSink {
       }
     }
 
+    // 与 stop() 相同：在 isRunning 翻转前注销触点回调并发送 CANCEL
+    GamepadManager.getInstance().setControllerTouchCallback(null);
     this.isRunning = false;
     NetworkBoostService.getInstance().stop();
     await this.cleanup();

--- a/entry/src/main/ets/service/usbdriver/AbstractController.ets
+++ b/entry/src/main/ets/service/usbdriver/AbstractController.ets
@@ -68,6 +68,15 @@ export abstract class AbstractController {
   protected touchpadActive: boolean = false;  // 是否有手指触摸
   protected touchpadX: number = 0;            // 触摸 X (0-1919)
   protected touchpadY: number = 0;            // 触摸 Y (0-1079 DS5 / 0-942 DS4)
+
+  // 第二触点（DS5 双触点触摸板）；无手指时为 false
+  protected touchPoint2Active: boolean = false;
+  protected touchPoint2X: number = 0;
+  protected touchPoint2Y: number = 0;
+
+  // 电池状态；chargingStatus 为 DS5 status[0] 高 4 位原始值，-1 表示尚未上报
+  protected batteryChargingStatus: number = -1;
+  protected batteryPercent: number = -1;
   
   // 控制器属性
   protected capabilities: number = 0;
@@ -289,6 +298,24 @@ export abstract class AbstractController {
   protected notifyTouchpadInput(active: boolean, x: number, y: number): void {
     if (this.listener) {
       this.listener.reportTouchpadInput(this.deviceId, active, x, y);
+    }
+  }
+
+  /**
+   * 报告多触点触摸板数据
+   */
+  protected notifyTouchPoint(pointIndex: number, active: boolean, x: number, y: number): void {
+    if (this.listener) {
+      this.listener.reportTouchPoint(this.deviceId, pointIndex, active, x, y);
+    }
+  }
+
+  /**
+   * 报告电池状态
+   */
+  protected notifyBatteryState(chargingStatus: number, batteryPercent: number): void {
+    if (this.listener) {
+      this.listener.reportControllerBattery(this.deviceId, chargingStatus, batteryPercent);
     }
   }
   

--- a/entry/src/main/ets/service/usbdriver/DualSenseController.ets
+++ b/entry/src/main/ets/service/usbdriver/DualSenseController.ets
@@ -222,6 +222,8 @@ export class DualSenseController extends AbstractDualSenseController {
       const status0 = buffer[53];
       const level = status0 & 0x0F;
       const chargingStatus = (status0 >> 4) & 0x0F;
+      // percent = -1 表示未知态（0xf 等），仍需上报让主机刷新为 UNKNOWN；
+      // 去重条件同时覆盖状态与百分比，未知态稳定后不会重复发送
       let percent = -1;
       if (chargingStatus === 0x0 || chargingStatus === 0x1) {
         percent = Math.min(level * 10 + 5, 100);
@@ -230,8 +232,7 @@ export class DualSenseController extends AbstractDualSenseController {
       } else if (chargingStatus === 0xa || chargingStatus === 0xb) {
         percent = 0;
       }
-      if (percent >= 0 &&
-          (chargingStatus !== this.batteryChargingStatus || percent !== this.batteryPercent)) {
+      if (chargingStatus !== this.batteryChargingStatus || percent !== this.batteryPercent) {
         this.batteryChargingStatus = chargingStatus;
         this.batteryPercent = percent;
         this.notifyBatteryState(chargingStatus, percent);

--- a/entry/src/main/ets/service/usbdriver/DualSenseController.ets
+++ b/entry/src/main/ets/service/usbdriver/DualSenseController.ets
@@ -79,8 +79,9 @@ export class DualSenseController extends AbstractDualSenseController {
     listener: UsbDriverListener
   ) {
     super(device, pipe, deviceId, listener);
-    // DualSense 支持扳机震动
+    // DualSense 支持扳机震动与电池状态上报
     this.capabilities |= ControllerCapabilities.TRIGGER_RUMBLE;
+    this.capabilities |= ControllerCapabilities.BATTERY;
     this.deviceName = 'DualSense Controller';
   }
   
@@ -192,7 +193,7 @@ export class DualSenseController extends AbstractDualSenseController {
     this.setButtonFlag(ButtonFlags.TOUCHPAD_FLAG, b10 & 0x02);  // Touchpad click
     this.setButtonFlag(ButtonFlags.MISC_FLAG, b10 & 0x04);  // Mute
     
-    // 触摸板数据 (bytes 33-36: touch point 0)
+    // 触摸板数据 (bytes 33-36: touch point 0, bytes 37-40: touch point 1)
     // DualSense touchpad resolution: 1920 x 1080
     if (buffer.length >= 37) {
       const contactByte = buffer[33];
@@ -201,6 +202,39 @@ export class DualSenseController extends AbstractDualSenseController {
       if (isActive) {
         this.touchpadX = buffer[34] | ((buffer[35] & 0x0F) << 8);
         this.touchpadY = ((buffer[35] & 0xF0) >> 4) | (buffer[36] << 4);
+      }
+      this.notifyTouchPoint(0, isActive, isActive ? this.touchpadX : 0, isActive ? this.touchpadY : 0);
+    }
+    if (buffer.length >= 41) {
+      const isActive2 = (buffer[37] & 0x80) === 0;
+      this.touchPoint2Active = isActive2;
+      if (isActive2) {
+        this.touchPoint2X = buffer[38] | ((buffer[39] & 0x0F) << 8);
+        this.touchPoint2Y = ((buffer[39] & 0xF0) >> 4) | (buffer[40] << 4);
+      }
+      this.notifyTouchPoint(1, isActive2, isActive2 ? this.touchPoint2X : 0, isActive2 ? this.touchPoint2Y : 0);
+    }
+
+    // 电池状态 (byte 53 = status[0])，编码与内核 hid-playstation 一致：
+    // 低 4 位容量档位 (0-10，每档 10%)，高 4 位充电状态
+    // (0x0 放电 / 0x1 充电 / 0x2 满电 / 0xa 0xb 电压温度异常 / 其他 未知)
+    if (buffer.length >= 54) {
+      const status0 = buffer[53];
+      const level = status0 & 0x0F;
+      const chargingStatus = (status0 >> 4) & 0x0F;
+      let percent = -1;
+      if (chargingStatus === 0x0 || chargingStatus === 0x1) {
+        percent = Math.min(level * 10 + 5, 100);
+      } else if (chargingStatus === 0x2) {
+        percent = 100;
+      } else if (chargingStatus === 0xa || chargingStatus === 0xb) {
+        percent = 0;
+      }
+      if (percent >= 0 &&
+          (chargingStatus !== this.batteryChargingStatus || percent !== this.batteryPercent)) {
+        this.batteryChargingStatus = chargingStatus;
+        this.batteryPercent = percent;
+        this.notifyBatteryState(chargingStatus, percent);
       }
     }
     

--- a/entry/src/main/ets/service/usbdriver/UsbDriverListener.ets
+++ b/entry/src/main/ets/service/usbdriver/UsbDriverListener.ets
@@ -73,6 +73,34 @@ export interface UsbDriverListener {
   ): void;
 
   /**
+   * 报告多触点触摸板数据（DS5 双触点）
+   * @param controllerId 控制器 ID
+   * @param pointIndex 触点索引 (0 或 1)
+   * @param active 该触点是否有手指
+   * @param x 触摸 X 坐标 (原始值)
+   * @param y 触摸 Y 坐标 (原始值)
+   */
+  reportTouchPoint(
+    controllerId: number,
+    pointIndex: number,
+    active: boolean,
+    x: number,
+    y: number
+  ): void;
+
+  /**
+   * 报告控制器电池状态（原始充电状态 + 百分比）
+   * @param controllerId 控制器 ID
+   * @param chargingStatus DS5 status[0] 高 4 位：0x0 放电 / 0x1 充电 / 0x2 满电 / 0xa 0xb 异常 / 其他 未知
+   * @param batteryPercent 电池百分比 (0-100)
+   */
+  reportControllerBattery(
+    controllerId: number,
+    chargingStatus: number,
+    batteryPercent: number
+  ): void;
+
+  /**
    * 设备移除回调
    * @param controller 被移除的控制器
    */

--- a/entry/src/main/ets/service/usbdriver/UsbDriverService.ets
+++ b/entry/src/main/ets/service/usbdriver/UsbDriverService.ets
@@ -954,6 +954,28 @@ export class UsbDriverService implements UsbDriverListener {
       this.listener.reportTouchpadInput(controllerId, active, x, y);
     }
   }
+
+  reportTouchPoint(
+    controllerId: number,
+    pointIndex: number,
+    active: boolean,
+    x: number,
+    y: number
+  ): void {
+    if (this.listener) {
+      this.listener.reportTouchPoint(controllerId, pointIndex, active, x, y);
+    }
+  }
+
+  reportControllerBattery(
+    controllerId: number,
+    chargingStatus: number,
+    batteryPercent: number
+  ): void {
+    if (this.listener) {
+      this.listener.reportControllerBattery(controllerId, chargingStatus, batteryPercent);
+    }
+  }
   
   deviceRemoved(controller: AbstractController): void {
     // 从列表中移除


### PR DESCRIPTION
## Summary
- 打通协议已有但客户端未用的两条 USB DS5 上行通路:
  - **电池状态**:解析 DS5 `status[0]`(编码对齐内核 hid-playstation:低 4 位容量档 ×10+5,高 4 位充电态),映射 `LI_BATTERY_STATE_*` 后经 `LiSendControllerBatteryEvent` 上报,状态变化时才发
  - **触摸板原生触点**:解析双触点(点 1 在 bytes 37-40),按槽位维护 down/move/up 状态机,坐标归一化 0-1 后发 `SS_CONTROLLER_TOUCH`;MOVE 按坐标变化去重;设备拔出对活动触点发 CANCEL
- arrival 包对物理 DS5 补声明 `LI_CCAP_BATTERY_STATE` / `LI_CCAP_TOUCHPAD` + `TOUCHPAD_FLAG` 按键位(此前物理触摸板完全未向主机声明)
- 触摸板转发门控:主机宣告 `LI_FF_CONTROLLER_TOUCH_EVENTS` 且未开触摸板鼠标模拟(鼠标模式优先)
- 对齐 `moonlight-common-c` 子模块检出至主仓已记录的 `8a5d956`(#20 dynamic-sdr-white,主仓代码已引用 `LiSendClientSdrWhiteNits`,此前本地检出停在旧的 #19)

## Test plan
- [x] `assembleHap` 构建通过
- [ ] 真机 USB DS5 串流:日志确认 arrival caps 含 `0x40`(电池)与 `0x08`(触摸板)
- [ ] Sunshine 2025+ 主机:游戏内可见手柄电量;触摸板手势作为原生触点生效
- [ ] 触摸板鼠标模拟开启时原生转发自动让位
- [ ] 旧版 Sunshine(无 controller-touch)主机:触摸板事件被正确跳过,无异常

## Notes
- 触摸板原生转发需 Sunshine 支持 controller-touch 扩展;电池在现行 Sunshine 即生效(inputtino 虚拟手柄 power_supply)
- `GamepadManager.ets` 工作区另有一段未提交的 GAMEPAD-IDLE 探针(DS5 幽灵输入排查 WIP),已与本 PR 改动分离,不在本提交内

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 支持 DualSense 控制器触摸板的多触点操作，并将触摸事件传递至串流会话。
  * 支持读取并上报控制器电池电量、充电状态及相关能力信息。
  * 改进混合控制器模式下的触点状态管理，移除设备时可自动结束活动触点。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->