### PR TITLE
fix(pc-list): surface custom HTTP/HTTPS ports in UI

### DIFF
--- a/entry/src/main/ets/components/ComputerCard.ets
+++ b/entry/src/main/ets/components/ComputerCard.ets
@@ -9,6 +9,7 @@
  */
 
 import { ObservableComputer } from '../viewmodel/ComputerViewModel';
+import { formatDisplayAddress } from '../model/ComputerInfo';
 import { AppColors, AppSizes, AppSpacing, AppAnimation, AppShadows, StatusColors } from '../common/Theme';
 import { LengthMetrics, ColorMetrics } from '@kit.ArkUI';
 
@@ -299,8 +300,8 @@ export struct ComputerCard {
         .textOverflow({ overflow: TextOverflow.Ellipsis })
         .width('100%')
 
-      // 第二行：IP 地址（优先显示手动地址，保持稳定；否则显示轮询活跃地址）
-      Text(this.computer.manualAddress || this.computer.address)
+      // 第二行：IP 地址（优先显示手动地址，保持稳定；否则显示轮询活跃地址；自定义端口时附带 :port）
+      Text(formatDisplayAddress(this.computer))
         .fontSize(AppSizes.FontBody)
         .fontColor(AppColors.TextSecondary)
         .fontFamily('monospace')

--- a/entry/src/main/ets/model/ComputerInfo.ets
+++ b/entry/src/main/ets/model/ComputerInfo.ets
@@ -8,6 +8,7 @@
  * (at your option) any later version.
  */
 
+import { DEFAULT_HTTP_PORT } from '../common/NetworkConstants';
 import { isLanIPv4Address, isLanAddress, isIPv6Address, isPublicAddress, detectAddressType, AddressType, getAddressTypeLabel } from '../utils/NetHelper';
 
 /**
@@ -132,6 +133,19 @@ export function selectBestAddress(computer: AddressHolder): string {
  */
 export function getAddressNetworkLabel(address: string | undefined): string {
   return getAddressTypeLabel(address);
+}
+
+/**
+ * 展示用地址：自定义 HTTP 端口时附加 :port，默认端口（47989）不附加
+ * 端口实际存储在 httpPort 字段，地址字段只存主机名，直接展示会让用户
+ * 以为自定义端口没生效
+ */
+export function formatDisplayAddress(computer: NvHttpHost): string {
+  const host = computer.manualAddress || computer.address;
+  if (host && computer.httpPort && computer.httpPort !== DEFAULT_HTTP_PORT) {
+    return `${host}:${computer.httpPort}`;
+  }
+  return host;
 }
 
 /**

--- a/entry/src/main/ets/model/ComputerInfo.ets
+++ b/entry/src/main/ets/model/ComputerInfo.ets
@@ -8,8 +8,8 @@
  * (at your option) any later version.
  */
 
-import { DEFAULT_HTTP_PORT } from '../common/NetworkConstants';
-import { isLanIPv4Address, isLanAddress, isIPv6Address, isPublicAddress, detectAddressType, AddressType, getAddressTypeLabel } from '../utils/NetHelper';
+import { DEFAULT_HTTP_PORT, MAX_PORT } from '../common/NetworkConstants';
+import { isLanIPv4Address, isLanAddress, isIPv6Address, isPublicAddress, detectAddressType, AddressType, getAddressTypeLabel, parseAddressAndPort, formatAddressForUrl } from '../utils/NetHelper';
 
 /**
  * 电脑信息模型
@@ -141,11 +141,17 @@ export function getAddressNetworkLabel(address: string | undefined): string {
  * 以为自定义端口没生效
  */
 export function formatDisplayAddress(computer: NvHttpHost): string {
-  const host = computer.manualAddress || computer.address;
-  if (host && computer.httpPort && computer.httpPort !== DEFAULT_HTTP_PORT) {
-    return `${host}:${computer.httpPort}`;
+  const selected = parseAddressAndPort(computer.manualAddress || computer.address);
+  if (!selected.host) {
+    return '';
   }
-  return host;
+  // 与 NvHttp 构造器同一优先级：地址内嵌端口优先，其次 httpPort 字段
+  const port = selected.port || computer.httpPort;
+  if (port && port !== DEFAULT_HTTP_PORT && port > 0 && port <= MAX_PORT) {
+    // 裸 IPv6 附端口前必须加方括号，否则 "fe80::1:30000" 有歧义
+    return `${formatAddressForUrl(selected.host)}:${port}`;
+  }
+  return selected.host;
 }
 
 /**

--- a/entry/src/main/ets/utils/NetworkErrorClassifierSelfCheck.ets
+++ b/entry/src/main/ets/utils/NetworkErrorClassifierSelfCheck.ets
@@ -24,7 +24,7 @@ import {
   parseAddressAndPort,
   parseRtspSessionHost,
 } from './NetHelper';
-import { selectBestAddress } from '../model/ComputerInfo';
+import { formatDisplayAddress, selectBestAddress } from '../model/ComputerInfo';
 import { ConnectionPath, ConnectionPathService } from '../service/network/ConnectionPathService';
 
 const TAG = 'NetworkSelfCheck';
@@ -132,6 +132,7 @@ export class NetworkErrorClassifierSelfCheck {
     failed += NetworkErrorClassifierSelfCheck.runConnectionPathCases();
     failed += NetworkErrorClassifierSelfCheck.runWakeOnLanCases();
     failed += NetworkErrorClassifierSelfCheck.runAddressSelectionCases();
+    failed += NetworkErrorClassifierSelfCheck.runDisplayAddressCases();
 
     if (failed === 0) {
       hilog.info(DOMAIN, TAG, 'network self-check passed');
@@ -399,6 +400,81 @@ export class NetworkErrorClassifierSelfCheck {
       failed += NetworkErrorClassifierSelfCheck.expectEqual('selectBestAddress', c.name, c.actual, c.expected, c.reason);
     }
     NetworkErrorClassifierSelfCheck.logGroupResult('selectBestAddress', failed);
+    return failed;
+  }
+
+  private static runDisplayAddressCases(): number {
+    let failed = 0;
+    const cases: StringCase[] = [
+      {
+        name: 'custom port appended to manual address',
+        actual: formatDisplayAddress({
+          address: '192.168.1.5',
+          localAddress: '',
+          remoteAddress: '',
+          manualAddress: 'ddns.example.com',
+          serverCert: '',
+          httpPort: 47990,
+        }),
+        expected: 'ddns.example.com:47990',
+        reason: '自定义端口必须可见，否则用户以为端口没生效',
+      },
+      {
+        name: 'custom port appended to active address',
+        actual: formatDisplayAddress({
+          address: '192.168.1.5',
+          localAddress: '',
+          remoteAddress: '',
+          manualAddress: '',
+          serverCert: '',
+          httpPort: 30000,
+        }),
+        expected: '192.168.1.5:30000',
+        reason: '无手动地址时回落到活跃地址仍要带端口',
+      },
+      {
+        name: 'default port omitted',
+        actual: formatDisplayAddress({
+          address: '192.168.1.5',
+          localAddress: '',
+          remoteAddress: '',
+          manualAddress: '',
+          serverCert: '',
+          httpPort: 47989,
+        }),
+        expected: '192.168.1.5',
+        reason: '默认端口不显示，避免噪音',
+      },
+      {
+        name: 'no port',
+        actual: formatDisplayAddress({
+          address: 'sunshine.local',
+          localAddress: '',
+          remoteAddress: '',
+          manualAddress: '',
+          serverCert: '',
+        }),
+        expected: 'sunshine.local',
+        reason: '自动发现的主机没有自定义端口',
+      },
+      {
+        name: 'empty fallback',
+        actual: formatDisplayAddress({
+          address: '',
+          localAddress: '',
+          remoteAddress: '',
+          manualAddress: '',
+          serverCert: '',
+        }),
+        expected: '',
+        reason: '无任何地址时返回空字符串',
+      },
+    ];
+
+    for (const c of cases) {
+      failed += NetworkErrorClassifierSelfCheck.expectEqual('formatDisplayAddress', c.name, c.actual, c.expected, c.reason);
+    }
+    NetworkErrorClassifierSelfCheck.logGroupResult('formatDisplayAddress', failed);
     return failed;
   }
 

--- a/entry/src/main/ets/utils/NetworkErrorClassifierSelfCheck.ets
+++ b/entry/src/main/ets/utils/NetworkErrorClassifierSelfCheck.ets
@@ -458,6 +458,45 @@ export class NetworkErrorClassifierSelfCheck {
         reason: '自动发现的主机没有自定义端口',
       },
       {
+        name: 'address embedded port wins over httpPort',
+        actual: formatDisplayAddress({
+          address: '192.168.1.5:30000',
+          localAddress: '',
+          remoteAddress: '',
+          manualAddress: '',
+          serverCert: '',
+          httpPort: 47990,
+        }),
+        expected: '192.168.1.5:30000',
+        reason: '对齐 NvHttp 构造器：地址内嵌端口优先，不重复拼接',
+      },
+      {
+        name: 'bare IPv6 host bracketed when port appended',
+        actual: formatDisplayAddress({
+          address: 'fe80::1',
+          localAddress: '',
+          remoteAddress: '',
+          manualAddress: '',
+          serverCert: '',
+          httpPort: 30000,
+        }),
+        expected: '[fe80::1]:30000',
+        reason: '裸 IPv6 附端口必须加方括号，避免歧义',
+      },
+      {
+        name: 'invalid port ignored',
+        actual: formatDisplayAddress({
+          address: '192.168.1.5',
+          localAddress: '',
+          remoteAddress: '',
+          manualAddress: '',
+          serverCert: '',
+          httpPort: 99999,
+        }),
+        expected: '192.168.1.5',
+        reason: '超出范围的端口不拼接',
+      },
+      {
         name: 'empty fallback',
         actual: formatDisplayAddress({
           address: '',

--- a/entry/src/main/ets/viewmodel/PcListActions.ets
+++ b/entry/src/main/ets/viewmodel/PcListActions.ets
@@ -610,7 +610,7 @@ export class PcListActions {
       `UUID: ${computer.uuid}`,
       ...addressLines,
       `MAC 地址: ${computer.macAddress || '未知'}`,
-      `HTTPS 端口: ${NvHttp.DEFAULT_HTTPS_PORT}`,
+      `HTTPS 端口: ${info.httpsPort || NvHttp.DEFAULT_HTTPS_PORT}`,
       `HTTP 端口: ${info.httpPort || NvHttp.DEFAULT_HTTP_PORT}`,
     ].join('\n');
 


### PR DESCRIPTION
## Summary

- PC 卡片地址栏新增 `formatDisplayAddress()`：自定义 HTTP 端口（≠47989）时显示 `host:port`。此前端口只存在 `httpPort` 字段、地址栏只显示主机名，用户无法确认自定义端口已生效
- 修复主机详情对话框的 HTTPS 端口 bug：原来写死显示 `DEFAULT_HTTPS_PORT`（47984），现改为显示 serverinfo 返回并缓存的 `httpsPort`（frp/端口转发场景下用户终于能看到真实端口）
- 网络自检新增 `formatDisplayAddress` 组 5 条用例（自定义端口附加 / 回落活跃地址 / 默认端口省略 / 无端口 / 空地址）

连接链路本身无改动：端口优先级（地址内嵌 > httpPort 字段 > 默认）与轮询兜底逻辑维持原状，纯展示层修复。

## Test plan

- [ ] 手动添加 `ip:自定义端口` 主机，卡片第二行显示 `ip:port`；默认端口主机无端口后缀
- [ ] 自定义 HTTPS 端口主机（frp/端口转发）：长按 → 详情，"HTTPS 端口"一行显示 serverinfo 返回的真实端口而非固定 47984
- [ ] 启动 hilog `network self-check passed`，无 CONTRACT BROKEN
- [ ] 常规 LAN/WAN 连接、配对、串流回归无异常

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 电脑卡片现在会根据实际配置显示 IP 地址及自定义 HTTP 端口，并支持 IPv6 地址格式化。
  - 详情弹窗优先显示实际 HTTPS 端口，未设置时使用默认端口。

- **错误修复**
  - 修正自定义端口、地址内嵌端口及非法端口场景下的地址显示问题。

- **测试**
  - 增加默认端口、自定义端口、IPv6、无端口及空地址等场景的校验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->