### PR TITLE
feat(network): per-flow scheduler priority via netBoost data-flow registration

### DIFF
--- a/entry/src/main/ets/service/network/NetworkBoostService.ets
+++ b/entry/src/main/ets/service/network/NetworkBoostService.ets
@@ -91,6 +91,7 @@ export class NetworkBoostService {
   private latestScene: SystemNetScene | null = null;
   private sceneListeners: Set<SystemNetSceneListener> = new Set();
   private registeredFlowFds: number[] = [];
+  private sceneEntered: boolean = false;
 
   static getInstance(): NetworkBoostService {
     if (!NetworkBoostService.instance) {
@@ -199,6 +200,7 @@ export class NetworkBoostService {
         scene: STREAMING_SERVICE_TYPE,
         sceneEvent: netBoost.SceneEvent.SCENE_EVENT_ENTER
       });
+      this.sceneEntered = true;
     } catch (err) {
       this.handleErr('registerStreamingFlows/setSceneDesc', err);
       return;
@@ -244,9 +246,10 @@ export class NetworkBoostService {
         console.warn(`[NetworkBoost] setDataFlowDesc(fd=${fd}) leave 失败: ${(err as Error).message}`);
       }
     });
-    if (fds.length === 0) {
+    if (!this.sceneEntered) {
       return;
     }
+    this.sceneEntered = false;
 
     try {
       netBoost.setSceneDesc({

--- a/entry/src/main/ets/service/network/NetworkBoostService.ets
+++ b/entry/src/main/ets/service/network/NetworkBoostService.ets
@@ -15,14 +15,17 @@
  *        本服务静默忽略。
  *
  * 后续步骤：
- *   Step 3: 订阅 'netSceneChange' 弱信号预测 → 主动降码率/提示用户
  *   Step 4: 引入 netHandover 多网切换（远程串流场景，需 LINKTURBO 受限权限）
  */
 
 import { netBoost, netQuality } from '@kit.NetworkBoostKit';
 import { Available, BusinessError, deviceInfo } from '@kit.BasicServicesKit';
+import { StreamSocketFds } from '../streaming/MoonBridge';
 
 const STREAMING_SERVICE_TYPE: netQuality.ServiceType = 'realtimeGame';
+
+/** setDataFlowDesc 起始 API 版本 */
+const DATA_FLOW_DESC_MIN_API = 26;
 
 type StreamQoeState = 'good' | 'poor';
 
@@ -73,43 +76,6 @@ export interface SystemNetScene {
 
 export type SystemNetSceneListener = (scene: SystemNetScene) => void;
 
-export type NetworkBoostTransportProtocol = 'udp' | 'tcp';
-export type NetworkBoostFlowPriority = 'normal' | 'high';
-
-export interface NetworkBoostEndpoint {
-  address: string;
-  port: number;
-}
-
-export interface NetworkBoostFlowExpectation {
-  /** 上行带宽，单位 Kbps */
-  uplinkBandwidthKbps?: number;
-  /** 下行带宽，单位 Kbps */
-  downlinkBandwidthKbps?: number;
-  /** 期望时延，单位毫秒 */
-  latencyMs?: number;
-  /** 请求/上传对象大小，单位 KB */
-  objectSizeKb?: number;
-  /** 流优先级 */
-  priority?: NetworkBoostFlowPriority;
-  /** 是否倾向低功耗传输 */
-  lowPowerMode?: boolean;
-}
-
-export interface NetworkBoostFiveTupleFlow {
-  flowType: 'fiveTuple';
-  protocol: NetworkBoostTransportProtocol;
-  local: NetworkBoostEndpoint;
-  remote: NetworkBoostEndpoint;
-  expectations?: NetworkBoostFlowExpectation;
-}
-
-export interface NetworkBoostSocketFlow {
-  flowType: 'socket';
-  socketFd: number;
-  expectations?: NetworkBoostFlowExpectation;
-}
-
 export class NetworkBoostService {
   private static instance: NetworkBoostService | null = null;
 
@@ -124,7 +90,7 @@ export class NetworkBoostService {
   private sceneCallback: ((list: Array<netQuality.NetworkScene>) => void) | null = null;
   private latestScene: SystemNetScene | null = null;
   private sceneListeners: Set<SystemNetSceneListener> = new Set();
-  private activeDataFlow: NetworkBoostFiveTupleFlow | NetworkBoostSocketFlow | null = null;
+  private registeredFlowFds: number[] = [];
 
   static getInstance(): NetworkBoostService {
     if (!NetworkBoostService.instance) {
@@ -214,29 +180,82 @@ export class NetworkBoostService {
   }
 
   /**
-   * HarmonyOS 26.0.0: 为关键串流 socket 标记实时游戏流。
+   * HarmonyOS 26.0.0: 为关键串流 socket 注册系统级流描述,获得 per-flow 调度优先级。
    *
-   * 只有在调用方能提供 native socket fd 或完整五元组时才调用；
-   * 当前 ArkTS 层没有可靠本地端口/fd，因此先作为可选入口保留。
+   * fd 来自 native 层 getStreamSocketFds()。注册失败不影响串流;
+   * 会话结束或 socket 关闭前由 clearDataFlowDesc() 注销。
    */
-  setDataFlowDesc(flow: NetworkBoostFiveTupleFlow | NetworkBoostSocketFlow): boolean {
+  registerStreamingFlows(fds: StreamSocketFds): void {
     if (!this.supported || !this.active) {
-      return false;
+      return;
     }
+    if (deviceInfo.sdkApiVersion < DATA_FLOW_DESC_MIN_API) {
+      console.info(`[NetworkBoost] API ${deviceInfo.sdkApiVersion} < ${DATA_FLOW_DESC_MIN_API},跳过流描述注册`);
+      return;
+    }
+
     try {
       netBoost.setSceneDesc({
         scene: STREAMING_SERVICE_TYPE,
         sceneEvent: netBoost.SceneEvent.SCENE_EVENT_ENTER
       });
-      if (flow.expectations?.lowPowerMode !== undefined && deviceInfo.sdkApiVersion >= 24) {
-        netBoost.setLowPowerMode(flow.expectations.lowPowerMode);
-      }
-      this.activeDataFlow = flow;
-      console.info('[NetworkBoost] setSceneDesc scene=realtimeGame event=enter');
-      return true;
     } catch (err) {
-      this.handleErr('setDataFlowDesc', err);
-      return false;
+      this.handleErr('registerStreamingFlows/setSceneDesc', err);
+      return;
+    }
+
+    this.registeredFlowFds = [];
+    this.registerOneFlow('videoRtp', fds.videoRtp.fd);
+    this.registerOneFlow('audioRtp', fds.audioRtp.fd);
+    this.registerOneFlow('control', fds.control.fd);
+  }
+
+  private registerOneFlow(name: string, fd: number): void {
+    if (fd < 0) {
+      console.info(`[NetworkBoost] ${name} fd 不可用,跳过注册`);
+      return;
+    }
+    try {
+      netBoost.setDataFlowDesc({
+        dataFlowInfo: fd,
+        scene: STREAMING_SERVICE_TYPE,
+        sceneEvent: netBoost.SceneEvent.SCENE_EVENT_ENTER,
+        expectations: { priority: netBoost.PriorityLevel.PRIO_HIGH }
+      });
+      this.registeredFlowFds.push(fd);
+      console.info(`[NetworkBoost] setDataFlowDesc ${name} fd=${fd} priority=HIGH`);
+    } catch (err) {
+      this.handleErr(`setDataFlowDesc(${name})`, err);
+    }
+  }
+
+  private clearDataFlowDesc(): void {
+    const fds = this.registeredFlowFds;
+    this.registeredFlowFds = [];
+    fds.forEach((fd) => {
+      try {
+        netBoost.setDataFlowDesc({
+          dataFlowInfo: fd,
+          scene: STREAMING_SERVICE_TYPE,
+          sceneEvent: netBoost.SceneEvent.SCENE_EVENT_LEAVE
+        });
+        console.info(`[NetworkBoost] setDataFlowDesc fd=${fd} event=leave`);
+      } catch (err) {
+        console.warn(`[NetworkBoost] setDataFlowDesc(fd=${fd}) leave 失败: ${(err as Error).message}`);
+      }
+    });
+    if (fds.length === 0) {
+      return;
+    }
+
+    try {
+      netBoost.setSceneDesc({
+        scene: STREAMING_SERVICE_TYPE,
+        sceneEvent: netBoost.SceneEvent.SCENE_EVENT_LEAVE
+      });
+      console.info('[NetworkBoost] setSceneDesc scene=realtimeGame event=leave');
+    } catch (err) {
+      console.warn(`[NetworkBoost] clearDataFlowDesc 失败: ${(err as Error).message}`);
     }
   }
 
@@ -378,23 +397,6 @@ export class NetworkBoostService {
       console.warn(`[NetworkBoost] off(netSceneChange) 失败: ${(err as Error).message}`);
     }
     this.sceneCallback = null;
-  }
-
-  private clearDataFlowDesc(): void {
-    if (!this.activeDataFlow) {
-      this.activeDataFlow = null;
-      return;
-    }
-    try {
-      netBoost.setSceneDesc({
-        scene: STREAMING_SERVICE_TYPE,
-        sceneEvent: netBoost.SceneEvent.SCENE_EVENT_LEAVE
-      });
-      console.info('[NetworkBoost] setSceneDesc scene=realtimeGame event=leave');
-    } catch (err) {
-      console.warn(`[NetworkBoost] clearDataFlowDesc 澶辫触: ${(err as Error).message}`);
-    }
-    this.activeDataFlow = null;
   }
 
   private handleErr(api: string, err: object): void {

--- a/entry/src/main/ets/service/streaming/MoonBridge.ets
+++ b/entry/src/main/ets/service/streaming/MoonBridge.ets
@@ -150,6 +150,35 @@ export interface RttInfo {
 }
 
 /**
+ * native getStreamSocketFds 返回的扁平结构
+ */
+interface NativeStreamSocketFds {
+  videoRtpFd: number;
+  videoRtpPort: number;
+  audioRtpFd: number;
+  audioRtpPort: number;
+  controlFd: number;
+  controlPort: number;
+}
+
+/**
+ * 串流 socket 信息（fd 为 -1 表示该流不可用）
+ */
+export interface StreamSocketInfo {
+  fd: number;
+  localPort: number;
+}
+
+/**
+ * 串流会话的活跃 socket 集合（仅在连接建立后有效）
+ */
+export interface StreamSocketFds {
+  videoRtp: StreamSocketInfo;
+  audioRtp: StreamSocketInfo;
+  control: StreamSocketInfo;
+}
+
+/**
  * Native 麦克风统计信息
  */
 export interface NativeMicStats {
@@ -725,6 +754,18 @@ class MoonBridgeClass {
 
   getHostFeatureFlags(): number {
     return nativeLib.getHostFeatureFlags();
+  }
+
+  getStreamSocketFds(): StreamSocketFds | null {
+    const raw = nativeLib.getStreamSocketFds() as NativeStreamSocketFds | null;
+    if (!raw) {
+      return null;
+    }
+    const video: StreamSocketInfo = { fd: raw.videoRtpFd, localPort: raw.videoRtpPort };
+    const audio: StreamSocketInfo = { fd: raw.audioRtpFd, localPort: raw.audioRtpPort };
+    const control: StreamSocketInfo = { fd: raw.controlFd, localPort: raw.controlPort };
+    const result: StreamSocketFds = { videoRtp: video, audioRtp: audio, control: control };
+    return result;
   }
 
   sendClientSdrWhiteNits(nits: number): number {

--- a/entry/src/main/ets/service/streaming/StreamingSession.ets
+++ b/entry/src/main/ets/service/streaming/StreamingSession.ets
@@ -733,6 +733,19 @@ export class StreamingSession implements Ds5TouchpadInputSink {
       this.isRunning = true;
       // Network Boost Kit: 声明实时游戏类业务，让系统优先调度
       NetworkBoostService.getInstance().start();
+      // Network Boost Kit: 注册串流 socket 流描述，获得 per-flow 调度优先级。
+      // startConnectionAsync 已返回，video/audio/control socket 均已建立。
+      try {
+        const sockets = MoonBridge.getStreamSocketFds();
+        if (sockets) {
+          console.info(`[StreamingSession] 串流 socket: video fd=${sockets.videoRtp.fd} port=${sockets.videoRtp.localPort}, ` +
+            `audio fd=${sockets.audioRtp.fd} port=${sockets.audioRtp.localPort}, ` +
+            `control fd=${sockets.control.fd} port=${sockets.control.localPort}`);
+          NetworkBoostService.getInstance().registerStreamingFlows(sockets);
+        }
+      } catch (err) {
+        console.warn(`[StreamingSession] 串流流描述注册失败(不影响串流): ${(err as Error).message}`);
+      }
     } catch (err) {
       await this.cleanup();
       throw new Error(`串流会话启动失败: ${(err as Error).message}`);

--- a/nativelib/src/main/cpp/moonlight_bridge.cpp
+++ b/nativelib/src/main/cpp/moonlight_bridge.cpp
@@ -1494,6 +1494,31 @@ napi_value MoonBridge_GetHostFeatureFlags(napi_env env, napi_callback_info info)
     return result;
 }
 
+napi_value MoonBridge_GetStreamSocketFds(napi_env env, napi_callback_info info) {
+    (void)info;
+
+    LI_STREAM_SOCKETS sockets;
+    LiGetStreamSockets(&sockets);
+
+    napi_value result;
+    napi_create_object(env, &result);
+
+    const char* fdKeys[] = { "videoRtpFd", "audioRtpFd", "controlFd" };
+    const int fdValues[] = { sockets.videoRtp.fd, sockets.audioRtp.fd, sockets.control.fd };
+    const char* portKeys[] = { "videoRtpPort", "audioRtpPort", "controlPort" };
+    const int portValues[] = { sockets.videoRtp.localPort, sockets.audioRtp.localPort, sockets.control.localPort };
+
+    for (int i = 0; i < 3; i++) {
+        napi_value value;
+        napi_create_int32(env, fdValues[i], &value);
+        napi_set_named_property(env, result, fdKeys[i], value);
+        napi_create_int32(env, portValues[i], &value);
+        napi_set_named_property(env, result, portKeys[i], value);
+    }
+
+    return result;
+}
+
 napi_value MoonBridge_SendClientSdrWhiteNits(napi_env env, napi_callback_info info) {
     size_t argc = 1;
     napi_value args[1];

--- a/nativelib/src/main/cpp/moonlight_bridge.h
+++ b/nativelib/src/main/cpp/moonlight_bridge.h
@@ -153,6 +153,7 @@ napi_value MoonBridge_GetPendingAudioDuration(napi_env env, napi_callback_info i
 napi_value MoonBridge_GetPendingVideoFrames(napi_env env, napi_callback_info info);
 napi_value MoonBridge_GetEstimatedRttInfo(napi_env env, napi_callback_info info);
 napi_value MoonBridge_GetHostFeatureFlags(napi_env env, napi_callback_info info);
+napi_value MoonBridge_GetStreamSocketFds(napi_env env, napi_callback_info info);
 napi_value MoonBridge_SendClientSdrWhiteNits(napi_env env, napi_callback_info info);
 napi_value MoonBridge_GetLaunchUrlQueryParameters(napi_env env, napi_callback_info info);
 

--- a/nativelib/src/main/cpp/napi_init.cpp
+++ b/nativelib/src/main/cpp/napi_init.cpp
@@ -108,6 +108,7 @@ static napi_value Init(napi_env env, napi_value exports) {
         { "getPendingVideoFrames", nullptr, MoonBridge_GetPendingVideoFrames, nullptr, nullptr, nullptr, napi_default, nullptr },
         { "getEstimatedRttInfo", nullptr, MoonBridge_GetEstimatedRttInfo, nullptr, nullptr, nullptr, napi_default, nullptr },
         { "getHostFeatureFlags", nullptr, MoonBridge_GetHostFeatureFlags, nullptr, nullptr, nullptr, napi_default, nullptr },
+        { "getStreamSocketFds", nullptr, MoonBridge_GetStreamSocketFds, nullptr, nullptr, nullptr, napi_default, nullptr },
         { "sendClientSdrWhiteNits", nullptr, MoonBridge_SendClientSdrWhiteNits, nullptr, nullptr, nullptr, napi_default, nullptr },
         { "getLaunchUrlQueryParameters", nullptr, MoonBridge_GetLaunchUrlQueryParameters, nullptr, nullptr, nullptr, napi_default, nullptr },
         


### PR DESCRIPTION
## 改了啥

- 串流三路 socket(video/audio RTP UDP、control)在连接建立后通过 native 桥 `getStreamSocketFds()` 拿到 fd + 本地端口，注册到 `netBoost.setDataFlowDesc`（API 26+，PRIO_HIGH），停止时发 LEAVE 注销
- `NetworkBoostService.registerStreamingFlows()`：API 版本守卫 + 逐流注册/注销，失败只打日志不影响串流
- 删除 PR #40 预埋后从未接线的五元组死接口（`NetworkBoostFiveTupleFlow` 等，无外部调用方）
- submodule pin 指向 qiin2333/moonlight-common-c#25（`LiGetStreamSockets()` fd 注册表）

## 为啥要改

抗网络抖动的最后一块空白：per-flow 调度优先级。此前只有 DSCP 标记（路由器内有效）和 `realtimeGame` 全 App 级 QoS 申报；`setDataFlowDesc` 能让系统调度精确到串流 socket 本身。一直没接的原因是 ArkTS 拿不到 native socket fd（PR #40 记录的原生阻碍），本 PR 与 common-c#25 一起把它补上。

## 验证

- 全新 worktree 基于 master + 本分支：`assembleHap` 构建通过（arm64-v8a + x86_64）
- 模拟器（API 24，HarmonyOS 6.1.0）+ 真实 Sunshine 主机串流实测：
  - fd 链路全通：`[StreamingSession] 串流 socket: video fd=93 port=59577, audio fd=80 port=37911, control fd=91 port=49135`
  - 运行时守卫正确跳过：`API 24 < 26,跳过流描述注册`
  - reportQoe / netQosChange / netSceneChange 既有行为无回归，串流期间无崩溃无异常
- ⏳ `setDataFlowDesc` 真实调用需 API 26 设备，待真机验证（模拟器系统镜像为 API 24）

## Test plan

- [ ] API 26 真机串流：hilog 确认三条流 `setDataFlowDesc` 注册成功、停止时 LEAVE
- [ ] 串流启停循环多次，确认 fd 重新注册无残留
- [ ] 弱网（可选）：观察系统调度是否改善抖动表现

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增串流连接信息获取能力，支持识别视频、音频和控制连接。
  * 串流启动后自动为相关连接配置更高优先级的网络调度。
  * 在受支持的设备和系统版本上优化实时游戏串流体验。

* **改进**
  * 串流结束时自动清理已注册的网络流和场景状态。
  * 网络流注册失败时不会中断串流过程。
  * 优化场景进入与退出处理，提升连接管理稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->