### PR TITLE
fix(input): use nanoseconds for device sensor intervals

### DIFF
--- a/entry/src/main/ets/service/input/DeviceSensorService.ets
+++ b/entry/src/main/ets/service/input/DeviceSensorService.ets
@@ -31,6 +31,12 @@ export const LI_MOTION_TYPE_GYRO = 0x02;
 /** 弧度转角度系数 */
 const RAD_TO_DEG = 57.2957795;
 
+/** HarmonyOS Sensor Service Kit 的 interval 单位为纳秒 */
+const NANOSECONDS_PER_SECOND = 1000000000;
+
+/** 传感器最小上报间隔为 5 ms，对应最高 200 Hz */
+const MAX_SENSOR_REPORT_RATE_HZ = 200;
+
 /**
  * 传感器数据回调
  */
@@ -242,8 +248,10 @@ export class DeviceSensorService {
       return;
     }
 
-    // 计算采样间隔（微秒） 
-    const intervalUs = Math.floor(1000000 / Math.min(200, reportRateHz));
+    // Sensor Service Kit 的 interval 使用纳秒，且支持的最小间隔为 5 ms。
+    const intervalNs = Math.floor(
+      NANOSECONDS_PER_SECOND / Math.min(MAX_SENSOR_REPORT_RATE_HZ, reportRateHz)
+    );
 
     try {
       sensor.on(sensor.SensorId.GYROSCOPE, (data: sensor.GyroscopeResponse) => {
@@ -271,10 +279,10 @@ export class DeviceSensorService {
         if (this.dataCallback) {
           this.dataCallback(this.controllerNumber, LI_MOTION_TYPE_GYRO, cx, cy, cz);
         }
-      }, { interval: intervalUs });
+      }, { interval: intervalNs });
 
       this.gyroEnabled = true;
-      console.info(`[DeviceSensor] 陀螺仪已启用: rate=${reportRateHz}Hz, interval=${intervalUs}us`);
+      console.info(`[DeviceSensor] 陀螺仪已启用: rate=${reportRateHz}Hz, interval=${intervalNs}ns`);
     } catch (err) {
       console.error(`[DeviceSensor] 启用陀螺仪失败: ${err}`);
       this.gyroAvailable = false;
@@ -302,7 +310,9 @@ export class DeviceSensorService {
       return;
     }
 
-    const intervalUs = Math.floor(1000000 / Math.min(200, reportRateHz));
+    const intervalNs = Math.floor(
+      NANOSECONDS_PER_SECOND / Math.min(MAX_SENSOR_REPORT_RATE_HZ, reportRateHz)
+    );
 
     try {
       sensor.on(sensor.SensorId.ACCELEROMETER, (data: sensor.AccelerometerResponse) => {
@@ -330,10 +340,10 @@ export class DeviceSensorService {
         if (this.dataCallback) {
           this.dataCallback(this.controllerNumber, LI_MOTION_TYPE_ACCEL, cx, cy, cz);
         }
-      }, { interval: intervalUs });
+      }, { interval: intervalNs });
 
       this.accelEnabled = true;
-      console.info(`[DeviceSensor] 加速度计已启用: rate=${reportRateHz}Hz, interval=${intervalUs}us`);
+      console.info(`[DeviceSensor] 加速度计已启用: rate=${reportRateHz}Hz, interval=${intervalNs}ns`);
     } catch (err) {
       console.error(`[DeviceSensor] 启用加速度计失败: ${err}`);
       this.accelAvailable = false;


### PR DESCRIPTION
## 改了啥呀

- 把设备陀螺仪和加速度计订阅的 `interval` 按纳秒计算
- 保留 200 Hz 上限，对应 Sensor Service Kit 支持的 5 ms 最小间隔
- 日志字段同步改成 `ns`，省得以后又被这个杂鱼单位骗到啦

## 为啥要改

HarmonyOS Sensor Service Kit 的数值型 `interval` 单位是纳秒；原实现却按微秒计算。比如请求 100 Hz 时，原来传入的是 10,000 ns，而正确值应为 10,000,000 ns，差了 1000 倍。

官方示例也以 100,000,000 ns 表示 100 ms，并说明常见支持范围为 5,000,000–200,000,000 ns：
https://gitee.com/openharmony/docs/blob/30904d2051d468bd681b08da17cbc6e87a77dbf1/en/application-dev/device/sensor-guidelines.md

本 PR 不改运动数据协议单位：陀螺仪仍从 rad/s 转成 deg/s，加速度计仍以 m/s² 发送。也不偷偷加死区或自动校准，免得把真实的慢速动作一起吃掉，哼。

## 验证

- `npm run check`
- `node hvigorw.js assembleApp --mode project -p product=default -p buildMode=debug --no-daemon --stacktrace`（unsigned，BUILD SUCCESSFUL）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 优化陀螺仪和加速度计的传感器采样间隔计算，提升高频采样场景下的计时精度。
  - 统一使用纳秒（ns）作为采样间隔单位，并同步更新相关状态日志。
  - 保持传感器数据转换、去重、方向校正及事件分发行为不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->