### PR TITLE
fix(stats): show network-only loss in performance overlay

### DIFF
--- a/entry/src/main/ets/components/PerformanceOverlay.ets
+++ b/entry/src/main/ets/components/PerformanceOverlay.ets
@@ -222,7 +222,7 @@ export struct PerformanceOverlay {
       this.perfLatency = stats.latency;
       this.perfNetworkLatency = stats.networkLatency;
       this.perfHostLatency = stats.hostLatency;
-      this.perfPacketLoss = stats.packetLoss;
+      this.perfPacketLoss = stats.networkFrameLossPercent;
       this.perfHdrVivid = stats.hdrVivid;
       // 🎃 愚人节彩蛋：负延迟串流™
       if (isAprilFools()) {

--- a/entry/src/main/ets/model/StreamConfig.ets
+++ b/entry/src/main/ets/model/StreamConfig.ets
@@ -278,7 +278,7 @@ export function getDefaultStreamConfig(): StreamConfig {
     enableSyncDecode: false, // 默认禁用同步解码（需要 API 20+；启用后低延迟优先）
     enableVrr: false,       // 默认禁用 VRR（可能丢帧）
     enableVsync: false,     // 默认关闭（低延迟优先；开启后更平滑但可能增加 1 帧左右延迟）
-    enableHostPacedPresentation: false, // 默认关闭，启用后使用有界低延迟 PTS 呈现
+    enableHostPacedPresentation: true,  // 默认开启，使用有界低延迟 PTS 呈现
     enablePostProcess: false, // 默认禁用后处理滤镜
     upscaleMode: 0,           // 默认不超分
     upscaleSharpness: 0.5,    // 默认锐度 50%

--- a/entry/src/main/ets/pages/SettingsPageV2.ets
+++ b/entry/src/main/ets/pages/SettingsPageV2.ets
@@ -244,7 +244,7 @@ struct SettingsPageV2 {
   @State enableSyncDecode: boolean = false;  // 同步解码模式，默认禁用
   @State enableVrr: boolean = false;  // VRR 可变刷新率，默认禁用
   @State enableVsync: boolean = false;
-  @State enableHostPacedPresentation: boolean = false;
+  @State enableHostPacedPresentation: boolean = true;
   @State enablePostProcess: boolean = false;  // 后处理滤镜（暗区抖动补偿）
   @State upscaleMode: number = 0;             // 超分辨率模式
   @State upscaleSharpness: number = 50;       // 超分锐度 (0-100)
@@ -601,7 +601,7 @@ struct SettingsPageV2 {
       this.enableVrr = await this.loadBoolean(SettingsKeys.ENABLE_VRR, false);  // VRR 默认禁用
       this.enableVsync = await this.loadBoolean(SettingsKeys.ENABLE_VSYNC, false);
       this.enableHostPacedPresentation = await this.loadBoolean(
-        SettingsKeys.ENABLE_HOST_PACED_PRESENTATION, false);
+        SettingsKeys.ENABLE_HOST_PACED_PRESENTATION, true);
       this.enablePostProcess = await this.loadBoolean(SettingsKeys.ENABLE_POST_PROCESS, false);
       this.upscaleMode = await PreferencesUtil.get<number>(SettingsKeys.UPSCALE_MODE, 0);
       this.upscaleSharpness = await PreferencesUtil.get<number>(SettingsKeys.UPSCALE_SHARPNESS, 50);

--- a/entry/src/main/ets/pages/SettingsPageV2.ets
+++ b/entry/src/main/ets/pages/SettingsPageV2.ets
@@ -2155,19 +2155,13 @@ struct SettingsPageV2 {
               },
               {
                 title: '相位调谐 (实验性)',
-                subtitle: this.developerMode
-                  ? '配合 Foundation Sunshine 主机的帧律感知；不是更快，只是每一帧都很会挑时机'
-                  : '开发者模式解锁后才让你碰',
+                subtitle: '配合 Foundation Sunshine 主机的帧律感知；不是更快，只是每一帧都很会挑时机',
                 type: 'toggle',
                 value: this.enableHostPacedPresentation,
-                isPro: true,
-                disabled: !this.developerMode,
                 action: () => {
-                  if (this.developerMode) {
-                    this.enableHostPacedPresentation = !this.enableHostPacedPresentation;
-                    this.saveSetting(SettingsKeys.ENABLE_HOST_PACED_PRESENTATION,
-                      this.enableHostPacedPresentation);
-                  }
+                  this.enableHostPacedPresentation = !this.enableHostPacedPresentation;
+                  this.saveSetting(SettingsKeys.ENABLE_HOST_PACED_PRESENTATION,
+                    this.enableHostPacedPresentation);
                 }
               },
               {

--- a/entry/src/main/ets/service/SettingsService.ets
+++ b/entry/src/main/ets/service/SettingsService.ets
@@ -651,8 +651,8 @@ export class SettingsService {
     const enableSyncDecode = await this.getBoolean(SettingsKeys.ENABLE_SYNC_DECODE, false);  // 默认禁用
     const enableVrr = await this.getBoolean(SettingsKeys.ENABLE_VRR, false);  // VRR 默认禁用
     const enableVsync = await this.getBoolean(SettingsKeys.ENABLE_VSYNC, false);
-    const enableHostPacedPresentation = developerMode && await this.getBoolean(
-      SettingsKeys.ENABLE_HOST_PACED_PRESENTATION, false);  // 非开发者模式下强制禁用
+    const enableHostPacedPresentation = await this.getBoolean(
+      SettingsKeys.ENABLE_HOST_PACED_PRESENTATION, false);
     const enablePostProcess = await this.getBoolean(SettingsKeys.ENABLE_POST_PROCESS, false);
     const upscaleMode = await this.getNumber(SettingsKeys.UPSCALE_MODE, 0);
     const upscaleSharpness = await this.getNumber(SettingsKeys.UPSCALE_SHARPNESS, 50) / 100.0;

--- a/entry/src/main/ets/service/SettingsService.ets
+++ b/entry/src/main/ets/service/SettingsService.ets
@@ -652,7 +652,7 @@ export class SettingsService {
     const enableVrr = await this.getBoolean(SettingsKeys.ENABLE_VRR, false);  // VRR 默认禁用
     const enableVsync = await this.getBoolean(SettingsKeys.ENABLE_VSYNC, false);
     const enableHostPacedPresentation = await this.getBoolean(
-      SettingsKeys.ENABLE_HOST_PACED_PRESENTATION, false);
+      SettingsKeys.ENABLE_HOST_PACED_PRESENTATION, true);
     const enablePostProcess = await this.getBoolean(SettingsKeys.ENABLE_POST_PROCESS, false);
     const upscaleMode = await this.getNumber(SettingsKeys.UPSCALE_MODE, 0);
     const upscaleSharpness = await this.getNumber(SettingsKeys.UPSCALE_SHARPNESS, 50) / 100.0;

--- a/entry/src/main/ets/service/streaming/StreamingSession.ets
+++ b/entry/src/main/ets/service/streaming/StreamingSession.ets
@@ -81,6 +81,7 @@ export interface StreamStats {
   hostLatency: number;     // 最近 1 秒主机处理延迟（编码时间）ms
   networkLatency: number;  // 网络延迟（RTT）ms
   packetLoss: number;      // %
+  networkFrameLossPercent: number; // common-c 网络重组层确认的帧丢失率（不含客户端丢帧）
   decodedFrames: number;
   codecOutputFrames: number;
   droppedFrames: number;
@@ -282,6 +283,7 @@ interface VideoStats {
   renderedFps: number;
   bitrate: number;
   hostLatency: number;
+  networkFrameLossPercent: number;
   totalDecodeTimeMs: number;
   validDecodeFrames: number;
   totalHostLatencyMs: number;
@@ -564,6 +566,7 @@ export class StreamingSession implements Ds5TouchpadInputSink {
   private stats: StreamStats = {
     fps: 0, codecOutputFps: 0, renderedFps: 0, bitrate: 0, latency: 0,
     hostLatency: 0, networkLatency: 0, packetLoss: 0,
+    networkFrameLossPercent: 0,
     decodedFrames: 0, codecOutputFrames: 0, droppedFrames: 0,
     hdrVivid: false,
     hostMaxLuminance: 0, hostMaxFullFrame: 0,
@@ -1159,6 +1162,7 @@ export class StreamingSession implements Ds5TouchpadInputSink {
       this.stats.bitrate = vs.bitrate || 0;
       this.stats.latency = vs.avgDecodeTimeMs || 0;
       this.stats.hostLatency = vs.hostLatency || 0;
+      this.stats.networkFrameLossPercent = vs.networkFrameLossPercent || 0;
 
       // 滑动窗口丢包率（对齐 Android: ~2秒窗口 = lastWindow + activeWindow）
       const totalFrames = vs.totalFrames || 0;
@@ -1237,6 +1241,7 @@ export class StreamingSession implements Ds5TouchpadInputSink {
       hostLatency: this.stats.hostLatency,
       networkLatency: this.stats.networkLatency,
       packetLoss: this.stats.packetLoss,
+      networkFrameLossPercent: this.stats.networkFrameLossPercent,
       decodedFrames: this.stats.decodedFrames,
       codecOutputFrames: this.stats.codecOutputFrames,
       droppedFrames: this.stats.droppedFrames,

--- a/entry/src/main/ets/service/streaming/StreamingSession.ets
+++ b/entry/src/main/ets/service/streaming/StreamingSession.ets
@@ -1773,7 +1773,7 @@ export class StreamingSession implements Ds5TouchpadInputSink {
     this.nativeModule.setDecoderSyncMode(this.config.enableSyncDecode);
     this.nativeModule.setVsyncEnabled(this.config.enableVsync);
     this.nativeModule.setHostPacedPresentationEnabled(
-      this.config.enableHostPacedPresentation ?? false);
+      this.config.enableHostPacedPresentation ?? true);
     this.nativeModule.setVrrEnabled(this.config.enableVrr);
     this.nativeModule.setPostProcessEnabled(this.config.enablePostProcess ?? false);
     this.nativeModule.setUpscaleMode(this.config.upscaleMode ?? 0, this.config.upscaleSharpness ?? 0.5);
@@ -1784,7 +1784,7 @@ export class StreamingSession implements Ds5TouchpadInputSink {
     }
 
     console.info(`解码器: buffers=${this.config.decoderBufferCount}, sync=${this.config.enableSyncDecode}, ` +
-      `vsync=${this.config.enableVsync}, hostPaced=${this.config.enableHostPacedPresentation ?? false}, ` +
+      `vsync=${this.config.enableVsync}, hostPaced=${this.config.enableHostPacedPresentation ?? true}, ` +
       `vrr=${this.config.enableVrr}`);
 
     const callStart = async (address: string): Promise<number> => {

--- a/nativelib/src/main/cpp/moonlight_bridge.cpp
+++ b/nativelib/src/main/cpp/moonlight_bridge.cpp
@@ -1774,6 +1774,7 @@ napi_value MoonBridge_GetVideoStats(napi_env env, napi_callback_info info) {
     setNumber("renderedFps", stats.renderedFps);
     setNumber("bitrate", stats.currentBitrate);
     setNumber("hostLatency", stats.recentHostProcessingLatency);
+    setNumber("networkFrameLossPercent", LiGetEstimatedVideoFrameLossPercentage());
     setCounter("framesLost", stats.framesLost);
     setCounter("totalFrames", stats.totalFrames);
     setNumber("totalDecodeTimeMs", stats.totalDecodeTimeMs);


### PR DESCRIPTION
## 改了啥呀

- 性能覆盖层的丢包率改为展示 common-c 网络重组层确认的帧丢失率
- 从 native bridge 到 ArkTS 统计快照贯通 `networkFrameLossPercent`
- 保留原有 `packetLoss` 给 ABR 和串流战报使用，才不会把杂鱼指标偷偷换口径啦
- common-c 依赖：qiin2333/moonlight-common-c#24（目标分支 `mic`，提交 `b546795`）

## 为啥要改

原覆盖层使用客户端滑动窗口统计，可能包含解码器或渲染路径的主动丢帧，无法只代表网络质量。新指标复用 common-c 的 3 秒连接状态采样，表示 FEC 后仍不可恢复的网络视频帧丢失。

## 验证

- `npm run check:scripts` 通过
- common-c 协议测试 3/3 通过
- 最新 `mic` 基线下完整 HarmonyOS Release HAP 构建成功
- `git diff --check` 通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增更准确的视频网络丢帧率统计，性能监控中的丢包数据更加可靠。
  * “相位调谐”设置现已对所有用户开放，可直接启用或关闭。
  * 有界低延迟 PTS 呈现默认开启，带来更流畅、低延迟的画面呈现体验。

* **问题修复**
  * 修正性能叠加层读取丢帧率数据不准确的问题。
  * 优化相关设置的默认值及持久化读取行为，确保配置状态一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->