### PR TITLE
Fix three-finger IME dismissal loop

### DIFF
--- a/entry/src/main/ets/pages/StreamPage.ets
+++ b/entry/src/main/ets/pages/StreamPage.ets
@@ -2146,10 +2146,10 @@ struct StreamPage {
     if (result === ThreeFingerImeGestureResult.TRIGGERED) {
       this.touchInputHandler.cancelActiveInput();
       this.panZoomHandler.cancelActiveGesture();
-      if (this.imeManager.isVisible) {
+      if (this.showKeyboardPanel) {
         // 三指再次触发时主动关闭；hide() 会同步解除锁定。
         this.imeManager.hide();
-      } else {
+      } else if (!this.imeManager.isVisible) {
         this.showVirtualKeyboard = false;
         // 三指呼出的 IME 默认锁定：画面失焦事件只能触发重新显示，
         // 仅再次三指或工具条关闭按钮可以主动关闭。

--- a/entry/src/main/ets/pages/StreamPage.ets
+++ b/entry/src/main/ets/pages/StreamPage.ets
@@ -2146,8 +2146,17 @@ struct StreamPage {
     if (result === ThreeFingerImeGestureResult.TRIGGERED) {
       this.touchInputHandler.cancelActiveInput();
       this.panZoomHandler.cancelActiveGesture();
-      this.showVirtualKeyboard = false;
-      this.imeManager.show();
+      if (this.imeManager.isVisible) {
+        // 三指再次触发时主动关闭；hide() 会同步解除锁定。
+        this.imeManager.hide();
+      } else {
+        this.showVirtualKeyboard = false;
+        // 三指呼出的 IME 默认锁定：画面失焦事件只能触发重新显示，
+        // 仅再次三指或工具条关闭按钮可以主动关闭。
+        this.imePanelLocked = true;
+        this.imeManager.setLocked(true);
+        this.imeManager.show();
+      }
     }
     return result !== ThreeFingerImeGestureResult.PASS_THROUGH;
   }

--- a/entry/src/main/ets/pages/StreamPage.ets
+++ b/entry/src/main/ets/pages/StreamPage.ets
@@ -2149,7 +2149,7 @@ struct StreamPage {
       if (this.showKeyboardPanel) {
         // 三指再次触发时主动关闭；hide() 会同步解除锁定。
         this.imeManager.hide();
-      } else if (!this.imeManager.isOpening && !this.imeManager.isVisible) {
+      } else {
         this.showVirtualKeyboard = false;
         // 三指呼出的 IME 默认锁定：画面失焦事件只能触发重新显示，
         // 仅再次三指或工具条关闭按钮可以主动关闭。

--- a/entry/src/main/ets/pages/StreamPage.ets
+++ b/entry/src/main/ets/pages/StreamPage.ets
@@ -2149,7 +2149,7 @@ struct StreamPage {
       if (this.showKeyboardPanel) {
         // 三指再次触发时主动关闭；hide() 会同步解除锁定。
         this.imeManager.hide();
-      } else if (!this.imeManager.isVisible) {
+      } else if (!this.imeManager.isOpening && !this.imeManager.isVisible) {
         this.showVirtualKeyboard = false;
         // 三指呼出的 IME 默认锁定：画面失焦事件只能触发重新显示，
         // 仅再次三指或工具条关闭按钮可以主动关闭。

--- a/entry/src/main/ets/service/streaming/StreamIMEManager.ets
+++ b/entry/src/main/ets/service/streaming/StreamIMEManager.ets
@@ -32,6 +32,7 @@ export interface IMECallbacks {
 export class StreamIMEManager {
   // ── 输入法控制器 ──
   private imeController: inputMethod.InputMethodController | null = null;
+  private showInProgress: boolean = false;
   private imeReadyTime: number = 0;
   /** 锁定模式：开启后点击其他区域不会收起 IME / IME bar，HIDE 事件会被拦截并重新唤起软键盘 */
   private locked: boolean = false;
@@ -67,6 +68,11 @@ export class StreamIMEManager {
     return this.imeController !== null;
   }
 
+  /** 当前是否正在异步显示 IME */
+  get isOpening(): boolean {
+    return this.showInProgress;
+  }
+
   /**
    * 当前是否处于锁定模式
    */
@@ -88,7 +94,9 @@ export class StreamIMEManager {
    */
   async show(): Promise<void> {
     const session = this.viewModel?.getSession();
-    if (!session) return;
+    if (!session || this.showInProgress || this.imeController) return;
+
+    this.showInProgress = true;
 
     try {
       // 监听键盘高度变化
@@ -147,6 +155,8 @@ export class StreamIMEManager {
       this.imeReadyTime = Date.now();
     } catch (err) {
       console.error(`[StreamPage] Failed to show IME: ${JSON.stringify(err)}`);
+    } finally {
+      this.showInProgress = false;
     }
   }
 

--- a/entry/src/main/ets/service/streaming/StreamIMEManager.ets
+++ b/entry/src/main/ets/service/streaming/StreamIMEManager.ets
@@ -33,6 +33,7 @@ export class StreamIMEManager {
   // ── 输入法控制器 ──
   private imeController: inputMethod.InputMethodController | null = null;
   private showInProgress: boolean = false;
+  private showRequestId: number = 0;
   private imeReadyTime: number = 0;
   /** 锁定模式：开启后点击其他区域不会收起 IME / IME bar，HIDE 事件会被拦截并重新唤起软键盘 */
   private locked: boolean = false;
@@ -62,18 +63,6 @@ export class StreamIMEManager {
   }
 
   /**
-   * 当前 IME 是否正在显示
-   */
-  get isVisible(): boolean {
-    return this.imeController !== null;
-  }
-
-  /** 当前是否正在异步显示 IME */
-  get isOpening(): boolean {
-    return this.showInProgress;
-  }
-
-  /**
    * 当前是否处于锁定模式
    */
   get isLocked(): boolean {
@@ -96,17 +85,20 @@ export class StreamIMEManager {
     const session = this.viewModel?.getSession();
     if (!session || this.showInProgress || this.imeController) return;
 
+    const requestId = ++this.showRequestId;
     this.showInProgress = true;
+    let win: window.Window | null = null;
+    let controller: inputMethod.InputMethodController | null = null;
 
     try {
       // 监听键盘高度变化
-      const win = await window.getLastWindow(this.context);
+      win = await window.getLastWindow(this.context);
+      if (requestId !== this.showRequestId) return;
       win.on('keyboardHeightChange', (height: number) => {
         this.callbacks?.onKeyboardHeightChanged(px2vp(height));
       });
 
-      const controller = inputMethod.getController();
-      this.imeController = controller;
+      controller = inputMethod.getController();
 
       // 先绑定输入法（必须先 attach 才能注册回调）
       const textConfig: inputMethod.TextConfig = {
@@ -116,6 +108,11 @@ export class StreamIMEManager {
         }
       };
       await controller.attach(true, textConfig);
+      if (requestId !== this.showRequestId) {
+        controller.detach();
+        win.off('keyboardHeightChange');
+        return;
+      }
 
       // attach 成功后注册输入回调
       controller.on('insertText', (text: string) => {
@@ -151,10 +148,30 @@ export class StreamIMEManager {
         }
       });
 
+      // 完成 attach 和全部回调注册后再发布 controller，避免暴露半初始化状态。
+      this.imeController = controller;
       this.callbacks?.onKeyboardVisibilityChanged(true);
       this.imeReadyTime = Date.now();
     } catch (err) {
       console.error(`[StreamPage] Failed to show IME: ${JSON.stringify(err)}`);
+      if (controller) {
+        try {
+          controller.detach();
+        } catch (cleanupErr) {
+          console.warn(`[StreamIME] Failed to detach after show error: ${JSON.stringify(cleanupErr)}`);
+        }
+      }
+      if (win) {
+        try {
+          win.off('keyboardHeightChange');
+        } catch (cleanupErr) {
+          console.warn(`[StreamIME] Failed to remove height listener: ${JSON.stringify(cleanupErr)}`);
+        }
+      }
+      this.imeController = null;
+      this.locked = false;
+      this.callbacks?.onKeyboardVisibilityChanged(false);
+      this.callbacks?.onKeyboardHeightChanged(0);
     } finally {
       this.showInProgress = false;
     }
@@ -165,6 +182,7 @@ export class StreamIMEManager {
    */
   hide(): void {
     // 主动 hide 时释放锁定状态，避免下次 show 时锁定误传递
+    this.showRequestId++;
     this.locked = false;
     try {
       if (this.imeController) {


### PR DESCRIPTION
## Summary

- lock the system IME when it is opened by the three-finger gesture
- ignore focus-loss dismissal while the IME is locked
- allow users to close it explicitly with another three-finger gesture or the IME toolbar close button
- preserve immediate touch forwarding without adding gesture-recognition latency

## Why

Clicking the streamed content after opening the IME could dismiss it immediately, forcing users into a repeated open/focus-loss cycle. Keeping gesture-opened IME sessions locked breaks that loop while retaining explicit close paths.

## Validation

- `StreamPage.ets` editor diagnostics: no errors
- HarmonyOS HAP build: successful (`assembleHap`, 41 tasks)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **功能优化**
  * 优化三指手势切换输入法面板：面板已显示时关闭；未显示时隐藏虚拟键盘并打开、锁定输入法面板。
  * 优化异步打开流程，避免过期请求导致面板状态异常。
* **问题修复**
  * 修复快速切换或打开失败时的状态清理问题，确保输入法面板可见状态及时更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->